### PR TITLE
Find free services available

### DIFF
--- a/cmd/edge/main.go
+++ b/cmd/edge/main.go
@@ -119,17 +119,6 @@ func main() {
 
 		// Load buttons for the designer
 		btns, _ := btnStore.Load()
-		funcs := httpx.FuncsFor(httpx.ResolveLocale(w, r))
-		renderer, err := ui.NewRenderer(
-			"web/ui/layouts/base.html",
-			"web/ui/pages/designer.html",
-			"web/ui/partials/buttons_admin.html",
-			funcs,
-		)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
 
 		data := map[string]any{
 			"title":     "Designer",
@@ -137,7 +126,7 @@ func main() {
 			"menuItems": buildMenu(cur.InstalledPlugins, cur.MenuPlugins, cur.PluginRecords),
 			"Buttons":   ui.ToVM(btns),
 		}
-		_ = renderer.Render(w, "designer", data)
+		httpx.Render("ui/pages/designer.html", data)(w, r)
 	})
 	mux.HandleFunc("/settings", func(w http.ResponseWriter, r *http.Request) {
 		cur := settings.GetAll()


### PR DESCRIPTION
Fix the `/designer` route to correctly render the designer page using the standard layout renderer, resolving a blank page issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-5fe1a40c-1757-4931-8086-02985a89f4ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5fe1a40c-1757-4931-8086-02985a89f4ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

