### PR TITLE
Fix button update to not remove all buttons

### DIFF
--- a/internal/ui/buttons.go
+++ b/internal/ui/buttons.go
@@ -201,7 +201,11 @@ func (h *ButtonsHTTP) Add(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	h.List(w, r) // Re-render with formatted prices
+	// Re-render admin grid so htmx swaps only the grid in designer
+	btns, _ := h.Store.Load()
+	_ = h.View.Render(w, "buttons_admin_grid", map[string]any{
+		"Buttons": ToVM(btns),
+	})
 }
 
 func (h *ButtonsHTTP) Remove(w http.ResponseWriter, r *http.Request) {
@@ -213,7 +217,10 @@ func (h *ButtonsHTTP) Remove(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	h.List(w, r)
+	btns, _ := h.Store.Load()
+	_ = h.View.Render(w, "buttons_admin_grid", map[string]any{
+		"Buttons": ToVM(btns),
+	})
 }
 
 type PriceResolverAdapter struct{ Store ButtonStore }

--- a/web/ui/partials/buttons_admin.html
+++ b/web/ui/partials/buttons_admin.html
@@ -1,3 +1,30 @@
+{{ define "buttons_admin_grid" }}
+<div id="buttons-grid-admin" class="grid">
+  {{ range .Buttons }}
+    <div class="btn-tile">
+      {{ if .ImageURL }}
+      <img class="thumb" src="{{ .ImageURL }}" alt="{{ .Label }}" />
+      {{ end }}
+      <div>{{ .Label }} £{{ .Price }}</div>
+      <div class="btn-actions">
+        <button class="btn secondary" 
+                onclick="editButton('{{ .Code }}', '{{ .Label }}', {{ .PriceCents }}, '{{ .ImageURL }}')">
+          Edit
+        </button>
+        <form class="remove"
+              hx-post="/api/buttons/remove"
+              hx-target="#buttons-grid-admin" hx-swap="outerHTML">
+          <input type="hidden" name="code" value="{{ .Code }}">
+          <button type="submit" class="btn danger">Remove</button>
+        </form>
+      </div>
+    </div>
+  {{ else }}
+    <p class="empty">No products yet.</p>
+  {{ end }}
+</div>
+{{ end }}
+
 {{ define "buttons_admin" }}
 <div class="products">
   <h2>Products</h2>
@@ -11,30 +38,7 @@
     <button type="button" id="cancel-btn" onclick="cancelEdit()" style="display:none">Cancel</button>
   </form>
 
-  <div id="buttons-grid-admin" class="grid">
-    {{ range .Buttons }}
-      <div class="btn-tile">
-        {{ if .ImageURL }}
-        <img class="thumb" src="{{ .ImageURL }}" alt="{{ .Label }}" />
-        {{ end }}
-        <div>{{ .Label }} £{{ .Price }}</div>
-        <div class="btn-actions">
-          <button class="btn secondary" 
-                  onclick="editButton('{{ .Code }}', '{{ .Label }}', {{ .PriceCents }}, '{{ .ImageURL }}')">
-            Edit
-          </button>
-          <form class="remove"
-                hx-post="/api/buttons/remove"
-                hx-target="#buttons-grid-admin" hx-swap="outerHTML">
-            <input type="hidden" name="code" value="{{ .Code }}">
-            <button type="submit" class="btn danger">Remove</button>
-          </form>
-        </div>
-      </div>
-    {{ else }}
-      <p class="empty">No products yet.</p>
-    {{ end }}
-  </div>
+  {{ template "buttons_admin_grid" . }}
 </div>
 
 <script>
@@ -56,6 +60,6 @@ function cancelEdit() {
   document.getElementById('submit-btn').textContent = 'Add / Replace';
   document.getElementById('cancel-btn').style.display = 'none';
 }
-</script>
+ </script>
 {{ end }}
 


### PR DESCRIPTION
Render only the admin buttons grid after add/remove operations to prevent the entire list from disappearing.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e21cf3d-b03f-47b2-a9ce-98661fa60ca4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9e21cf3d-b03f-47b2-a9ce-98661fa60ca4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

