### PR TITLE
docs: point dev config at deployed marketplace; sync README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ cd universal-till
 make build
 
 # Run
-./bin/edge
+make run          # or: ./bin/unitill-pos
 ```
 
 Open http://localhost:8080
@@ -120,9 +120,9 @@ Open http://localhost:8080
 git clone https://github.com/universaltill/universal-till.git
 cd universal-till
 
-# Copy and configure environment
-cp edge.env.example edge.env.dev
-# Edit edge.env.dev with your settings
+# Configure environment (docker-compose.edge.yml reads pos.env.dev)
+cp pos.env.example pos.env.dev
+# Edit pos.env.dev with your settings
 
 # Run with Docker Compose
 docker compose -f docker-compose.edge.yml up --build
@@ -130,26 +130,33 @@ docker compose -f docker-compose.edge.yml up --build
 
 Open http://localhost:8080
 
-### Option 4: Development Mode (with Mock Marketplace)
+### Option 4: Development Mode (with the marketplace)
 
-For development and testing with marketplace features:
+For development and testing with plugin-marketplace features:
 
 ```bash
-# 1. Start mock marketplace (in one terminal)
-go run scripts/mock-marketplace/main.go
-# Mock runs on :8082
-
-# 2. Start POS with dev environment (in another terminal)
+# Start the POS with the dev environment
 ./scripts/dev.sh
 # Or manually:
-# export $(grep -v '^#' pos.env.dev | grep -v '^$' | xargs)
+# set -a; source <(grep -v '^#' pos.env.dev | grep -v '^$'); set +a
 # make build && ./bin/unitill-pos
 ```
 
-This loads configuration from `pos.env.dev` which includes:
-- Mock marketplace endpoint (http://localhost:8082)
-- Dev OAuth credentials
-- BCP 47 locale settings
+`./scripts/dev.sh` loads `pos.env.dev`, which by default points at the **deployed
+dev marketplace** in the homelab cluster
+(`https://marketplace.home.taskrunnertech.co.uk/api`). It runs with auth disabled,
+so **no OAuth client secret / API key is required** — you can browse the plugin
+store and one-click install the FAQ plugin out of the box. `pos.env.dev` also
+carries the marketplace's Ed25519 signing public key, which the POS uses to verify
+plugin signatures before installing.
+
+**Fully offline?** Point `UT_MARKETPLACE_ENDPOINT_URL` at the mock instead and run
+it in another terminal:
+
+```bash
+go run scripts/mock-marketplace/main.go   # serves a stub marketplace on :8082
+# then set UT_MARKETPLACE_ENDPOINT_URL=http://localhost:8082 in pos.env.dev
+```
 
 ---
 
@@ -182,11 +189,14 @@ UT_CURRENCY=USD                        # Currency code (USD, GBP, EUR, etc.)
 UT_TAX_INCLUSIVE=true                  # Tax included in prices?
 UT_TAX_RATE=20                         # Tax rate percentage
 
-# Marketplace integration (cloud plugin store)
-UT_MARKETPLACE_ENDPOINT_URL=http://127.0.0.1:8081  # Production marketplace API
-# For local testing with mock: http://localhost:8082
-UT_MARKETPLACE_CLIENT_ID=              # OAuth2 client ID (leave empty for local dev)
-UT_MARKETPLACE_CLIENT_SECRET=          # OAuth2 client secret
+# Marketplace integration (cloud plugin store). The endpoint must include /api.
+UT_MARKETPLACE_ENDPOINT_URL=https://marketplace.home.taskrunnertech.co.uk/api  # Dev marketplace
+# Fully offline mock instead: http://localhost:8082 (go run scripts/mock-marketplace/main.go)
+UT_MARKETPLACE_PUBLIC_KEY=             # Ed25519 signing key (hex) used to verify plugin signatures
+UT_MARKETPLACE_CLIENT_ID=              # Doubles as merchant_id on the install path
+UT_MARKETPLACE_STORE_ID=               # Store identifier for entitlement/install
+UT_MARKETPLACE_DEVICE_ID=              # Device identifier (defaults to hostname)
+UT_MARKETPLACE_CLIENT_SECRET=          # OAuth2 client secret (only if the marketplace enforces auth)
 UT_MARKETPLACE_API_VERSION=1.0.0       # Marketplace API version
 UT_MARKETPLACE_TELEMETRY_OPT_IN=false  # Send usage telemetry to marketplace
 UT_DEV_MODE=false                      # Enable developer mode features

--- a/pos.env.dev
+++ b/pos.env.dev
@@ -7,10 +7,21 @@ UT_TAX_INCLUSIVE=false
 UT_TAX_RATE=20
 
 # Marketplace Configuration (009-cloud-marketplace)
-# For local testing with mock marketplace on port 8082
-# For real marketplace, change to http://localhost:8081 or production URL
-UT_MARKETPLACE_ENDPOINT_URL=http://localhost:8082
-UT_MARKETPLACE_CLIENT_ID=pos-client
-UT_MARKETPLACE_CLIENT_SECRET=dev-secret
+# Default dev target is the DEPLOYED dev marketplace in the homelab cluster.
+# It runs with auth disabled, so no OAuth client secret / API key is needed.
+# (To develop fully offline instead, point this at the mock on http://localhost:8082
+#  and run `go run scripts/mock-marketplace/main.go` — see README "Development Mode".)
+UT_MARKETPLACE_ENDPOINT_URL=https://marketplace.home.taskrunnertech.co.uk/api
+
+# Ed25519 public key the POS uses to verify plugin signatures. This is the live
+# dev marketplace signing key (GET /ui/api/signing-key).
+UT_MARKETPLACE_PUBLIC_KEY=581306fb77b04fdb045a7c6e7641fe93e4223a23ec1741d4dca8a683e7038229
+
+# CLIENT_ID doubles as the marketplace merchant_id on the install path; STORE_ID
+# is the store. merchant-1/store-1 matches the entitlement provisioned on the
+# dev marketplace so one-click install of the FAQ plugin works out of the box.
+UT_MARKETPLACE_CLIENT_ID=merchant-1
+UT_MARKETPLACE_STORE_ID=store-1
+UT_MARKETPLACE_DEVICE_ID=pos-device-1
 UT_MARKETPLACE_API_VERSION=1.0.0
 UT_MARKETPLACE_LOCALE=en-US


### PR DESCRIPTION
## Why
Running `./scripts/dev.sh` surfaced **"Missing API key"** — `pos.env.dev` pointed the POS at the **mock** marketplace (`localhost:8082`), which expects OAuth credentials. The dev marketplace is now deployed in the homelab cluster (`marketplace.home.taskrunnertech.co.uk`) with auth disabled, so the mock is no longer needed for normal POS development.

## Changes
- **`pos.env.dev`** → deployed dev marketplace (`/api`), with `UT_MARKETPLACE_PUBLIC_KEY` (Ed25519 signing key), `CLIENT_ID=merchant-1` (doubles as `merchant_id` on the install path), `STORE_ID=store-1`, `DEVICE_ID`. These match the live entitlement so one-click install works out of the box.
- **`README.md`** — fixed real errors (`./bin/edge` → `make run`; nonexistent `edge.env.example` → `pos.env.dev`), rewrote the Development Mode section around the deployed marketplace (mock kept as an offline fallback), and updated the marketplace config vars.

## Verification
Ran the POS with the new config:
- Catalog lists the FAQ plugin
- `POST /api/plugins/install-from-marketplace` → **HTTP 200**, `signature verified: true`
- No "Missing API key"

🤖 Generated with [Claude Code](https://claude.com/claude-code)