### PR TITLE
Default new till installs to cloud.universaltill.com

### DIFF
--- a/docs/code-reviews/2026-07-20-cloud-canonical-till-default.md
+++ b/docs/code-reviews/2026-07-20-cloud-canonical-till-default.md
@@ -1,0 +1,50 @@
+# 2026-07-20 — Packaged till default: cloud.universaltill.com
+
+## Context
+Stage E of the ut-market-place→ut-cloud rename plan (domain consolidation),
+explicitly gated pending Farshid's sign-off given the blast radius: every
+till in the field ships with `UT_MARKETPLACE_ENDPOINT_URL` defaulting to
+`marketplace.universaltill.com`, and a sync failure never blocks checkout
+(offline-first) — so a bad default fails silently. Farshid signed off on
+the full scope today, including this step: change the *packaged* default
+for new installs to `cloud.universaltill.com`, the now-canonical host
+(`cloud.universaltill.com` was also just promoted to the primary OIDC
+redirect host in `homelab-k8s`, see that repo's
+`feat/cloud-canonical-oidc-host` PR).
+
+## Change
+- `packaging/pos.env.example:29` — default flips to
+  `https://cloud.universaltill.com/api`.
+- `docs/marketplace-config.md` — three example URLs updated, plus a new
+  line noting `marketplace.universaltill.com` still answers and is kept
+  alive indefinitely for tills packaged before this change.
+- New test: `packaging/pos_env_example_test.go` —
+  `TestPosEnvExampleDefaultsToCanonicalCloudHost`, asserting the packaged
+  default line verbatim. There was no prior coverage pinning this value at
+  all, despite the silent-failure blast radius — added per an independent
+  review's suggestion.
+
+## Review (independent, sonnet)
+- Confirmed `internal/config/config.go`'s actual runtime fallback is
+  `http://127.0.0.1:8081` — the marketplace/cloud domain is **not** compiled
+  into the binary; it only exists as a value in this packaged template.
+- Confirmed `.goreleaser.yaml` and `packaging/macos/build-app.sh` both copy
+  `pos.env.example` verbatim into release artifacts, and no other file in
+  the repo hardcodes the old domain as a default — this fix is complete,
+  not partial.
+- Confirmed `cloud.universaltill.com` is live and routes to the identical
+  backend Service as `marketplace.universaltill.com`
+  (`homelab-k8s/kubernetes/apps/unitill-marketplace/deployment.yaml`).
+- Confirmed this change has **zero effect on tills already in the field** —
+  it only changes the default baked into *future* installer packages;
+  existing tills have their own already-materialized `pos.env` on disk.
+- Verdict: safe to commit and release.
+
+## Verification
+- `go build ./...`, `go test ./...`, `scripts/ci/guard-data-access.sh` all
+  green, including the new packaging test.
+
+## Not touched (by design)
+- `docs/code-reviews/2026-07-16-store-enrolment.md` and
+  `2026-07-16-marketplace-endpoint-and-port-fallback.md` — historical dated
+  records, correctly left describing what was true then.

--- a/docs/marketplace-config.md
+++ b/docs/marketplace-config.md
@@ -7,8 +7,12 @@ Universal Till can connect to different marketplace endpoints for plugin install
 | Environment | Port | Endpoint | Use Case |
 |-------------|------|----------|----------|
 | **Mock** | 8082 | http://localhost:8082 | Local development & testing |
-| **Production** | 8081 | http://localhost:8081 or https://marketplace.universaltill.com | Production use |
+| **Production** | 8081 | http://localhost:8081 or https://cloud.universaltill.com | Production use |
 | **Custom** | Any | Custom URL | Self-hosted marketplace |
+
+`marketplace.universaltill.com` still answers too — it's the legacy default
+baked into tills packaged before 2026-07-20 and is kept alive indefinitely for
+that fleet. New installs default to `cloud.universaltill.com` (ADR-0018).
 
 # Marketplace Configuration Guide
 
@@ -42,7 +46,7 @@ nano pos.env  # Edit with your settings
 
 ```bash
 # Production marketplace
-UT_MARKETPLACE_ENDPOINT_URL=https://marketplace.universaltill.com
+UT_MARKETPLACE_ENDPOINT_URL=https://cloud.universaltill.com
 
 # Local/self-hosted marketplace
 UT_MARKETPLACE_ENDPOINT_URL=http://localhost:8081
@@ -74,7 +78,7 @@ UT_MARKETPLACE_CLIENT_ID=pos-client
 UT_MARKETPLACE_CLIENT_SECRET=dev-secret
 
 # For production marketplace
-UT_MARKETPLACE_ENDPOINT_URL=https://marketplace.universaltill.com
+UT_MARKETPLACE_ENDPOINT_URL=https://cloud.universaltill.com
 UT_MARKETPLACE_CLIENT_ID=your-client-id
 UT_MARKETPLACE_CLIENT_SECRET=your-client-secret
 ```

--- a/packaging/pos.env.example
+++ b/packaging/pos.env.example
@@ -26,7 +26,7 @@
 # marketplace so the Plugin Store is populated out of the box. Point it at your
 # own marketplace, or comment it out to run fully standalone (no plugin store).
 # Sales always work offline regardless of this setting.
-UT_MARKETPLACE_ENDPOINT_URL=https://marketplace.universaltill.com/api
+UT_MARKETPLACE_ENDPOINT_URL=https://cloud.universaltill.com/api
 # Identity: leave everything below unset and the till ENROLS ITSELF on first
 # boot — it generates a device id, registers anonymously with the marketplace,
 # and fetches the plugin-signing key, so free plugins install out of the box.

--- a/packaging/pos_env_example_test.go
+++ b/packaging/pos_env_example_test.go
@@ -1,0 +1,24 @@
+// Package packaging holds nothing but pos.env.example, the template stamped
+// into every release artifact (.goreleaser.yaml, macos/build-app.sh). Its
+// UT_MARKETPLACE_ENDPOINT_URL default is never read at runtime — only
+// packaged — so a stale value here fails silently: sales keep working
+// offline, but the plugin store and cloud sync quietly point at whatever
+// domain shipped, with no error the operator would ever see.
+package packaging
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPosEnvExampleDefaultsToCanonicalCloudHost(t *testing.T) {
+	data, err := os.ReadFile("pos.env.example")
+	if err != nil {
+		t.Fatalf("read pos.env.example: %v", err)
+	}
+	const want = "UT_MARKETPLACE_ENDPOINT_URL=https://cloud.universaltill.com/api"
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("pos.env.example missing the canonical default line %q — every new till install picks up whatever this file says", want)
+	}
+}


### PR DESCRIPTION
## Summary
- Stage E (domain consolidation), per Farshid's go-ahead: new installer packages default `UT_MARKETPLACE_ENDPOINT_URL` to `https://cloud.universaltill.com/api`.
- Existing tills unaffected — only the packaged template changes, not any runtime default or already-materialized `pos.env` on disk.
- `marketplace.universaltill.com` keeps answering indefinitely for the fielded fleet.
- Independent review confirmed: no other hardcoded copy of the old domain exists, the runtime fallback is `127.0.0.1:8081` (unrelated), and cloud.universaltill.com already routes to the identical backend.
- Adds `TestPosEnvExampleDefaultsToCanonicalCloudHost` — no prior test pinned this value despite the silent-failure blast radius (offline-first, sync failures never block checkout).

## Test plan
- [x] `go build ./...`, `go test ./...`, `scripts/ci/guard-data-access.sh` all green
- [ ] CI green on this PR
- [ ] Cut a release once merged so the new default actually ships

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>