### PR TITLE
docs: dev marketplace endpoint is now cloud.home.taskrunnertech.co.uk

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ For development and testing with plugin-marketplace features:
 
 `./scripts/dev.sh` loads `pos.env.dev`, which points at the **deployed dev
 marketplace** in the homelab cluster
-(`https://marketplace.home.taskrunnertech.co.uk/api`). It runs with auth disabled,
+(`https://cloud.home.taskrunnertech.co.uk/api`). It runs with auth disabled,
 so **no OAuth client secret / API key is required** — you can browse the plugin
 store and one-click install the FAQ plugin out of the box. `pos.env.dev` also
 carries the marketplace's Ed25519 signing public key, which the POS uses to verify
@@ -192,7 +192,7 @@ UT_TAX_INCLUSIVE=true                  # Tax included in prices?
 UT_TAX_RATE=20                         # Tax rate percentage
 
 # Marketplace integration (cloud plugin store). The endpoint must include /api.
-UT_MARKETPLACE_ENDPOINT_URL=https://marketplace.home.taskrunnertech.co.uk/api  # Dev marketplace
+UT_MARKETPLACE_ENDPOINT_URL=https://cloud.home.taskrunnertech.co.uk/api  # Dev marketplace
 UT_MARKETPLACE_PUBLIC_KEY=             # Ed25519 signing key (hex) used to verify plugin signatures
 UT_MARKETPLACE_CLIENT_ID=              # Doubles as merchant_id on the install path
 UT_MARKETPLACE_STORE_ID=               # Store identifier for entitlement/install

--- a/pos.env.dev
+++ b/pos.env.dev
@@ -10,7 +10,7 @@ UT_TAX_RATE=20
 # Points at the DEPLOYED dev marketplace in the homelab cluster. It runs with auth
 # disabled, so no OAuth client secret / API key is needed. Change the URL (must
 # include /api) + PUBLIC_KEY below to target a different marketplace.
-UT_MARKETPLACE_ENDPOINT_URL=https://marketplace.home.taskrunnertech.co.uk/api
+UT_MARKETPLACE_ENDPOINT_URL=https://cloud.home.taskrunnertech.co.uk/api
 
 # Ed25519 public key the POS uses to verify plugin signatures. This is the live
 # dev marketplace signing key (GET /ui/api/signing-key).


### PR DESCRIPTION
## Summary
- Part of the marketplace→cloud domain sweep: the internal homelab dev endpoint documented/configured in this repo now points at `cloud.home.taskrunnertech.co.uk` instead of `marketplace.home.taskrunnertech.co.uk`.
- The old host still works (kept as an Ingress alias in homelab-k8s) — verified both return 200 on `/ui/api/signing-key` before merging this.

## Test plan
- [x] `go build ./...`, `go test ./...`, `scripts/ci/guard-data-access.sh` all green (no code touched, docs/config only)
- [ ] CI green on this PR

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>