### PR TITLE
Verify FAQ content bundle checksum_sha256

### DIFF
--- a/docs/code-reviews/2026-07-21-faq-content-checksum-verification.md
+++ b/docs/code-reviews/2026-07-21-faq-content-checksum-verification.md
@@ -1,0 +1,85 @@
+# 2026-07-21 — Verify FAQ (and future page-plugin) content bundle checksums
+
+## Context
+Companion fix in `ut-plugin-faq` (same session): every `content/<locale>.json`
+now carries a real `checksum_sha256` (was `""`), computed by
+`scripts/checksum.py` via byte-level placeholder substitution (the field
+zeroes its own value to a 64-char placeholder before hashing, since it can't
+hash its own bytes as-is). This change adds the till-side half: actually
+verifying it when a page plugin's content bundle is loaded.
+
+## Changes
+- `internal/pages/plugin_page.go`: `checksumValid(raw []byte) bool` — same
+  byte-level substitution scheme as the Python packaging tool (deliberately
+  not JSON re-serialization, to avoid any Go/Python formatting mismatch).
+  Wired into `loadContentBundle`: a mismatch logs via `logging.L().Warnf`
+  (feeds the existing warn/error ring buffer already surfaced through the
+  till's heartbeat digest → merchant portal Problems feed — reusing existing
+  plumbing, not a new alerting path) and the bundle is refused, falling
+  through to the existing `content/index.html` / empty-state chain. A bundle
+  with no populated checksum field (older content, or a plugin author who
+  hasn't adopted the convention) is treated as nothing-to-verify and passes
+  through unchanged — defense-in-depth against post-install on-disk
+  corruption, not a replacement for the Ed25519 whole-bundle signature
+  already verified at install time.
+- Cross-language proof: ran this exact Go logic against all 9 real
+  `ut-plugin-faq/content/*.json` files (post their own fix) — all 9 verify
+  `true`.
+- Tests: `TestPluginPage_ChecksumValidBundleRenders` (matching checksum
+  renders normally), `TestPluginPage_ChecksumMismatchRefusesToRender`
+  (content tampered after signing → refused, tampered text never reaches the
+  response body).
+
+## Independent review
+One review pass (3 angles: line-by-line/regex correctness, cross-file
+caller/fixture trace, failure-mode/observability). Findings and
+disposition:
+
+**Fixed:**
+- Hex class was lowercase-only (`[0-9a-f]{64}`) — a valid but uppercase
+  digest (e.g. hand-edited, or a future tool using `.hexdigest().upper()`)
+  would silently skip verification instead of being checked. Made the
+  pattern case-insensitive and lowercase both sides before comparing.
+- `want` was read from the first regex match while `ReplaceAll` zeroed
+  *every* match — correct only when the field appears exactly once. Changed
+  to `FindAllSubmatch(raw, 2)`: 0 matches → nothing to verify, 1 → verify
+  normally, 2+ → refuse (a duplicate `checksum_sha256` key is itself a sign
+  of a malformed/tampered file; refusing is consistent with fail-closed,
+  never picks an arbitrary occurrence as "the" checksum). Note: reviewer
+  confirmed the pre-fix asymmetry could only ever fail *closed* (reject a
+  legitimate file), never fail *open* (accept tampered content) — not a
+  security hole, but worth tightening since it's a one-line fix.
+
+**Considered, deliberately not changed:**
+- *On checksum failure, `loadContentBundle` gives up entirely instead of
+  trying another candidate locale file the same plugin ships (e.g. `en-GB`
+  intact next to a corrupted `en-US`).* Real gap, but a bigger structural
+  change to the locale-picking loop (would need to try every candidate in
+  fallback order until one both parses and verifies, not just pick once).
+  Logged as a follow-up rather than rushed through under time pressure —
+  today's behavior (refuse → generic "no page content" fallback) is safe,
+  just not maximally available.
+- *A checksum failure is visually indistinguishable from a plugin that
+  simply ships no content page.* True, but a distinct error banner is a
+  UI/UX change beyond this fix's scope.
+- *The warning only lives in the in-memory `logging.Recent()` ring buffer
+  (capped, no disk persistence) until the next heartbeat sample.* This is
+  the same mechanism the existing persistent Problems/logs feed
+  (`ProblemEvent`, ADR-0018 2a) already reads from — the correct existing
+  integration point, not a shortcut. Building separate durable storage for
+  this one warning would duplicate that system.
+- The repo's own `data/plugins/com.universaltill.ut-faq/*/content/en-US.json`
+  sample fixtures (pre-existing, gitignored `data/plugins/` per
+  `.gitignore` — confirmed untracked, not shipped) still carry the old
+  empty checksum; harmless (empty → "nothing to verify"), and out of scope
+  to regenerate here since they're local dev-state, not repo content.
+
+## Verification
+`go build ./...`, `go test ./...`, `scripts/ci/guard-data-access.sh` — all
+green. Cross-checked all 9 real `ut-plugin-faq` locale bundles verify `true`
+against this implementation.
+
+## Follow-up (not done here)
+Try remaining candidate locale files on a checksum failure instead of
+giving up immediately — needs restructuring `loadContentBundle`'s
+single-`pick` selection into an ordered-candidates loop.

--- a/internal/pages/plugin_page.go
+++ b/internal/pages/plugin_page.go
@@ -1,17 +1,21 @@
 package pages
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"html/template"
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/universaltill/universal-till/internal/data"
 	"github.com/universaltill/universal-till/internal/httpx"
+	"github.com/universaltill/universal-till/internal/logging"
 	"github.com/universaltill/universal-till/internal/pages/common"
 	"github.com/universaltill/universal-till/internal/plugins"
 )
@@ -201,6 +205,10 @@ func loadContentBundle(contentDir, locale string) (*contentBundle, bool) {
 	if err != nil {
 		return nil, false
 	}
+	if !checksumValid(raw) {
+		logging.L().Warnf("plugin content: %s failed checksum_sha256 verification (on-disk corruption?), refusing to render", filepath.Join(contentDir, pick+".json"))
+		return nil, false
+	}
 	var b contentBundle
 	if err := json.Unmarshal(raw, &b); err != nil {
 		return nil, false
@@ -210,6 +218,43 @@ func loadContentBundle(contentDir, locale string) (*contentBundle, bool) {
 		return nil, false
 	}
 	return &b, true
+}
+
+// checksumFieldPattern matches a populated checksum_sha256 field the same
+// way ut-plugin-faq's scripts/checksum.py writes it.
+var checksumFieldPattern = regexp.MustCompile(`(?i)("checksum_sha256":\s*")([0-9a-f]{64})(")`)
+
+// checksumValid verifies a content bundle's self-referential checksum_sha256
+// field, if present. The field can't hash the file's raw bytes as-is (that
+// would be circular — it would need to already know its own value), so the
+// checksum instead covers the file with its own checksum_sha256 VALUE
+// zeroed out to a same-length placeholder (sha256 hex digests are always
+// exactly 64 chars, so zeroing never changes the file's byte length or
+// reflows anything). This is pure byte-level substitution, not JSON
+// re-serialization, so it matches ut-plugin-faq's Python packaging tool
+// exactly with no cross-language canonicalization risk.
+//
+// A bundle with no populated checksum field (older content, or a
+// page-plugin author who hasn't adopted this convention) has nothing to
+// verify and passes through unchanged — this is a defense-in-depth check
+// against post-install on-disk corruption, not a replacement for the
+// Ed25519 signature already verified at install time.
+func checksumValid(raw []byte) bool {
+	matches := checksumFieldPattern.FindAllSubmatch(raw, 2)
+	switch len(matches) {
+	case 0:
+		return true
+	case 1:
+		want := strings.ToLower(string(matches[0][2]))
+		zeroed := checksumFieldPattern.ReplaceAll(raw, []byte(`${1}`+strings.Repeat("0", 64)+`${3}`))
+		sum := sha256.Sum256(zeroed)
+		return hex.EncodeToString(sum[:]) == want
+	default:
+		// More than one checksum_sha256 field is itself a sign something is
+		// wrong with the file (duplicate/injected key) — refuse rather than
+		// guess which occurrence is authoritative.
+		return false
+	}
 }
 
 // bundleView groups bundle entries under their (sorted) categories for the

--- a/internal/pages/plugin_page_test.go
+++ b/internal/pages/plugin_page_test.go
@@ -1,6 +1,8 @@
 package pages
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,6 +12,20 @@ import (
 
 	"github.com/universaltill/universal-till/internal/pages/common"
 )
+
+// bundleWithChecksum mirrors ut-plugin-faq's scripts/checksum.py: the
+// checksum covers the JSON with its own checksum_sha256 value zeroed to a
+// same-length placeholder.
+func bundleWithChecksum(t *testing.T, jsonWithEmptyChecksum string) string {
+	t.Helper()
+	zeroed := strings.Replace(jsonWithEmptyChecksum, `"checksum_sha256":""`, `"checksum_sha256":"`+strings.Repeat("0", 64)+`"`, 1)
+	if zeroed == jsonWithEmptyChecksum {
+		t.Fatal(`bundleWithChecksum: fixture must contain "checksum_sha256":""`)
+	}
+	sum := sha256.Sum256([]byte(zeroed))
+	digest := hex.EncodeToString(sum[:])
+	return strings.Replace(zeroed, strings.Repeat("0", 64), digest, 1)
+}
 
 func pluginPageTestDeps(t *testing.T) (*common.Deps, string) {
 	t.Helper()
@@ -73,6 +89,75 @@ func TestPluginPage_RendersContentBundle(t *testing.T) {
 	// It must NOT be the home page.
 	if strings.Contains(body, "kiosk-checkout-start") {
 		t.Error("plugin route rendered the home page")
+	}
+}
+
+func TestPluginPage_ChecksumValidBundleRenders(t *testing.T) {
+	d, base := pluginPageTestDeps(t)
+
+	if _, err := d.Db.Exec(`INSERT INTO plugins(id,name,version) VALUES('com.x.faq','FAQ Plugin','1.2.0')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.Db.Exec(`INSERT INTO plugin_entries(id,plugin_id,type,key,route,label) VALUES('e1','com.x.faq','page','faq-page','/plugin/faq','Help / FAQ')`); err != nil {
+		t.Fatal(err)
+	}
+	contentDir := filepath.Join(base, "com.x.faq", "1.2.0", "content")
+	if err := os.MkdirAll(contentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fixture := `{"locale":"en-US","checksum_sha256":"","rtl":false,
+		"categories":[{"id":"general","name":"General","sort_order":1}],
+		"faq_entries":[{"id":"q1","category":"general","question":"How do I scan?","answer":"Point and shoot.","sort_order":1}]}`
+	if err := os.WriteFile(filepath.Join(contentDir, "en-US.json"), []byte(bundleWithChecksum(t, fixture)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	registerPluginPages(mux, d)
+	req := httptest.NewRequest(http.MethodGet, "/plugin/faq", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "How do I scan?") {
+		t.Fatalf("valid-checksum bundle: code=%d body=%s", rec.Code, rec.Body.String()[:min(300, rec.Body.Len())])
+	}
+}
+
+func TestPluginPage_ChecksumMismatchRefusesToRender(t *testing.T) {
+	d, base := pluginPageTestDeps(t)
+
+	if _, err := d.Db.Exec(`INSERT INTO plugins(id,name,version) VALUES('com.x.faq','FAQ Plugin','1.2.0')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.Db.Exec(`INSERT INTO plugin_entries(id,plugin_id,type,key,route,label) VALUES('e1','com.x.faq','page','faq-page','/plugin/faq','Help / FAQ')`); err != nil {
+		t.Fatal(err)
+	}
+	contentDir := filepath.Join(base, "com.x.faq", "1.2.0", "content")
+	if err := os.MkdirAll(contentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fixture := `{"locale":"en-US","checksum_sha256":"","rtl":false,
+		"categories":[{"id":"general","name":"General","sort_order":1}],
+		"faq_entries":[{"id":"q1","category":"general","question":"How do I scan?","answer":"Point and shoot.","sort_order":1}]}`
+	signed := bundleWithChecksum(t, fixture)
+	// Corrupt the content AFTER signing — same shape as on-disk bit-rot or a
+	// hand-edit, the checksum no longer matches.
+	tampered := strings.Replace(signed, "Point and shoot.", "Point and shoot!!", 1)
+	if err := os.WriteFile(filepath.Join(contentDir, "en-US.json"), []byte(tampered), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	registerPluginPages(mux, d)
+	req := httptest.NewRequest(http.MethodGet, "/plugin/faq", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	// loadContentBundle refuses the corrupted bundle; renderPluginPage falls
+	// through to the "ships no page content" empty state rather than the
+	// (possibly tampered) FAQ text.
+	if strings.Contains(rec.Body.String(), "Point and shoot") {
+		t.Fatalf("rendered content from a checksum-mismatched bundle: %s", rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Companion to ut-plugin-faq populating real checksum_sha256 values in its content bundles.
- Till-side verification in loadContentBundle; mismatch refuses to render and logs via existing warn/error plumbing (heartbeat Problems feed).

## Test plan
- [x] go test ./... green
- [x] scripts/ci/guard-data-access.sh green
- [x] Cross-checked against all 9 real ut-plugin-faq locale bundles

Full review: docs/code-reviews/2026-07-21-faq-content-checksum-verification.md

https://claude.ai/code/session_01VmtYSR3cSEtjfsABwEmCti