### PR TITLE
Content bundle: locale-fallback notice + version/last-updated metadata

### DIFF
--- a/docs/code-reviews/2026-07-22-faq-locale-fallback-notice-and-metadata.md
+++ b/docs/code-reviews/2026-07-22-faq-locale-fallback-notice-and-metadata.md
@@ -1,0 +1,75 @@
+# 2026-07-22 — Content bundle locale-fallback notice + version/last-updated metadata
+
+## Context
+Spec audit gap (`ut-docs/QUEUE.md`, ut-plugin-faq spec 001-multilingual-faq-page):
+`loadContentBundle()` silently fell back to whatever locale file was
+available with no signal reaching the template (spec FR-004 / US2
+acceptance scenario 2: "presents a clear fallback notice without breaking
+layout direction"), and the bundle's `version`/per-entry `last_updated`
+fields existed in the JSON schema but were never parsed or shown, so staff
+had no way to confirm content recency without developer tools (FR-007).
+
+## Changes
+- `contentBundle` gained `Version` (bundle-level) and each entry gained
+  `LastUpdated` — both already present in real `ut-plugin-faq` content,
+  just never parsed.
+- `loadContentBundle`'s signature changed to also return `usedFallback
+  bool`: true only when the requested locale needed a true language
+  fallback (no shipped file matches its language at all), false for an
+  exact match, a regional-prefix match (`en` → `en-US`), or — new — a
+  same-base-language match (`en-GB` requested, only `en-US` shipped: still
+  the requester's language, just a different region, so NOT a fallback).
+- `bundleView` now also returns `Version` and the max of all entries'
+  `LastUpdated` (plain string comparison — safe since the dates are
+  fixed-width ISO-8601 `YYYY-MM-DD`, which sorts lexicographically in
+  chronological order).
+- `plugin_content.html`: a fallback notice paragraph when
+  `.bundle.FallbackNotice`, and a version/last-updated line when both are
+  present. New i18n keys `plugin.content.fallback_notice` /
+  `plugin.content.meta` in all 4 core locales (en/ar/fa/tr) — the `meta`
+  string is itself a `%s %s` format string consumed via Go template's
+  `printf`, the same pattern already used by
+  `web/ui/partials/receipt.html`'s `receipt.legal.plugin_label`.
+- Tests: unavailable locale gets the notice + correct (max) version/date;
+  matched locale doesn't; same-base-language regional variant doesn't
+  either.
+
+## Independent review
+One review pass (line-by-line + cross-file trace of the only caller;
+test-coverage gap check; i18n/escaping correctness). Findings and
+disposition:
+
+**Fixed:**
+- **Real false-positive**: the prefix-match tier is one-directional (only
+  checks "does a shipped file start with `locale-`", e.g. `locale=en` →
+  `en-US.json`) — it never checked the reverse: a regional locale request
+  (`en-GB`) against a differently-regioned shipped file of the *same*
+  language (`en-US.json`). Without a fix, an English speaker whose region
+  isn't shipped would incorrectly see "not available in your language yet"
+  even though it plainly is their language. Added a same-base-language tier
+  (`baseLang()` — the subtag before the first `-`) between the prefix-match
+  and the final `en-US`/first-available fallback tier. New test:
+  `TestPluginPage_SameBaseLanguageDifferentRegionHasNoFallbackNotice`.
+- **Translation phrasing**: reviewer flagged the Turkish, Persian, and
+  Arabic `plugin.content.meta` strings as awkward/calque-like versus the
+  more fluent `fallback_notice` strings in the same files. Fixed: Turkish
+  `sürüm` spelled out (was a bare "s" glued to the placeholder); Persian
+  and Arabic reordered to the natural "version of the content" possessive
+  construction instead of a literal English word-order copy.
+
+**Considered, deliberately not changed:**
+- *`contentBundle.FallbackLocale` (`fallback_locale`) is parsed but never
+  consulted anywhere in the tier-selection logic* — pre-existing (predates
+  this change, the doc comment already described it before this diff), and
+  fixing it well requires clarifying what the field is actually meant to
+  mean (a locale's own declared preference vs. a global default) — not
+  something to guess at under this fix's scope. Corrected the function's
+  doc comment to stop implying it's consulted, so the next person reading
+  it isn't misled the way this review's reviewer initially was. Left as a
+  known gap, not filed as a new backlog item since it's cosmetic (the
+  fallback chain already lands on `en-US` either way).
+
+## Verification
+`go build ./...`, `go test ./...`, `scripts/ci/guard-data-access.sh`,
+`scripts/ci/guard-i18n.sh` — all green, including the 7
+`TestPluginPage_*` cases.

--- a/internal/pages/plugin_page.go
+++ b/internal/pages/plugin_page.go
@@ -28,6 +28,7 @@ var pluginPagesDir = "./data/plugins"
 // FAQ reference plugin publishes).
 type contentBundle struct {
 	Locale         string `json:"locale"`
+	Version        string `json:"version"`
 	RTL            bool   `json:"rtl"`
 	FallbackLocale string `json:"fallback_locale"`
 	Categories     []struct {
@@ -36,11 +37,12 @@ type contentBundle struct {
 		SortOrder int    `json:"sort_order"`
 	} `json:"categories"`
 	Entries []struct {
-		ID        string `json:"id"`
-		Category  string `json:"category"`
-		Question  string `json:"question"`
-		Answer    string `json:"answer"`
-		SortOrder int    `json:"sort_order"`
+		ID          string `json:"id"`
+		Category    string `json:"category"`
+		Question    string `json:"question"`
+		Answer      string `json:"answer"`
+		SortOrder   int    `json:"sort_order"`
+		LastUpdated string `json:"last_updated"`
 	} `json:"faq_entries"`
 }
 
@@ -133,8 +135,10 @@ func renderPluginPage(w http.ResponseWriter, r *http.Request, d *common.Deps, en
 		"menuItems": d.Menu,
 	}
 
-	if bundle, ok := loadContentBundle(filepath.Join(pluginDir, "content"), locale); ok {
-		base["bundle"] = bundleView(bundle)
+	if bundle, usedFallback, ok := loadContentBundle(filepath.Join(pluginDir, "content"), locale); ok {
+		view := bundleView(bundle)
+		view["FallbackNotice"] = usedFallback
+		base["bundle"] = view
 		httpx.Render("ui/pages/plugin_content.html", base)(w, r)
 		return
 	}
@@ -153,13 +157,33 @@ func renderPluginPage(w http.ResponseWriter, r *http.Request, d *common.Deps, en
 	httpx.Render("ui/pages/plugin_embed.html", base)(w, r)
 }
 
+// baseLang returns the language subtag before the first '-' (lowercased),
+// e.g. "en-GB" -> "en"; a tag with no '-' is returned lowercased as-is.
+func baseLang(locale string) string {
+	lower := strings.ToLower(locale)
+	if i := strings.Index(lower, "-"); i >= 0 {
+		return lower[:i]
+	}
+	return lower
+}
+
 // loadContentBundle picks the best content/<locale>.json for the POS locale:
-// exact match, prefix match (en -> en-US/en-GB), declared fallback, en-US,
-// then any bundle.
-func loadContentBundle(contentDir, locale string) (*contentBundle, bool) {
+// exact match, prefix match (en -> en-US/en-GB), same base language but a
+// different region (en-GB requested, only en-US shipped), then en-US, then
+// any bundle. (The bundle's own "fallback_locale" field is parsed but NOT
+// consulted here — pre-existing, not addressed by this function.) The
+// second return value reports whether
+// the pick required a true language fallback (e.g. requested ja-JP but
+// served en-US) as opposed to matching the requested language in some form
+// (exact, regional prefix, or same base language) — the caller surfaces
+// this to the page so staff know they're seeing a different language, not
+// their own (spec FR-004 / US2 acceptance scenario 2). A same-base-language
+// pick (en-GB -> en-US) is deliberately NOT a fallback for this purpose:
+// it's still the requester's language, just a different region's bundle.
+func loadContentBundle(contentDir, locale string) (bundle *contentBundle, usedFallback bool, ok bool) {
 	files, err := os.ReadDir(contentDir)
 	if err != nil {
-		return nil, false
+		return nil, false, false
 	}
 	var names []string
 	for _, f := range files {
@@ -168,7 +192,7 @@ func loadContentBundle(contentDir, locale string) (*contentBundle, bool) {
 		}
 	}
 	if len(names) == 0 {
-		return nil, false
+		return nil, false, false
 	}
 	sort.Strings(names)
 
@@ -188,6 +212,16 @@ func loadContentBundle(contentDir, locale string) (*contentBundle, bool) {
 		}
 	}
 	if pick == "" {
+		reqBase := baseLang(locale)
+		for _, n := range names {
+			if baseLang(n) == reqBase {
+				pick = n
+				break
+			}
+		}
+	}
+	matchedRequestedLanguage := pick != ""
+	if pick == "" {
 		for _, fallback := range []string{"en-US", names[0]} {
 			for _, n := range names {
 				if n == fallback {
@@ -203,21 +237,21 @@ func loadContentBundle(contentDir, locale string) (*contentBundle, bool) {
 
 	raw, err := os.ReadFile(filepath.Join(contentDir, pick+".json"))
 	if err != nil {
-		return nil, false
+		return nil, false, false
 	}
 	if !checksumValid(raw) {
 		logging.L().Warnf("plugin content: %s failed checksum_sha256 verification (on-disk corruption?), refusing to render", filepath.Join(contentDir, pick+".json"))
-		return nil, false
+		return nil, false, false
 	}
 	var b contentBundle
 	if err := json.Unmarshal(raw, &b); err != nil {
-		return nil, false
+		return nil, false, false
 	}
 	// A bundle without entries isn't a content page.
 	if len(b.Entries) == 0 {
-		return nil, false
+		return nil, false, false
 	}
-	return &b, true
+	return &b, !matchedRequestedLanguage, true
 }
 
 // checksumFieldPattern matches a populated checksum_sha256 field the same
@@ -278,8 +312,14 @@ func bundleView(b *contentBundle) map[string]any {
 	}
 
 	grouped := map[string][]entryView{}
+	lastUpdated := ""
 	for _, e := range b.Entries {
 		grouped[e.Category] = append(grouped[e.Category], entryView{Question: e.Question, Answer: e.Answer, Sort: e.SortOrder})
+		// ISO 8601 (YYYY-MM-DD) dates compare lexicographically in
+		// chronological order, so a plain string max is correct here.
+		if e.LastUpdated > lastUpdated {
+			lastUpdated = e.LastUpdated
+		}
 	}
 
 	cats := make([]categoryView, 0, len(grouped))
@@ -293,5 +333,10 @@ func bundleView(b *contentBundle) map[string]any {
 	}
 	sort.Slice(cats, func(i, j int) bool { return cats[i].Sort < cats[j].Sort })
 
-	return map[string]any{"RTL": b.RTL, "Categories": cats}
+	return map[string]any{
+		"RTL":         b.RTL,
+		"Categories":  cats,
+		"Version":     b.Version,
+		"LastUpdated": lastUpdated,
+	}
 }

--- a/internal/pages/plugin_page_test.go
+++ b/internal/pages/plugin_page_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/universaltill/universal-till/internal/config"
+	"github.com/universaltill/universal-till/internal/httpx"
 	"github.com/universaltill/universal-till/internal/pages/common"
 )
 
@@ -158,6 +160,133 @@ func TestPluginPage_ChecksumMismatchRefusesToRender(t *testing.T) {
 	// (possibly tampered) FAQ text.
 	if strings.Contains(rec.Body.String(), "Point and shoot") {
 		t.Fatalf("rendered content from a checksum-mismatched bundle: %s", rec.Body.String())
+	}
+}
+
+func TestPluginPage_UnavailableLocaleShowsFallbackNoticeAndMeta(t *testing.T) {
+	d, base := pluginPageTestDeps(t)
+	i18n, err := config.NewI18n(filepath.Join("web", "locales"), "en")
+	if err != nil {
+		t.Fatalf("i18n: %v", err)
+	}
+	httpx.InitI18n(i18n, "en")
+
+	if _, err := d.Db.Exec(`INSERT INTO plugins(id,name,version) VALUES('com.x.faq','FAQ Plugin','1.2.0')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.Db.Exec(`INSERT INTO plugin_entries(id,plugin_id,type,key,route,label) VALUES('e1','com.x.faq','page','faq-page','/plugin/faq','Help / FAQ')`); err != nil {
+		t.Fatal(err)
+	}
+	contentDir := filepath.Join(base, "com.x.faq", "1.2.0", "content")
+	if err := os.MkdirAll(contentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bundle := `{"locale":"en-US","version":"1.4.0","rtl":false,
+		"categories":[{"id":"general","name":"General","sort_order":1}],
+		"faq_entries":[{"id":"q1","category":"general","question":"How do I scan?","answer":"Point and shoot.","sort_order":1,"last_updated":"2026-06-01"},
+		               {"id":"q2","category":"general","question":"How do I refund?","answer":"Use the journal.","sort_order":2,"last_updated":"2026-07-13"}]}`
+	if err := os.WriteFile(filepath.Join(contentDir, "en-US.json"), []byte(bundle), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	registerPluginPages(mux, d)
+
+	// ja-JP isn't shipped by this plugin (only en-US) — must fall back to
+	// en-US and say so, not render as if ja-JP were actually available.
+	req := httptest.NewRequest(http.MethodGet, "/plugin/faq?lang=ja-JP", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /plugin/faq?lang=ja-JP = %d (%s)", rec.Code, body[:min(300, len(body))])
+	}
+	if !strings.Contains(body, "available in your language yet") {
+		t.Errorf("expected a fallback notice for an unshipped locale, body=%s", body[:min(600, len(body))])
+	}
+	// The most recent of the two entries' last_updated wins, not the first.
+	if !strings.Contains(body, "1.4.0") || !strings.Contains(body, "2026-07-13") {
+		t.Errorf("expected version/last-updated metadata (v1.4.0, 2026-07-13), body=%s", body[:min(600, len(body))])
+	}
+}
+
+func TestPluginPage_MatchedLocaleHasNoFallbackNotice(t *testing.T) {
+	d, base := pluginPageTestDeps(t)
+
+	if _, err := d.Db.Exec(`INSERT INTO plugins(id,name,version) VALUES('com.x.faq','FAQ Plugin','1.2.0')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.Db.Exec(`INSERT INTO plugin_entries(id,plugin_id,type,key,route,label) VALUES('e1','com.x.faq','page','faq-page','/plugin/faq','Help / FAQ')`); err != nil {
+		t.Fatal(err)
+	}
+	contentDir := filepath.Join(base, "com.x.faq", "1.2.0", "content")
+	if err := os.MkdirAll(contentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bundle := `{"locale":"en-US","version":"1.4.0","rtl":false,
+		"categories":[{"id":"general","name":"General","sort_order":1}],
+		"faq_entries":[{"id":"q1","category":"general","question":"How do I scan?","answer":"Point and shoot.","sort_order":1,"last_updated":"2026-06-01"}]}`
+	if err := os.WriteFile(filepath.Join(contentDir, "en-US.json"), []byte(bundle), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	registerPluginPages(mux, d)
+
+	req := httptest.NewRequest(http.MethodGet, "/plugin/faq?lang=en-US", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /plugin/faq?lang=en-US = %d (%s)", rec.Code, body[:min(300, len(body))])
+	}
+	if strings.Contains(body, "available in your language yet") {
+		t.Errorf("matched locale should not show a fallback notice, body=%s", body[:min(600, len(body))])
+	}
+}
+
+// A regional variant of the SAME language (en-GB requested, only en-US
+// shipped) is still "your language" — must not trigger the fallback
+// notice, even though a different regional file is served.
+func TestPluginPage_SameBaseLanguageDifferentRegionHasNoFallbackNotice(t *testing.T) {
+	d, base := pluginPageTestDeps(t)
+
+	if _, err := d.Db.Exec(`INSERT INTO plugins(id,name,version) VALUES('com.x.faq','FAQ Plugin','1.2.0')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.Db.Exec(`INSERT INTO plugin_entries(id,plugin_id,type,key,route,label) VALUES('e1','com.x.faq','page','faq-page','/plugin/faq','Help / FAQ')`); err != nil {
+		t.Fatal(err)
+	}
+	contentDir := filepath.Join(base, "com.x.faq", "1.2.0", "content")
+	if err := os.MkdirAll(contentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bundle := `{"locale":"en-US","version":"1.4.0","rtl":false,
+		"categories":[{"id":"general","name":"General","sort_order":1}],
+		"faq_entries":[{"id":"q1","category":"general","question":"How do I scan?","answer":"Point and shoot.","sort_order":1,"last_updated":"2026-06-01"}]}`
+	if err := os.WriteFile(filepath.Join(contentDir, "en-US.json"), []byte(bundle), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	registerPluginPages(mux, d)
+
+	// Only en-US.json exists; the request is en-GB — same language, just a
+	// different region. Neither exact nor prefix match fires (prefix only
+	// checks file-startswith-locale, not the reverse), so without the
+	// same-base-language tier this would wrongly claim a fallback.
+	req := httptest.NewRequest(http.MethodGet, "/plugin/faq?lang=en-GB", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if rec.Code != http.StatusOK || !strings.Contains(body, "How do I scan?") {
+		t.Fatalf("en-GB requesting en-US content: code=%d body=%s", rec.Code, body[:min(300, len(body))])
+	}
+	if strings.Contains(body, "available in your language yet") {
+		t.Errorf("en-GB served en-US (same base language) should not show a fallback notice, body=%s", body[:min(600, len(body))])
 	}
 }
 

--- a/web/locales/ar.json
+++ b/web/locales/ar.json
@@ -889,5 +889,7 @@
   "backoffice.no_problems": "لا توجد تحذيرات أو أخطاء حديثة.",
   "backoffice.go_deeper": "تعمّق أكثر",
   "backoffice.inventory": "المخزون",
-  "backoffice.settings": "الإعدادات"
+  "backoffice.settings": "الإعدادات",
+  "plugin.content.fallback_notice": "هذا المحتوى غير متوفر بلغتك بعد — يتم عرض المتوفر حاليًا.",
+  "plugin.content.meta": "إصدار المحتوى %s · آخر تحديث %s"
 }

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -889,5 +889,7 @@
   "backoffice.no_problems": "No recent warnings or errors.",
   "backoffice.go_deeper": "Go deeper",
   "backoffice.inventory": "Inventory",
-  "backoffice.settings": "Settings"
+  "backoffice.settings": "Settings",
+  "plugin.content.fallback_notice": "This content isn't available in your language yet — showing what's there so far.",
+  "plugin.content.meta": "Content v%s · updated %s"
 }

--- a/web/locales/fa.json
+++ b/web/locales/fa.json
@@ -889,5 +889,7 @@
   "backoffice.no_problems": "هشدار یا خطای اخیری وجود ندارد.",
   "backoffice.go_deeper": "جزئیات بیشتر",
   "backoffice.inventory": "انبار",
-  "backoffice.settings": "تنظیمات"
+  "backoffice.settings": "تنظیمات",
+  "plugin.content.fallback_notice": "این محتوا هنوز به زبان شما ترجمه نشده — محتوای موجود نمایش داده می‌شود.",
+  "plugin.content.meta": "نسخهٔ محتوا %s · به‌روزرسانی %s"
 }

--- a/web/locales/tr.json
+++ b/web/locales/tr.json
@@ -889,5 +889,7 @@
   "backoffice.no_problems": "Yakın zamanda uyarı veya hata yok.",
   "backoffice.go_deeper": "Detaya in",
   "backoffice.inventory": "Envanter",
-  "backoffice.settings": "Ayarlar"
+  "backoffice.settings": "Ayarlar",
+  "plugin.content.fallback_notice": "Bu içerik henüz dilinize çevrilmedi — mevcut içerik gösteriliyor.",
+  "plugin.content.meta": "İçerik sürüm %s · güncellenme %s"
 }

--- a/web/ui/pages/plugin_content.html
+++ b/web/ui/pages/plugin_content.html
@@ -1,5 +1,8 @@
 {{ define "content" }}
 <h1>{{ .title }}</h1>
+{{ if .bundle.FallbackNotice }}
+<p class="plugin-content-notice">{{ T "plugin.content.fallback_notice" }}</p>
+{{ end }}
 <div class="card plugin-content" {{ if .bundle.RTL }}dir="rtl"{{ end }}>
   {{ range .bundle.Categories }}
   <section class="plugin-content-category">
@@ -13,4 +16,7 @@
   </section>
   {{ end }}
 </div>
+{{ if and .bundle.Version .bundle.LastUpdated }}
+<p class="plugin-content-meta muted">{{ printf (T "plugin.content.meta") .bundle.Version .bundle.LastUpdated }}</p>
+{{ end }}
 {{ end }}


### PR DESCRIPTION
## Summary
- Closes a spec-audit gap: content bundle rendering silently fell back to another locale with no signal to the page, and version/last_updated metadata existed in the schema but was never shown.
- loadContentBundle now reports whether a true language fallback occurred (vs. an exact/regional/same-base-language match); the page shows a notice only in the true-fallback case, plus a version/updated line when present.

## Test plan
- [x] go test ./... green (7 TestPluginPage_* cases, including new fallback/metadata/same-base-language tests)
- [x] scripts/ci/guard-i18n.sh and guard-data-access.sh green

Full review: docs/code-reviews/2026-07-22-faq-locale-fallback-notice-and-metadata.md

https://claude.ai/code/session_01VmtYSR3cSEtjfsABwEmCti