### PR TITLE
Keyword search over content bundle FAQ entries

### DIFF
--- a/docs/code-reviews/2026-07-22-faq-keyword-search.md
+++ b/docs/code-reviews/2026-07-22-faq-keyword-search.md
@@ -1,0 +1,84 @@
+# 2026-07-22 — Keyword search over content bundle entries
+
+## Context
+Spec-audit gap (FR-005/SC-003, `ut-plugin-faq` spec 001-multilingual-faq-page):
+"Users MUST be able to browse FAQs by category and search by keyword" —
+each entry's JSON already carries a `keywords` array, parsed nowhere;
+`plugin_content.html` had only category accordions, no search input.
+
+## Changes
+- `contentBundle`'s entry struct gained `Keywords []string`.
+- `bundleView`'s `entryView` gained `Search string`: a lowercased
+  `question + answer + keywords...` haystack, computed once per entry.
+- `plugin_content.html`: a `#plugin-content-search` input (shown only when
+  the bundle has categories); each `.plugin-content-entry` carries
+  `data-search="{{ .Search }}"`; an inline IIFE `<script>` filters on
+  `input`, hiding entries whose haystack doesn't contain the (lowercased)
+  query substring and hiding a whole `.plugin-content-category` section if
+  every entry inside it is hidden. Mirrors the existing, already-shipped
+  `#catalog-search` pattern in `catalog.html` (same hide-via-`.hidden`
+  approach), applied to the plugin-content classes instead.
+- New i18n key `plugin.content.search_placeholder` in all 4 core locales,
+  inserted as a single line each (learned from the previous fix in this
+  same session not to round-trip a locale file through a generic
+  `map`+re-marshal — verified independently by the reviewer this time,
+  each diff is a clean `+1` line).
+- Test: `TestPluginPage_KeywordsAreSearchable` — seeds an entry whose
+  question/answer do NOT contain "barcode", only its `keywords` array
+  does, and asserts the rendered `data-search` attribute carries it,
+  proving keywords are actually indexed, not just parsed and dropped.
+
+## Independent review
+One review pass (line-by-line JS/logic trace of the new script and
+`Search` construction; cross-repo CSS/class reuse check; direct
+re-verification of the locale-file diff hygiene). Findings and
+disposition:
+
+**Fixed:**
+- Reviewer confirmed the search input had zero matching CSS (unlike
+  `#catalog-search`, which gets `min-width`/flex placement from
+  `.page-head`) — would have rendered at the browser's tiny default
+  search-input width, stacked alone above the card. Added a
+  `.plugin-content-search` rule in `app.css`.
+
+**Considered, deliberately not changed:**
+- *Search input isn't inside the `{{ if .bundle.RTL }}dir="rtl"{{ end }}`
+  div, so it doesn't inherit that attribute directly.* Reviewer's own
+  trace confirmed this is very likely fine in practice: the page's
+  `<html dir="...">` is already set from the resolved UI locale
+  (`internal/httpx`'s `dir()` template func), which normally agrees with
+  `bundle.RTL` since the bundle is chosen based on that same locale. Only
+  a genuine locale/content-language mismatch (bundle fell back
+  cross-language) could disagree, and even then the search placeholder
+  text itself is UI-locale text, not content-locale text — correct as
+  designed, not a bug.
+- *Turkish dotted/dotless I casing*: neither Go's `strings.ToLower` nor
+  JS's `String.prototype.toLowerCase()` implement Turkish-specific
+  casing rules, so a dotless-ı-based query could in theory miss a
+  keyword. Real but niche (would need a specific Turkish keyword +
+  specific query casing to trigger); not fixed — would need a
+  locale-aware casing library on both the Go and JS sides for a fix that
+  actually holds together, disproportionate to the gap.
+- *No live-browser/headless test of the actual JS filtering behavior* —
+  correct gap (Go tests can only prove the markup/attributes are right,
+  not that the script executes correctly in a real DOM). Checked: no
+  Playwright/Puppeteer harness exists elsewhere in this repo to hook into
+  cheaply. Mitigated instead by `node --check` confirming the extracted
+  script is syntactically valid, and the logic being a near-line-for-line
+  copy of `catalog.html`'s already-shipped, working `#catalog-search`
+  pattern (same hide-via-`.hidden`, same "re-show on empty query"
+  short-circuit). Building new e2e infra for one small feature is out of
+  proportion here; flagging as a known verification gap rather than
+  rushing browser automation together under time pressure.
+- *No regression test pinning `data-search`'s HTML-attribute escaping for
+  question/answer/keyword text containing quotes* — reviewer traced this
+  as already safe (`html/template`, not `text/template`, is in use
+  throughout this renderer, confirmed earlier in this same session's
+  checksum-verification review), just untested. Not added under time
+  pressure; low risk since the escaping guarantee is structural (which
+  template package is imported), not per-call-site.
+
+## Verification
+`go build ./...`, `go test ./...`, `scripts/ci/guard-i18n.sh`,
+`scripts/ci/guard-data-access.sh` — all green, including the 8
+`TestPluginPage_*` cases.

--- a/internal/pages/plugin_page.go
+++ b/internal/pages/plugin_page.go
@@ -37,12 +37,13 @@ type contentBundle struct {
 		SortOrder int    `json:"sort_order"`
 	} `json:"categories"`
 	Entries []struct {
-		ID          string `json:"id"`
-		Category    string `json:"category"`
-		Question    string `json:"question"`
-		Answer      string `json:"answer"`
-		SortOrder   int    `json:"sort_order"`
-		LastUpdated string `json:"last_updated"`
+		ID          string   `json:"id"`
+		Category    string   `json:"category"`
+		Question    string   `json:"question"`
+		Answer      string   `json:"answer"`
+		SortOrder   int      `json:"sort_order"`
+		LastUpdated string   `json:"last_updated"`
+		Keywords    []string `json:"keywords"`
 	} `json:"faq_entries"`
 }
 
@@ -297,6 +298,10 @@ func bundleView(b *contentBundle) map[string]any {
 	type entryView struct {
 		Question, Answer string
 		Sort             int
+		// Search is a lowercased "question answer keyword1 keyword2..."
+		// haystack for the client-side keyword filter (FR-005/SC-003) —
+		// rendered as a data-search attribute, never displayed.
+		Search string
 	}
 	type categoryView struct {
 		Name    string
@@ -314,7 +319,8 @@ func bundleView(b *contentBundle) map[string]any {
 	grouped := map[string][]entryView{}
 	lastUpdated := ""
 	for _, e := range b.Entries {
-		grouped[e.Category] = append(grouped[e.Category], entryView{Question: e.Question, Answer: e.Answer, Sort: e.SortOrder})
+		haystack := strings.ToLower(strings.Join(append([]string{e.Question, e.Answer}, e.Keywords...), " "))
+		grouped[e.Category] = append(grouped[e.Category], entryView{Question: e.Question, Answer: e.Answer, Sort: e.SortOrder, Search: haystack})
 		// ISO 8601 (YYYY-MM-DD) dates compare lexicographically in
 		// chronological order, so a plain string max is correct here.
 		if e.LastUpdated > lastUpdated {

--- a/internal/pages/plugin_page_test.go
+++ b/internal/pages/plugin_page_test.go
@@ -94,6 +94,47 @@ func TestPluginPage_RendersContentBundle(t *testing.T) {
 	}
 }
 
+func TestPluginPage_KeywordsAreSearchable(t *testing.T) {
+	d, base := pluginPageTestDeps(t)
+
+	if _, err := d.Db.Exec(`INSERT INTO plugins(id,name,version) VALUES('com.x.faq','FAQ Plugin','1.2.0')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.Db.Exec(`INSERT INTO plugin_entries(id,plugin_id,type,key,route,label) VALUES('e1','com.x.faq','page','faq-page','/plugin/faq','Help / FAQ')`); err != nil {
+		t.Fatal(err)
+	}
+	contentDir := filepath.Join(base, "com.x.faq", "1.2.0", "content")
+	if err := os.MkdirAll(contentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Neither the question nor the answer mentions "barcode" — only the
+	// keywords array does. The rendered data-search haystack must still
+	// carry it, or a search for "barcode" would find nothing.
+	bundle := `{"locale":"en-US","rtl":false,
+		"categories":[{"id":"general","name":"General","sort_order":1}],
+		"faq_entries":[{"id":"q1","category":"general","question":"How do I add an item?","answer":"Tap the tile.","sort_order":1,"keywords":["barcode","scan"]}]}`
+	if err := os.WriteFile(filepath.Join(contentDir, "en-US.json"), []byte(bundle), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	registerPluginPages(mux, d)
+	req := httptest.NewRequest(http.MethodGet, "/plugin/faq", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /plugin/faq = %d (%s)", rec.Code, body[:min(300, len(body))])
+	}
+	if !strings.Contains(body, `id="plugin-content-search"`) {
+		t.Error("expected a search input on the content page")
+	}
+	if !strings.Contains(body, `data-search="how do i add an item? tap the tile. barcode scan"`) {
+		t.Errorf("expected data-search to include the keywords, body=%s", body[:min(1200, len(body))])
+	}
+}
+
 func TestPluginPage_ChecksumValidBundleRenders(t *testing.T) {
 	d, base := pluginPageTestDeps(t)
 

--- a/web/locales/ar.json
+++ b/web/locales/ar.json
@@ -891,5 +891,6 @@
   "backoffice.inventory": "المخزون",
   "backoffice.settings": "الإعدادات",
   "plugin.content.fallback_notice": "هذا المحتوى غير متوفر بلغتك بعد — يتم عرض المتوفر حاليًا.",
-  "plugin.content.meta": "إصدار المحتوى %s · آخر تحديث %s"
+  "plugin.content.meta": "إصدار المحتوى %s · آخر تحديث %s",
+  "plugin.content.search_placeholder": "بحث…"
 }

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -891,5 +891,6 @@
   "backoffice.inventory": "Inventory",
   "backoffice.settings": "Settings",
   "plugin.content.fallback_notice": "This content isn't available in your language yet — showing what's there so far.",
-  "plugin.content.meta": "Content v%s · updated %s"
+  "plugin.content.meta": "Content v%s · updated %s",
+  "plugin.content.search_placeholder": "Search…"
 }

--- a/web/locales/fa.json
+++ b/web/locales/fa.json
@@ -891,5 +891,6 @@
   "backoffice.inventory": "انبار",
   "backoffice.settings": "تنظیمات",
   "plugin.content.fallback_notice": "این محتوا هنوز به زبان شما ترجمه نشده — محتوای موجود نمایش داده می‌شود.",
-  "plugin.content.meta": "نسخهٔ محتوا %s · به‌روزرسانی %s"
+  "plugin.content.meta": "نسخهٔ محتوا %s · به‌روزرسانی %s",
+  "plugin.content.search_placeholder": "جستجو…"
 }

--- a/web/locales/tr.json
+++ b/web/locales/tr.json
@@ -891,5 +891,6 @@
   "backoffice.inventory": "Envanter",
   "backoffice.settings": "Ayarlar",
   "plugin.content.fallback_notice": "Bu içerik henüz dilinize çevrilmedi — mevcut içerik gösteriliyor.",
-  "plugin.content.meta": "İçerik sürüm %s · güncellenme %s"
+  "plugin.content.meta": "İçerik sürüm %s · güncellenme %s",
+  "plugin.content.search_placeholder": "Ara…"
 }

--- a/web/public/app.css
+++ b/web/public/app.css
@@ -125,6 +125,10 @@ body.sale-screen .session-user { font-size: 1rem; padding: .3rem .5rem; }
 .page-head { display: flex; align-items: center; justify-content: space-between;
              gap: 1rem; margin: .25rem 0 1rem; }
 .page-head input[type="search"] { min-width: 260px; }
+
+/* ---------- Plugin content pages (FAQ etc.) ---------- */
+.plugin-content-search { display: block; min-width: 260px; max-width: 100%;
+                          margin: 0 0 1rem; }
 .catalog-layout { display: grid; grid-template-columns: minmax(0, 1fr) 360px;
                   gap: 1rem; align-items: start; }
 @media (max-width: 900px) { .catalog-layout { grid-template-columns: 1fr; } }

--- a/web/ui/pages/plugin_content.html
+++ b/web/ui/pages/plugin_content.html
@@ -3,12 +3,16 @@
 {{ if .bundle.FallbackNotice }}
 <p class="plugin-content-notice">{{ T "plugin.content.fallback_notice" }}</p>
 {{ end }}
+{{ if .bundle.Categories }}
+<input type="search" id="plugin-content-search" class="plugin-content-search"
+       placeholder="{{ T "plugin.content.search_placeholder" }}" autocomplete="off">
+{{ end }}
 <div class="card plugin-content" {{ if .bundle.RTL }}dir="rtl"{{ end }}>
   {{ range .bundle.Categories }}
   <section class="plugin-content-category">
     <h2>{{ .Name }}</h2>
     {{ range .Entries }}
-    <details class="plugin-content-entry">
+    <details class="plugin-content-entry" data-search="{{ .Search }}">
       <summary><strong>{{ .Question }}</strong></summary>
       <p>{{ .Answer }}</p>
     </details>
@@ -19,4 +23,23 @@
 {{ if and .bundle.Version .bundle.LastUpdated }}
 <p class="plugin-content-meta muted">{{ printf (T "plugin.content.meta") .bundle.Version .bundle.LastUpdated }}</p>
 {{ end }}
+<script>
+(function () {
+  var search = document.getElementById('plugin-content-search');
+  if (!search) return;
+  function filterEntries() {
+    var q = (search.value || '').toLowerCase();
+    document.querySelectorAll('.plugin-content-category').forEach(function (section) {
+      var visible = 0;
+      section.querySelectorAll('.plugin-content-entry').forEach(function (entry) {
+        var match = q === '' || (entry.dataset.search || '').indexOf(q) !== -1;
+        entry.hidden = !match;
+        if (match) visible++;
+      });
+      section.hidden = visible === 0;
+    });
+  }
+  search.addEventListener('input', filterEntries);
+})();
+</script>
 {{ end }}


### PR DESCRIPTION
## Summary
- Closes FR-005/SC-003: keywords array existed in the JSON schema, never parsed or searchable.
- Search input filters entries client-side (same pattern as catalog.html's existing #catalog-search), hides emptied categories.

## Test plan
- [x] go test ./... green (8 TestPluginPage_* cases)
- [x] guard-i18n.sh / guard-data-access.sh green
- [x] node --check on extracted inline script (syntax valid)

Full review: docs/code-reviews/2026-07-22-faq-keyword-search.md

https://claude.ai/code/session_01VmtYSR3cSEtjfsABwEmCti