### PR TITLE
docs: refresh README for 2026, fix plugin guide/WASM mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,17 @@
 - Enhanced security features
 
 ### Plugin Marketplace
-- Payment processors (Stripe, Square, PayPal, regional providers)
-- Marketplaces (eBay, Amazon, Shopify integration)
-- Delivery services (Uber Eats, DoorDash, Deliveroo)
-- Accounting systems (QuickBooks, Xero, Wave)
-- ERP integration (Odoo, ERPNext)
-- Industry-specific features
+Available now: Stripe / QR Pay / demo card payments, German & Spanish
+language packs, themes, a "No Sale" register-drawer plugin, a self-hosted
+AI assistant, a webhook/ERP connector, and a help/FAQ plugin. One-click
+install from the in-app store
+(`ut-cloud`), Ed25519-signature verified before anything runs.
+
+Categories the taxonomy supports and welcomes contributions for: more
+payment processors (Square, PayPal, regional providers), marketplaces
+(eBay, Amazon, Shopify), delivery services (Uber Eats, DoorDash,
+Deliveroo), accounting systems (QuickBooks, Xero, Wave), ERP integration
+(Odoo, ERPNext), and industry-specific features.
 
 ---
 
@@ -240,39 +245,23 @@ Access `/settings` in the web interface to configure:
 
 ## 🔌 Plugin Development
 
-Want to extend Universal Till? Plugins are easy to build!
-
-```go
-package main
-
-import "github.com/universaltill/plugin-sdk"
-
-type MyPlugin struct{}
-
-func (p *MyPlugin) Initialize(config plugin.Config) error {
-    // Setup your plugin
-    return nil
-}
-
-func (p *MyPlugin) ProcessTransaction(tx plugin.Transaction) error {
-    // Handle transaction
-    return nil
-}
-
-func main() {
-    plugin.Serve(&MyPlugin{})
-}
-```
+Want to extend Universal Till? Plugins run **in-process as WASM modules**
+(via [wazero](https://wazero.io), no cgo) — write the logic in Go
+(`GOOS=wasip1 GOARCH=wasm`), Rust, TinyGo, or anything else that compiles to
+WASM. One architecture-independent `.wasm` artifact per plugin, Ed25519-signed
+and capability-gated (a module gets nothing until the manifest grants it).
+Asset-only plugins (themes, language packs) use `runtime: "none"` instead —
+no code, just files. Hardware/device plugins needing raw OS access (USB,
+serial) run as a supervised process (`runtime: "go"`), the minority case.
 
 **See [PLUGIN_GUIDELINES.md](docs/plugin_guidelines.md) for complete documentation.**
 
 ### Plugin Store
 
-Submit your plugins to our **free** plugin store:
+Submit your plugins to the marketplace:
 - Free hosting and distribution
-- Automatic security scanning
-- User ratings and reviews
-- Build free or paid plugins (20% commission on paid)
+- Ed25519 signature verification before install
+- Build free or paid plugins
 
 ---
 
@@ -345,9 +334,15 @@ We'll even link to notable forks in this README! 🎉
 
 ## 🌍 Internationalization
 
-Currently supported languages:
+Built into core (`web/locales/`), including full RTL layout:
 - English (en)
-- More coming soon!
+- Arabic (ar) — RTL
+- Persian / Farsi (fa) — RTL
+- Turkish (tr)
+
+Available as install-time language plugins:
+- German (de) — `ut-plugin-language-de`
+- Spanish (es) — `ut-plugin-language-es`
 
 Want to add your language? See [CONTRIBUTING.md](CONTRIBUTING.md) for translation guidelines.
 
@@ -355,30 +350,31 @@ Want to add your language? See [CONTRIBUTING.md](CONTRIBUTING.md) for translatio
 
 ## 📊 Roadmap
 
-### Current Focus (Q1 2025)
-- [x] Core POS functionality
+### Shipped
+- [x] Core POS functionality, offline-first checkout
 - [x] SQLite database support
-- [ ] Plugin system architecture
-- [ ] Payment processor plugins (Stripe, Square)
-- [ ] Cloud sync service (optional)
-- [ ] Mobile app
+- [x] Plugin system architecture — in-process WASM runtime (wazero),
+      Ed25519-signed manifests, 20-type plugin taxonomy
+- [x] Plugin marketplace with one-click install (`ut-cloud`)
+- [x] Payment plugins: Stripe, QR Pay, demo card terminal
+- [x] Language plugins: German, Spanish (core ships en/ar/fa/tr)
+- [x] Theme plugins, FAQ / help plugin
+- [x] Self-hosted AI assistant plugin (camera item ID, "Ask your till")
+- [x] Webhook / ERP connector plugin
+- [x] Cloud sync service (optional, self-hostable)
 
-### Upcoming (Q2-Q3 2025)
+### In progress
 - [ ] Advanced inventory management
-- [ ] Employee scheduling
-- [ ] Customer loyalty programs
-- [ ] Marketplace integrations (eBay, Amazon)
-- [ ] Accounting integrations (QuickBooks, Xero)
 - [ ] Multi-location support
-- [ ] Kitchen display system
-- [ ] Table management (restaurants)
+- [ ] More payment/marketplace/accounting integrations (Square, PayPal,
+      eBay, Amazon, QuickBooks, Xero)
 
 ### Long-term
-- [ ] Hardware manufacturer partnerships
-- [ ] White-label licensing
+- [ ] Employee scheduling, customer loyalty programs
+- [ ] Kitchen display system, table management (restaurants)
+- [ ] Mobile app
 - [ ] Advanced analytics and BI
-- [ ] AI-powered insights
-- [ ] Multi-channel commerce platform
+- [ ] Hardware manufacturer partnerships, white-label licensing
 
 **See [our project board](https://github.com/universaltill/universal-till/projects) for detailed progress.**
 

--- a/docs/plugin_guidelines.md
+++ b/docs/plugin_guidelines.md
@@ -1,8 +1,18 @@
 # Universal Till Plugin Development Guidelines
 
-**Version 1.0 - December 2025**
+**Updated 2026-07-24** — reflects the current plugin runtime (ADR-0001,
+ADR-0002 in the `docs` repo: `reference/adr/`).
 
 Welcome to Universal Till plugin development! This guide will help you build, test, and publish plugins for the Universal Till ecosystem.
+
+Some sections below (Getting Started, Plugin Types interfaces, Publishing)
+describe a CLI-tool/SDK workflow that hasn't been built yet — they're kept
+as a design sketch of where plugin tooling is headed, not something you can
+run today. **For the actual, working way to build a plugin right now,
+skip to [Plugin Architecture](#plugin-architecture) below and copy a real
+example**: `ut-plugin-payment-stripe` (wasm, payment), `ut-plugin-faq`
+(none, asset-only), or `ut-plugin-integration-webhook` (wasm, integration)
+— all real, shipping plugins in the marketplace today.
 
 ---
 
@@ -36,27 +46,26 @@ Plugins extend Universal Till's functionality without modifying the core system.
 - Integrate with hardware (custom receipt printers, scales)
 - Export data to external systems
 
-### Plugin Execution Models
+### Plugin Runtime (ADR-0001)
 
-Plugins can run in two modes:
+Every plugin declares a `runtime` in its manifest:
 
-**1. Local Mode (Runs on Device)**
-```
-POS Device → Plugin (local process) → External API
-```
-- Best for: Simple integrations, privacy-focused merchants
-- Pros: Works offline, no cloud dependency
-- Cons: Merchant manages API keys
+- **`"wasm"`** (the default for logic plugins) — a single
+  architecture-independent `.wasm` module, executed **in-process** by the
+  till via [wazero](https://wazero.io) (pure Go, no cgo, no separate
+  process). Write it in Go (`GOOS=wasip1 GOARCH=wasm`), Rust, TinyGo, or
+  anything else that targets WASM. The module gets no capabilities by
+  default — the manifest's `permissions` array (e.g. `net:api.stripe.com`,
+  `pos.tender`, `storage`) is what the host grants. This is what payment,
+  integration, and most other logic plugins use.
+- **`"none"`** — asset-only: content bundles, themes, language packs. No
+  code runs at all; the till renders/serves the files directly.
+- **`"go"`** — a separately supervised OS process. Reserved for hardware/
+  device plugins that need raw USB/serial access; the minority case.
 
-**2. Cloud-Enhanced Mode (Optional)**
-```
-POS Device → Universal Till Cloud → Plugin (cloud) → External API
-```
-- Best for: Advanced features, multiple devices
-- Pros: Centralized config, advanced features, analytics
-- Cons: Requires internet, cloud subscription
-
-**Your plugin can support both!**
+All three talk to the rest of the system the same way once loaded: through
+event hooks declared in the manifest (see below), not a direct function-call
+API.
 
 ---
 
@@ -81,49 +90,53 @@ my-plugin/
 
 ### Manifest File (manifest.json)
 
+This is the real, current schema — trimmed from the shipping
+`ut-plugin-payment-stripe` manifest:
+
 ```json
 {
   "id": "com.example.stripe",
-  "name": "Stripe Payments",
-  "version": "1.0.0",
-  "description": "Accept credit card payments via Stripe Terminal",
-  "author": {
-    "name": "Your Name",
-    "email": "you@example.com",
-    "url": "https://example.com"
-  },
-  "license": "MIT",
-  "category": "payment",
-  "tags": ["payment", "credit-card", "stripe"],
-  "repository": "https://github.com/yourusername/ut-stripe",
-  
-  "modes": {
-    "local": {
-      "supported": true,
-      "requires": ["stripe_api_key", "stripe_secret_key"],
-      "permissions": ["network", "storage"],
-      "features": ["process_payment", "refund", "void"]
-    },
-    "cloud": {
-      "supported": true,
-      "requires": ["ut_cloud_token"],
-      "permissions": ["network", "storage", "analytics"],
-      "features": ["process_payment", "refund", "void", "fraud_detection", "reconciliation"]
+  "name": "Stripe Card Payments",
+  "version": "1.2.0",
+  "description": "Take card payments through Stripe...",
+  "author": "Your Name",
+  "website": "https://example.com",
+  "canonical_type": "payment",
+  "runtime": "wasm",
+  "device_arch": "any",
+  "min_pos_version": "1.0.0",
+  "permissions": [
+    "pos.tender",
+    "events:receive",
+    "net:api.stripe.com",
+    "storage"
+  ],
+  "locales": ["en-US"],
+  "entries": [
+    {
+      "type": "payment",
+      "key": "stripe",
+      "label": "Card (Stripe)",
+      "sort_order": 4,
+      "trigger_event": "payment.stripe.requested"
     }
-  },
-  
-  "compatibility": {
-    "min_version": "1.0.0",
-    "platforms": ["linux", "windows", "darwin", "android"]
-  },
-  
-  "pricing": {
-    "model": "free",  // or "one_time", "subscription"
-    "price": 0,
-    "currency": "USD"
-  }
+  ],
+  "settings": [
+    { "key": "stripe_secret_key", "default_value": "", "scope": "global" }
+  ],
+  "entrypoint": "./bin/plugin.wasm",
+  "hooks": [
+    { "event": "payment.stripe.requested", "action": "stripe.settled" }
+  ]
 }
 ```
+
+`canonical_type` is one of the 20 fixed types in the plugin taxonomy
+(ADR-0002) — payment, page, theme, integration, etc. `entries` control
+where the plugin shows up in the UI; `hooks` wire manifest-declared events
+to the plugin's exported functions (for `runtime: "wasm"`) — there is no
+`modes.local`/`modes.cloud` split and no separate `pricing` block in the
+manifest itself.
 
 ---
 


### PR DESCRIPTION
## Summary
- README roadmap still said "Q1/Q2-Q3 2025" — rewrote against what's actually shipped (WASM plugin runtime, marketplace, Stripe/QR Pay/demo payments, de/es language plugins, themes, AI assistant, webhook connector, FAQ plugin, No Sale plugin).
- README's i18n section claimed English-only; core actually ships en/ar/fa/tr, with de/es as language plugins.
- README's "Plugin Development" section had a `plugin.Serve()`/`plugin-sdk` code sample describing a separate-process model that contradicts ADR-0001 (in-process WASM via wazero). Replaced with an accurate description.
- `docs/plugin_guidelines.md` (linked from the README) had the same stale architecture throughout. Added a banner pointing readers at real example plugins for anything that works today, and corrected the Plugin Architecture / manifest.json sections to the real, current schema (grounded in the actual `ut-plugin-payment-stripe` manifest).

## Test plan
- [x] Docs-only change, no code paths affected
- [x] Independent subagent review of the README diff against ADRs and sibling plugin repos; findings (missing No Sale plugin, plugin_guidelines.md contradiction) applied

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>