### PR TITLE
Dev-mode marketplace override: validation, health-check, fallback, isolated TLS

### DIFF
--- a/docs/code-reviews/2026-07-24-dev-mode-override-safety.md
+++ b/docs/code-reviews/2026-07-24-dev-mode-override-safety.md
@@ -1,0 +1,96 @@
+# 2026-07-24 — Dev-mode marketplace override: validation, health-check, fallback, isolated TLS
+
+## Context
+Spec-audit gap (`ut-docs/QUEUE.md`, FR-015): `DevOverrideURL` routed all
+marketplace traffic there unconditionally whenever set — never checked
+`cfg.DevMode`, never validated the URL, never health-checked reachability,
+no fallback-to-cloud-on-timeout, no self-signed-cert handling. The opposite
+of the spec'd safety net for a dev-only escape hatch.
+
+## Design
+Found that the config surface for this was already fully built —
+`cfg.DevMode`, `cfg.Marketplace.HealthCheckTimeoutSec`,
+`cfg.Marketplace.FallbackTimeoutSec` all existed, wired to env vars with
+"(FR-015)" comments — but completely unused anywhere in `internal/plugins/`.
+Added `DevMode bool` to `MarketplaceConfig` itself (mirroring `Config
+.DevMode`; the marketplace `Client` only holds `*MarketplaceConfig`) and
+wired the rest into real behavior for the first time:
+
+- **Startup validation + health check** (`NewClient`): the override is only
+  ever used if `DevMode` is true, the URL parses as a real `http`/`https`
+  URL with a host, and it passes one bounded `GET /healthz` — the same
+  health endpoint the real marketplace exposes, unauthenticated. Any
+  failure logs a warning and the client uses the cloud endpoint for its
+  entire lifetime; no per-request re-checking.
+- **Fallback-on-failure** (`doWithFallback`): when active, a request tries
+  the dev override first (bounded by `FallbackTimeoutSec`, so a hung dev
+  server can't stall a real request), and on any transport-level error
+  (connection refused, timeout — NOT a non-2xx HTTP response, which
+  propagates as-is) retries against the real cloud endpoint. `doRequest`
+  (used by `IssueDownloadToken`/`AckDownload`/`ReportPluginStatus`) and
+  `ListPlugins` (the live catalog-browsing path) both use it; `GetRevocations`
+  (confirmed dead code, zero callers) got the cheap endpoint-selection fix
+  for consistency but not the full fallback wrapping.
+- Along the way: `ListPlugins` had a pre-existing bug (always sent
+  `Authorization: Bearer <empty>` when no token was configured, instead of
+  omitting the header like every other method does) — fixed.
+
+## Independent review — caught two real problems in the first pass
+Opus-model review, explicitly adversarial given the TLS-verification
+surface. Both findings were empirically confirmed with throwaway tests
+before I fixed them, not just argued.
+
+**Fixed (both were real, both from one root cause — a single shared
+`http.Transport`):**
+- **MEDIUM — configuring an unhealthy/unused dev override silently
+  disabled TLS verification for the real cloud endpoint.** The first
+  version set `InsecureSkipVerify` on ONE shared transport whenever
+  `DevMode && DevOverrideURL != "" && isValidHTTPURL(...) &&` it was
+  `https://` — decided BEFORE the health check, and that transport backed
+  every request the client made, dev override or cloud. Confirmed: `DevMode
+  =true` + an unreachable `https://` override (health check fails,
+  `devOverrideActive=false`, 100% of traffic goes to cloud) still ran every
+  cloud request with TLS verification off. The code's own comment claimed
+  this was "never for the real cloud endpoint" — false because of transport
+  sharing. Fixed by splitting into two fully independent `*http.Client`s
+  (`cloudClient`, `devClient`), each with its own transport; the bypass is
+  only ever set on `devClient`'s transport, which is never used for cloud
+  requests under any code path.
+- **MEDIUM (functional) — a self-signed HTTPS dev override could never
+  actually activate**, which is the primary scenario `DevOverrideURL`
+  exists for (a LAN dev box). The health check built its own bare
+  `&http.Client{Timeout: timeout}` with the default transport — no TLS
+  bypass — so `GET /healthz` against a self-signed cert always failed
+  verification, `devOverrideActive` stayed false forever, and the override
+  was permanently unusable over HTTPS. Fixed by health-checking with the
+  same `devClient` (and its TLS-bypass transport) that real requests will
+  use.
+
+**Confirmed correct (verified independently, not just accepted my claim):**
+- No stale-state risk from `enroll.Effective(cfg)` — it copies the whole
+  `Config` by value and only overwrites identity fields (DeviceID,
+  ClientID, StoreID, PublicKey, MerchantToken); `DevMode`/`DevOverrideURL`/
+  timeouts pass through untouched, and every real call site constructs a
+  fresh `Client` per operation — no hot-reload/mutation hazard.
+- The buffered-body retry in `doRequest` (`io.ReadAll` once, fresh
+  `bytes.NewReader` per attempt) doesn't change behavior for any real
+  caller — all three already pass small, already-in-memory
+  `bytes.NewReader(marshaledJSON)`, never a streaming reader.
+- `ListPlugins`'s empty-Bearer-header fix is correct and matches the
+  existing "auth is optional" contract elsewhere in this file.
+- `/healthz` on the real marketplace (`ut-cloud`) genuinely requires no
+  auth (`AllowUnauthenticatedPaths`) and returns 200/503 correctly —
+  verified by reading that repo directly, not assumed.
+- Fallback triggering only on transport errors (not HTTP 5xx from the dev
+  override) is a deliberate, reasonable design choice, not an oversight —
+  now documented explicitly in `doWithFallback`'s comment.
+
+## Verification
+`go build ./...`, `go vet ./...` clean. `go test ./...` (full repo) clean.
+New tests in `dev_override_test.go`: DevMode-off ignores a healthy override,
+invalid URL ignored, unhealthy override ignored, healthy override activates,
+a self-signed HTTPS override activates (regression test for finding 2), the
+cloud client's transport never gets `InsecureSkipVerify` from merely
+configuring an unhealthy dev override (regression test for finding 1), and
+mid-session fallback when an active override dies after passing its startup
+health check.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,7 +41,12 @@ type MarketplaceConfig struct {
 	// Telemetry opt-in flag (FR-013)
 	TelemetryOptIn bool
 
-	// Dev-mode local override (FR-015, only honored when UT_DEV_MODE=true)
+	// DevMode mirrors Config.DevMode, co-located here because the
+	// marketplace Client only holds *MarketplaceConfig, not the full
+	// Config — this is what actually gates DevOverrideURL (FR-015).
+	DevMode bool
+
+	// Dev-mode local override (FR-015, only honored when DevMode is true)
 	DevOverrideURL string
 
 	// Health check timeout for endpoint validation (FR-015)
@@ -102,6 +107,7 @@ func Init() (*Config, error) {
 			ClientSecret:          getenv("UT_MARKETPLACE_CLIENT_SECRET", ""),
 			APIVersion:            getenv("UT_MARKETPLACE_API_VERSION", "1.0.0"),
 			TelemetryOptIn:        telemetryOptIn,
+			DevMode:               devMode,
 			DevOverrideURL:        getenv("UT_MARKETPLACE_DEV_OVERRIDE_URL", ""),
 			HealthCheckTimeoutSec: healthCheckTimeout,
 			FallbackTimeoutSec:    fallbackTimeout,

--- a/internal/plugins/marketplace/client.go
+++ b/internal/plugins/marketplace/client.go
@@ -23,29 +23,165 @@ import (
 type Client struct {
 	cfg         *config.MarketplaceConfig
 	tokenClient oauth.TokenProvider
-	httpClient  *http.Client
+	// cloudClient always talks to cfg.EndpointURL, on its own transport —
+	// its TLS verification is never affected by dev-override configuration
+	// or activity. devClient is nil unless a syntactically valid dev
+	// override URL is configured; it has its own transport (TLS bypass only
+	// when the override itself is https) and is never used for cloud
+	// traffic. Two separate *http.Client/transport pairs, not a shared one
+	// with conditional settings — a previous version shared one transport
+	// and set InsecureSkipVerify on it whenever DevMode+DevOverrideURL were
+	// merely *configured*, which silently disabled TLS verification for
+	// cloud requests too whenever the override existed, even if it failed
+	// its health check and was never actually used.
+	cloudClient *http.Client
+	devClient   *http.Client
+	// devOverrideActive is decided once at construction: DevMode must be on,
+	// DevOverrideURL must parse as a real http(s) URL, and it must pass a
+	// bounded startup health check (GET /healthz). A dev-only escape hatch
+	// must never silently redirect production traffic (FR-015) — any of
+	// those failing means every request uses the real cloud endpoint for
+	// this Client's lifetime.
+	devOverrideActive bool
 }
 
 // NewClient creates a marketplace client with OAuth2 authentication.
 func NewClient(cfg *config.MarketplaceConfig, tokenClient oauth.TokenProvider) *Client {
-	// Create HTTP client with custom transport for local development
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-
-	// Skip TLS verification for localhost/127.0.0.1 (development only)
-	if strings.HasPrefix(cfg.EndpointURL, "https://localhost") ||
-		strings.HasPrefix(cfg.EndpointURL, "https://127.0.0.1") {
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	cloudTransport := http.DefaultTransport.(*http.Transport).Clone()
+	// Skip TLS verification for localhost/127.0.0.1 (development only) —
+	// this is about EndpointURL itself pointing at a local dev marketplace,
+	// unrelated to DevOverrideURL.
+	if isLocalHTTPS(cfg.EndpointURL) {
+		cloudTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 		log.Printf("[WARN] Skipping TLS verification for development endpoint: %s", cfg.EndpointURL)
+	}
+	cloudClient := &http.Client{
+		Timeout:   time.Duration(cfg.RequestTimeoutSec) * time.Second,
+		Transport: cloudTransport,
+	}
+
+	var devClient *http.Client
+	devOverrideActive := false
+	if cfg.DevMode && cfg.DevOverrideURL != "" {
+		switch {
+		case !isValidHTTPURL(cfg.DevOverrideURL):
+			log.Printf("[WARN] marketplace dev override URL is invalid, ignoring: %q", cfg.DevOverrideURL)
+		default:
+			devTransport := http.DefaultTransport.(*http.Transport).Clone()
+			if strings.HasPrefix(cfg.DevOverrideURL, "https://") {
+				// A dev override is very likely a LAN box with a self-signed
+				// cert; this transport is dedicated to the override, never
+				// shared with cloudClient, so bypassing verification here
+				// can never affect a real cloud request.
+				devTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+				log.Printf("[WARN] Skipping TLS verification for dev override endpoint: %s", cfg.DevOverrideURL)
+			}
+			devClient = &http.Client{
+				Timeout:   time.Duration(cfg.RequestTimeoutSec) * time.Second,
+				Transport: devTransport,
+			}
+
+			devOverrideActive = devOverrideHealthy(devClient, cfg.DevOverrideURL, healthCheckTimeout(cfg))
+			if devOverrideActive {
+				log.Printf("[INFO] marketplace dev override active: %s", cfg.DevOverrideURL)
+			} else {
+				log.Printf("[WARN] marketplace dev override %s failed its health check, using %s instead", cfg.DevOverrideURL, cfg.EndpointURL)
+			}
+		}
 	}
 
 	return &Client{
-		cfg:         cfg,
-		tokenClient: tokenClient,
-		httpClient: &http.Client{
-			Timeout:   time.Duration(cfg.RequestTimeoutSec) * time.Second,
-			Transport: transport,
-		},
+		cfg:               cfg,
+		tokenClient:       tokenClient,
+		cloudClient:       cloudClient,
+		devClient:         devClient,
+		devOverrideActive: devOverrideActive,
 	}
+}
+
+func isLocalHTTPS(rawURL string) bool {
+	return strings.HasPrefix(rawURL, "https://localhost") || strings.HasPrefix(rawURL, "https://127.0.0.1")
+}
+
+func isValidHTTPURL(rawURL string) bool {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	return (parsed.Scheme == "http" || parsed.Scheme == "https") && parsed.Host != ""
+}
+
+func healthCheckTimeout(cfg *config.MarketplaceConfig) time.Duration {
+	if cfg.HealthCheckTimeoutSec <= 0 {
+		return 5 * time.Second
+	}
+	return time.Duration(cfg.HealthCheckTimeoutSec) * time.Second
+}
+
+// devOverrideHealthy does one bounded GET /healthz against the override —
+// the same health endpoint the real marketplace exposes. Uses the
+// caller-supplied client so a self-signed-cert override is checked with
+// the same TLS bypass its real requests will use; a bare default-transport
+// client here would make an https override with a self-signed cert fail
+// the health check even when it's genuinely reachable.
+func devOverrideHealthy(client *http.Client, baseURL string, timeout time.Duration) bool {
+	healthURL, err := url.JoinPath(baseURL, "/healthz")
+	if err != nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+// endpoint returns the marketplace base URL to prefer for the next request.
+func (c *Client) endpoint() string {
+	if c.devOverrideActive {
+		return c.cfg.DevOverrideURL
+	}
+	return c.cfg.EndpointURL
+}
+
+// fallbackTimeout bounds how long a dev-override attempt gets before
+// doWithFallback retries against the real cloud endpoint.
+func (c *Client) fallbackTimeout() time.Duration {
+	if c.cfg.FallbackTimeoutSec <= 0 {
+		return 10 * time.Second
+	}
+	return time.Duration(c.cfg.FallbackTimeoutSec) * time.Second
+}
+
+// doWithFallback tries send against the dev override first (bounded by
+// fallbackTimeout, so a hung/dead dev server can't stall a real request,
+// and on devClient — never cloudClient) when it's active, then always
+// falls back to the real cloud endpoint (on cloudClient) on any transport
+// error. A non-2xx HTTP response from the override is NOT treated as a
+// fallback trigger here — send only returns a Go error for transport-level
+// failures (connection refused, timeout); an override that responds with a
+// real error status propagates that response to the caller as-is. When the
+// override isn't active, it just calls the cloud endpoint once.
+func (c *Client) doWithFallback(ctx context.Context, send func(ctx context.Context, endpoint string, client *http.Client) (*http.Response, error)) (*http.Response, error) {
+	if !c.devOverrideActive {
+		return send(ctx, c.cfg.EndpointURL, c.cloudClient)
+	}
+
+	devCtx, cancel := context.WithTimeout(ctx, c.fallbackTimeout())
+	defer cancel()
+	resp, err := send(devCtx, c.cfg.DevOverrideURL, c.devClient)
+	if err == nil {
+		return resp, nil
+	}
+	log.Printf("[WARN] marketplace dev override request failed (%v), falling back to %s", err, c.cfg.EndpointURL)
+	return send(ctx, c.cfg.EndpointURL, c.cloudClient)
 }
 
 // doRequest performs an authenticated HTTP request with API version metadata.
@@ -58,51 +194,58 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body io.Rea
 		token = ""
 	}
 
-	endpoint := c.cfg.EndpointURL
-	if c.cfg.DevOverrideURL != "" {
-		endpoint = c.cfg.DevOverrideURL
+	// Buffered once so a dev-override retry against the cloud endpoint can
+	// send the same body again — an io.Reader can only be consumed once.
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read request body: %w", err)
+		}
 	}
 
-	reqURL, err := url.JoinPath(endpoint, path)
-	if err != nil {
-		return nil, fmt.Errorf("invalid request URL: %w", err)
-	}
+	return c.doWithFallback(ctx, func(ctx context.Context, endpoint string, client *http.Client) (*http.Response, error) {
+		reqURL, err := url.JoinPath(endpoint, path)
+		if err != nil {
+			return nil, fmt.Errorf("invalid request URL: %w", err)
+		}
 
-	// DEBUG: Log the request URL
-	log.Printf("[DEBUG] Marketplace request: %s %s", method, reqURL)
+		var reqBody io.Reader
+		if bodyBytes != nil {
+			reqBody = bytes.NewReader(bodyBytes)
+		}
 
-	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
+		log.Printf("[DEBUG] Marketplace request: %s %s", method, reqURL)
 
-	// Add OAuth2 bearer token when present
-	if token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-	// Add API version metadata per FR-016
-	req.Header.Set("x-marketplace-api-version", c.cfg.APIVersion)
-	req.Header.Set("Content-Type", "application/json")
+		req, err := http.NewRequestWithContext(ctx, method, reqURL, reqBody)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
+		// Add OAuth2 bearer token when present
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		// Add API version metadata per FR-016
+		req.Header.Set("x-marketplace-api-version", c.cfg.APIVersion)
+		req.Header.Set("Content-Type", "application/json")
 
-	// DEBUG: Log the response status
-	log.Printf("[DEBUG] Marketplace response: %d for %s %s", resp.StatusCode, method, reqURL)
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("request failed: %w", err)
+		}
 
-	return resp, nil
+		log.Printf("[DEBUG] Marketplace response: %d for %s %s", resp.StatusCode, method, reqURL)
+		return resp, nil
+	})
 }
 
 // ResolveURL turns a possibly-relative marketplace URL (e.g. the bundle_url
 // "/api/v1/downloads/artifact/...") into an absolute URL against the configured
 // endpoint origin. Absolute inputs are returned unchanged.
 func (c *Client) ResolveURL(ref string) (string, error) {
-	endpoint := c.cfg.EndpointURL
-	if c.cfg.DevOverrideURL != "" {
-		endpoint = c.cfg.DevOverrideURL
-	}
+	endpoint := c.endpoint()
 	base, err := url.Parse(endpoint)
 	if err != nil {
 		return "", fmt.Errorf("invalid marketplace endpoint %q: %w", endpoint, err)
@@ -288,25 +431,6 @@ func (c *Client) ListPlugins(ctx context.Context, req *ListPluginsRequest) (*Lis
 		params.Set("page_token", req.PageToken)
 	}
 
-	// Build URL properly with query parameters
-	endpoint := c.cfg.EndpointURL
-	if c.cfg.DevOverrideURL != "" {
-		endpoint = c.cfg.DevOverrideURL
-	}
-
-	reqURL, err := url.JoinPath(endpoint, "/v1/catalog/plugins")
-	if err != nil {
-		return nil, fmt.Errorf("invalid request URL: %w", err)
-	}
-
-	// Parse URL and add query params
-	parsedURL, err := url.Parse(reqURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse URL: %w", err)
-	}
-	parsedURL.RawQuery = params.Encode()
-
-	// Get token
 	// Auth is optional: when marketplace OAuth2 credentials are not configured
 	// (or the marketplace has auth disabled), proceed unauthenticated.
 	token, tokenErr := c.tokenClient.GetToken(ctx)
@@ -315,25 +439,38 @@ func (c *Client) ListPlugins(ctx context.Context, req *ListPluginsRequest) (*Lis
 		token = ""
 	}
 
-	// Create request
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), nil)
+	resp, err := c.doWithFallback(ctx, func(ctx context.Context, endpoint string, client *http.Client) (*http.Response, error) {
+		reqURL, err := url.JoinPath(endpoint, "/v1/catalog/plugins")
+		if err != nil {
+			return nil, fmt.Errorf("invalid request URL: %w", err)
+		}
+		parsedURL, err := url.Parse(reqURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse URL: %w", err)
+		}
+		parsedURL.RawQuery = params.Encode()
+
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		if token != "" {
+			httpReq.Header.Set("Authorization", "Bearer "+token)
+		}
+		httpReq.Header.Set("x-marketplace-api-version", c.cfg.APIVersion)
+
+		log.Printf("[DEBUG] Marketplace request: GET %s", parsedURL.String())
+		resp, err := client.Do(httpReq)
+		if err != nil {
+			return nil, fmt.Errorf("request failed: %w", err)
+		}
+		log.Printf("[DEBUG] Marketplace response: %d", resp.StatusCode)
+		return resp, nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	httpReq.Header.Set("Authorization", "Bearer "+token)
-	httpReq.Header.Set("x-marketplace-api-version", c.cfg.APIVersion)
-
-	// DEBUG
-	log.Printf("[DEBUG] Marketplace request: GET %s", parsedURL.String())
-
-	resp, err := c.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, err
 	}
 	defer resp.Body.Close()
-
-	log.Printf("[DEBUG] Marketplace response: %d", resp.StatusCode)
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("catalog request failed: status %d", resp.StatusCode)
@@ -460,12 +597,7 @@ type GetRevocationsResponse struct {
 
 // GetRevocations fetches plugin revocations since a given version.
 func (c *Client) GetRevocations(ctx context.Context, req *GetRevocationsRequest) (*GetRevocationsResponse, error) {
-	endpoint := c.cfg.EndpointURL
-	if c.cfg.DevOverrideURL != "" {
-		endpoint = c.cfg.DevOverrideURL
-	}
-
-	reqURL, err := url.JoinPath(endpoint, "/v1/revocations")
+	reqURL, err := url.JoinPath(c.endpoint(), "/v1/revocations")
 	if err != nil {
 		return nil, fmt.Errorf("invalid request URL: %w", err)
 	}
@@ -492,10 +624,15 @@ func (c *Client) GetRevocations(ctx context.Context, req *GetRevocationsRequest)
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	httpReq.Header.Set("Authorization", "Bearer "+token)
+	if token != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+token)
+	}
 	httpReq.Header.Set("x-marketplace-api-version", c.cfg.APIVersion)
 
-	resp, err := c.httpClient.Do(httpReq)
+	// Dead code today (zero callers — revocation checking uses a separate
+	// implementation), so this intentionally isn't wired through
+	// doWithFallback; cloudClient is the safe default if that ever changes.
+	resp, err := c.cloudClient.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}

--- a/internal/plugins/marketplace/dev_override_test.go
+++ b/internal/plugins/marketplace/dev_override_test.go
@@ -1,0 +1,233 @@
+package marketplace
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/config"
+)
+
+func newHealthyServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/healthz" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestNewClient_DevOverrideIgnoredWhenDevModeOff(t *testing.T) {
+	cloud := newHealthyServer(t)
+	dev := newHealthyServer(t) // healthy, but DevMode is off — must not matter
+
+	cfg := &config.MarketplaceConfig{
+		EndpointURL:       cloud.URL,
+		DevMode:           false,
+		DevOverrideURL:    dev.URL,
+		APIVersion:        "1.0.0",
+		RequestTimeoutSec: 5,
+	}
+	client := NewClient(cfg, &mockTokenClient{token: "t"})
+
+	if client.devOverrideActive {
+		t.Fatal("expected the dev override to be inactive when DevMode is off, regardless of health")
+	}
+	if got := client.endpoint(); got != cloud.URL {
+		t.Fatalf("expected the cloud endpoint, got %q", got)
+	}
+}
+
+func TestNewClient_DevOverrideIgnoredWhenURLInvalid(t *testing.T) {
+	cloud := newHealthyServer(t)
+
+	cfg := &config.MarketplaceConfig{
+		EndpointURL:           cloud.URL,
+		DevMode:               true,
+		DevOverrideURL:        "not a url", // no scheme/host
+		APIVersion:            "1.0.0",
+		RequestTimeoutSec:     5,
+		HealthCheckTimeoutSec: 1,
+	}
+	client := NewClient(cfg, &mockTokenClient{token: "t"})
+
+	if client.devOverrideActive {
+		t.Fatal("expected an invalid dev override URL to be ignored")
+	}
+	if got := client.endpoint(); got != cloud.URL {
+		t.Fatalf("expected the cloud endpoint as fallback, got %q", got)
+	}
+}
+
+func TestNewClient_DevOverrideIgnoredWhenUnhealthy(t *testing.T) {
+	cloud := newHealthyServer(t)
+	unhealthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable) // /healthz fails
+	}))
+	defer unhealthy.Close()
+
+	cfg := &config.MarketplaceConfig{
+		EndpointURL:           cloud.URL,
+		DevMode:               true,
+		DevOverrideURL:        unhealthy.URL,
+		APIVersion:            "1.0.0",
+		RequestTimeoutSec:     5,
+		HealthCheckTimeoutSec: 1,
+	}
+	client := NewClient(cfg, &mockTokenClient{token: "t"})
+
+	if client.devOverrideActive {
+		t.Fatal("expected an unhealthy dev override to be ignored")
+	}
+	if got := client.endpoint(); got != cloud.URL {
+		t.Fatalf("expected the cloud endpoint as fallback, got %q", got)
+	}
+}
+
+func TestNewClient_DevOverrideActiveWhenHealthy(t *testing.T) {
+	cloud := newHealthyServer(t)
+	dev := newHealthyServer(t)
+
+	cfg := &config.MarketplaceConfig{
+		EndpointURL:           cloud.URL,
+		DevMode:               true,
+		DevOverrideURL:        dev.URL,
+		APIVersion:            "1.0.0",
+		RequestTimeoutSec:     5,
+		HealthCheckTimeoutSec: 1,
+	}
+	client := NewClient(cfg, &mockTokenClient{token: "t"})
+
+	if !client.devOverrideActive {
+		t.Fatal("expected a healthy, valid dev override under DevMode to be active")
+	}
+	if got := client.endpoint(); got != dev.URL {
+		t.Fatalf("expected the dev override endpoint, got %q", got)
+	}
+}
+
+// newHealthyTLSServer is like newHealthyServer but self-signed HTTPS —
+// exactly the "LAN box with a self-signed cert" scenario the dev-override
+// feature exists for.
+func newHealthyTLSServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestNewClient_SelfSignedHTTPSOverrideActivates guards the bug an earlier
+// version of this code had: a self-signed-cert https:// dev override could
+// never pass its own health check, because the health-check HTTP client
+// didn't share the override's TLS-bypass transport.
+func TestNewClient_SelfSignedHTTPSOverrideActivates(t *testing.T) {
+	cloud := newHealthyServer(t)
+	dev := newHealthyTLSServer(t)
+
+	cfg := &config.MarketplaceConfig{
+		EndpointURL:           cloud.URL,
+		DevMode:               true,
+		DevOverrideURL:        dev.URL,
+		APIVersion:            "1.0.0",
+		RequestTimeoutSec:     5,
+		HealthCheckTimeoutSec: 2,
+	}
+	client := NewClient(cfg, &mockTokenClient{token: "t"})
+
+	if !client.devOverrideActive {
+		t.Fatal("expected a self-signed HTTPS dev override to pass its health check and activate")
+	}
+	if got := client.endpoint(); got != dev.URL {
+		t.Fatalf("expected the dev override endpoint, got %q", got)
+	}
+}
+
+// TestNewClient_CloudTLSNeverBypassedByDevOverrideConfig guards the more
+// serious bug: an earlier version shared ONE transport between cloud and
+// dev-override traffic, so merely *configuring* an https:// dev override
+// (DevMode on) set InsecureSkipVerify on the transport that ALSO served
+// real cloud requests — even when the override failed its health check and
+// was never actually used. A stray/misconfigured DevOverrideURL in a
+// staging or production-like environment must never weaken TLS verification
+// for the real cloud endpoint.
+func TestNewClient_CloudTLSNeverBypassedByDevOverrideConfig(t *testing.T) {
+	cloud := newHealthyServer(t) // plain HTTP; verification isn't exercised
+	// An https override that will fail its health check (nothing is
+	// listening there), so devOverrideActive ends up false — the exact
+	// case where the old code still leaked InsecureSkipVerify onto the
+	// shared transport.
+	cfg := &config.MarketplaceConfig{
+		EndpointURL:           cloud.URL,
+		DevMode:               true,
+		DevOverrideURL:        "https://127.0.0.1:1", // valid URL shape, nothing listening
+		APIVersion:            "1.0.0",
+		RequestTimeoutSec:     5,
+		HealthCheckTimeoutSec: 1,
+	}
+	client := NewClient(cfg, &mockTokenClient{token: "t"})
+
+	if client.devOverrideActive {
+		t.Fatal("expected the unreachable dev override to fail its health check")
+	}
+
+	transport, ok := client.cloudClient.Transport.(*http.Transport)
+	if !ok || transport.TLSClientConfig == nil {
+		return // no custom TLS config at all means verification is on (default)
+	}
+	if transport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("cloudClient must never have InsecureSkipVerify set just because a dev override was configured")
+	}
+}
+
+func TestDoRequest_FallsBackToCloudWhenDevOverrideDiesMidSession(t *testing.T) {
+	var cloudHit bool
+	cloud := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cloudHit = true
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer cloud.Close()
+
+	// Healthy at construction time, so devOverrideActive is true — this is
+	// what makes the test exercise doWithFallback's mid-request retry, not
+	// just NewClient's startup health check (that's covered separately by
+	// TestNewClient_DevOverrideIgnoredWhenUnhealthy).
+	dev := newHealthyServer(t)
+
+	cfg := &config.MarketplaceConfig{
+		EndpointURL:           cloud.URL,
+		DevMode:               true,
+		DevOverrideURL:        dev.URL,
+		APIVersion:            "1.0.0",
+		RequestTimeoutSec:     5,
+		HealthCheckTimeoutSec: 1,
+		FallbackTimeoutSec:    1,
+	}
+	client := NewClient(cfg, &mockTokenClient{token: "t"})
+	if !client.devOverrideActive {
+		t.Fatal("expected the dev override to be active after passing its startup health check")
+	}
+
+	// Now kill the dev server — simulates it going down mid-session, after
+	// the client already decided to trust it.
+	dev.Close()
+
+	resp, err := client.doRequest(context.Background(), http.MethodGet, "/v1/whatever", nil)
+	if err != nil {
+		t.Fatalf("doRequest: %v", err)
+	}
+	defer resp.Body.Close()
+	if !cloudHit {
+		t.Fatal("expected the request to fall back to and reach the cloud endpoint")
+	}
+}


### PR DESCRIPTION
## Summary
- `DevOverrideURL` routed all marketplace traffic there unconditionally whenever set — no `DevMode` gate, no URL validation, no health check, no fallback-to-cloud on failure.
- The config surface for the fix already existed (`DevMode`, `HealthCheckTimeoutSec`, `FallbackTimeoutSec`, all commented "FR-015") but was completely unused. Wired it in for real: startup `GET /healthz` check, per-request fallback to cloud on transport failure.
- Independent (opus-model, adversarial) review caught a real security issue in the first pass: a shared HTTP transport meant merely *configuring* an unreachable/unhealthy dev override still disabled TLS verification for the real cloud endpoint. Fixed by fully separating cloud vs. dev-override HTTP clients/transports — verified with a regression test that inspects `cloudClient`'s transport directly.
- Same review also caught that a self-signed-cert HTTPS override (the primary use case) could never pass its own health check, since the health-check client didn't share the TLS bypass. Fixed and regression-tested.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` (full repo) — all clean
- [x] New tests: DevMode-off ignores override, invalid URL ignored, unhealthy override ignored, healthy override activates, self-signed HTTPS override activates, cloud TLS never bypassed by dev-override config, mid-session fallback when an active override dies
- [x] Review: `docs/code-reviews/2026-07-24-dev-mode-override-safety.md`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>