### PR TITLE
Require a manager session for all plugin management operations

### DIFF
--- a/docs/code-reviews/2026-07-24-plugin-manager-gating.md
+++ b/docs/code-reviews/2026-07-24-plugin-manager-gating.md
@@ -1,0 +1,83 @@
+# 2026-07-24 — Plugin management now requires a manager session
+
+## Context
+Spec-audit gap (`ut-docs/QUEUE.md`): "no marketplace audit trail/filter UI,
+no permission or telemetry-opt-in badges" — the entry included a claim that
+"Manager-PIN install gating itself does work
+(`authorizer.go` `requireManagerPIN`)". Investigation found that claim was
+**false**: `internal/plugins/authorizer.go`'s entire `Authorizer` type
+(`CheckPermission`, `AuditLog`, `requireManagerPIN`) has zero callers
+anywhere in the codebase — it was never instantiated, never wired into any
+handler. `internal/pages/plugin_api.go`'s install/uninstall/enable/disable/
+update/rollback/permission-grant/permission-revoke/trust-level/upload/
+import handlers had no role check of any kind: any authenticated user,
+including the lowest-privilege cashier role, could manage plugins.
+
+## Design
+Applied the codebase's existing, already-proven gate —
+`isManagerOrAuthOff(r)` (`settings_page.go`, same `pages` package; already
+used for printer settings, idle-lock, and today's telemetry opt-in toggle)
+— to every mutating plugin-management handler, as the first check (after
+any pre-existing HTTP-method check), before any side effect. Left
+deliberately ungated: `/api/plugins/marketplace` (catalog browsing) and
+`handleCheckUpdates` — both read-only, no DB write, no download, no install.
+
+`handleInstallFromMarketplace` returns its rejection through the handler's
+own JSON envelope (`writeInstallResponse`, new `message_key:
+"plugins.install.error.forbidden"`) to match its existing response
+contract, rather than a bare `http.Error`; new i18n key added to all 4 core
+locales and wired into `plugin_install_modal.html`'s client-side message
+mapping.
+
+## Independent review — caught a critical gap before merge
+Opus-model review, explicitly instructed to search more broadly than the
+one file this change touched.
+
+**Fixed (HIGH — the fix was incomplete without this):**
+- A **second, fully-live, parallel plugin install path** was missed
+  entirely: `internal/pages/plugins_store_page.go`'s `registerPluginStoreAPI`
+  (`POST /api/plugins/store/download`, `/install`, `/delete-download`) is
+  registered on the same mux via `registerPluginStore`
+  (`internal/pages/init.go`) but is a completely separate route
+  registration from `registerPluginAPI` — the file this change originally
+  touched. This is the actual install button on `/plugins/store`
+  (`PluginStoreHandler`), so a cashier could still install/download/delete
+  plugins through the store page despite every route in `plugin_api.go`
+  being gated. Fixed: same `isManagerOrAuthOff` gate added to all three
+  handlers, first statement, before any side effect. New test
+  (`TestPluginStoreEndpoints_RejectWithoutManagerAuth`) covers all three;
+  the read-only store *page* render itself stays ungated, consistent with
+  catalog browsing elsewhere.
+
+**Confirmed correct (verified independently, not just accepted my
+claim):**
+- Full route coverage within `plugin_api.go` re-derived independently from
+  `registerPluginAPI` — all 12 mutating routes gated; `/api/plugins/{id}
+  /settings` (a different file, already gated pre-existing) and
+  `/api/plugins/entries/{plugin}/{key}/action` (a plugin runtime event, not
+  lifecycle management) correctly out of scope.
+- `isManagerOrAuthOff` fails closed: traced `auth.Disabled` (exact-match
+  `"off"` only), `auth.FromContext` (returns `ok=false` with no session),
+  and `IsManager()` (`Role == "manager" || "admin"`) — no edge case
+  (nil user, empty role, malformed session) slips through as manager.
+- `handleInstallFromMarketplace`'s `writeInstallResponse` genuinely returns
+  403 (not 200), and the new i18n key is wired end-to-end — all 4 locales
+  carry an identical key set, `guard-i18n.sh` passes.
+- The gate test exercises real route registration via `mux.ServeHTTP` with
+  `UT_AUTH` left unset (not `"off"`), so a missing gate would surface as
+  200/500, not silently pass; a typo'd path would 404, which also fails the
+  assertion — the test can't pass by accident.
+- The three pre-existing tests updated to add `t.Setenv("UT_AUTH", "off")`
+  still exercise their own original logic (version-required,
+  traversal-rejection, operator-visible-status) — the gate bypass doesn't
+  mask anything unrelated.
+- Every gate is the first statement, before `ParseForm`, any download, DB
+  write, or status-store save — no side effect precedes a gate anywhere.
+
+## Verification
+`go build ./...`, `go vet ./...`, `bash scripts/ci/guard-i18n.sh` (688
+template keys, all locales match), `go test ./...` (full repo) — all
+green. New tests: `TestPluginManagementEndpoints_RejectWithoutManagerAuth`
+(13 routes in `plugin_api.go`), `TestPluginStoreEndpoints_RejectWithoutManagerAuth`
+(3 routes in `plugins_store_page.go`, added after independent review caught
+the gap), `TestPluginCatalogBrowsing_DoesNotRequireManagerAuth`.

--- a/internal/pages/plugin_api.go
+++ b/internal/pages/plugin_api.go
@@ -27,6 +27,10 @@ func registerPluginAPI(mux *http.ServeMux, d *common.Deps) {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
+		if !isManagerOrAuthOff(r) {
+			http.Error(w, "manager or admin required", http.StatusForbidden)
+			return
+		}
 
 		if err := r.ParseForm(); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -236,6 +240,10 @@ func registerPluginAPI(mux *http.ServeMux, d *common.Deps) {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
+		if !isManagerOrAuthOff(r) {
+			http.Error(w, "manager or admin required", http.StatusForbidden)
+			return
+		}
 
 		if err := r.ParseForm(); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -346,6 +354,10 @@ func registerPluginAPI(mux *http.ServeMux, d *common.Deps) {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
+		if !isManagerOrAuthOff(r) {
+			http.Error(w, "manager or admin required", http.StatusForbidden)
+			return
+		}
 
 		if err := r.ParseForm(); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -372,6 +384,10 @@ func registerPluginAPI(mux *http.ServeMux, d *common.Deps) {
 	mux.HandleFunc("/api/plugins/permissions/revoke", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if !isManagerOrAuthOff(r) {
+			http.Error(w, "manager or admin required", http.StatusForbidden)
 			return
 		}
 
@@ -401,6 +417,10 @@ func registerPluginAPI(mux *http.ServeMux, d *common.Deps) {
 	mux.HandleFunc("/api/plugins/trust", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if !isManagerOrAuthOff(r) {
+			http.Error(w, "manager or admin required", http.StatusForbidden)
 			return
 		}
 
@@ -441,6 +461,10 @@ func registerPluginAPI(mux *http.ServeMux, d *common.Deps) {
 // handleInstallFromMarketplace handles marketplace plugin installation (T017)
 func handleInstallFromMarketplace(d *common.Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if !isManagerOrAuthOff(r) {
+			writeInstallResponse(w, http.StatusForbidden, false, "manager or admin required", "plugins.install.error.forbidden")
+			return
+		}
 		ctx := r.Context()
 		statusStore := plugins.NewInstallStatusStore(d.Db)
 
@@ -555,6 +579,10 @@ func handleEnablePlugin(d *common.Deps) http.HandlerFunc {
 // manager + nav so the change takes effect immediately.
 func setPluginActiveHandler(d *common.Deps, active bool, verb string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if !isManagerOrAuthOff(r) {
+			http.Error(w, "manager or admin required", http.StatusForbidden)
+			return
+		}
 		ctx := r.Context()
 		pluginID := r.PathValue("id")
 		if pluginID == "" {
@@ -595,6 +623,10 @@ func handleDisablePlugin(d *common.Deps) http.HandlerFunc {
 // installed files, and reloads the plugin manager so the nav/menu drops it.
 func handleUninstallPlugin(d *common.Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if !isManagerOrAuthOff(r) {
+			http.Error(w, "manager or admin required", http.StatusForbidden)
+			return
+		}
 		ctx := r.Context()
 		pluginID := r.PathValue("id")
 		if pluginID == "" {
@@ -654,6 +686,10 @@ func handleUninstallPlugin(d *common.Deps) http.HandlerFunc {
 // Ed25519 verification path — never an unverified extract.
 func handleUpdatePlugin(d *common.Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if !isManagerOrAuthOff(r) {
+			http.Error(w, "manager or admin required", http.StatusForbidden)
+			return
+		}
 		ctx := r.Context()
 		pluginID := r.PathValue("id")
 
@@ -752,6 +788,10 @@ func handleUpdatePlugin(d *common.Deps) http.HandlerFunc {
 // handleRollbackPlugin handles rolling back a plugin to a previous version (T025)
 func handleRollbackPlugin(d *common.Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if !isManagerOrAuthOff(r) {
+			http.Error(w, "manager or admin required", http.StatusForbidden)
+			return
+		}
 		ctx := r.Context()
 		pluginID := r.PathValue("id")
 
@@ -822,6 +862,10 @@ func handleCheckUpdates(d *common.Deps) http.HandlerFunc {
 // handleImportFromFile handles manual plugin import from uploaded file (T028)
 func handleImportFromFile(d *common.Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if !isManagerOrAuthOff(r) {
+			http.Error(w, "manager or admin required", http.StatusForbidden)
+			return
+		}
 		ctx := r.Context()
 
 		// Parse multipart form (max 200 MB)
@@ -930,6 +974,10 @@ func handleImportFromFile(d *common.Deps) http.HandlerFunc {
 // Version is taken from ?version= since a plugin may have multiple installed.
 func handleExportPlugin(d *common.Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if !isManagerOrAuthOff(r) {
+			http.Error(w, "manager or admin required", http.StatusForbidden)
+			return
+		}
 		ctx := r.Context()
 		pluginID := strings.TrimSpace(r.PathValue("id"))
 		version := strings.TrimSpace(r.URL.Query().Get("version"))

--- a/internal/pages/plugin_api_manager_gate_test.go
+++ b/internal/pages/plugin_api_manager_gate_test.go
@@ -1,0 +1,109 @@
+package pages
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/config"
+	"github.com/universaltill/universal-till/internal/pages/common"
+)
+
+// Every plugin-management endpoint that mutates install state (install,
+// uninstall, enable, disable, update, rollback, permission grant/revoke,
+// trust level, upload, import) must reject a request with no manager
+// session — previously none of them checked this at all. UT_AUTH is
+// deliberately left unset (not "off") so isManagerOrAuthOff's bypass
+// doesn't mask a missing gate.
+func TestPluginManagementEndpoints_RejectWithoutManagerAuth(t *testing.T) {
+	chdirRoot(t)
+	db := openPagesTestDB(t)
+	defer db.Close()
+
+	dp := &common.Deps{Cfg: &config.Config{}, Db: db}
+	mux := http.NewServeMux()
+	registerPluginAPI(mux, dp)
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"upload", http.MethodPost, "/api/plugins/upload"},
+		{"marketplace install", http.MethodPost, "/api/plugins/marketplace/install"},
+		{"permissions grant", http.MethodPost, "/api/plugins/permissions/grant"},
+		{"permissions revoke", http.MethodPost, "/api/plugins/permissions/revoke"},
+		{"trust level", http.MethodPost, "/api/plugins/trust"},
+		{"install from marketplace", http.MethodPost, "/api/plugins/install-from-marketplace"},
+		{"enable", http.MethodPost, "/api/plugins/some-plugin/enable"},
+		{"disable", http.MethodPost, "/api/plugins/some-plugin/disable"},
+		{"uninstall", http.MethodPost, "/api/plugins/some-plugin/uninstall"},
+		{"update", http.MethodPost, "/api/plugins/some-plugin/update"},
+		{"rollback", http.MethodPost, "/api/plugins/some-plugin/rollback"},
+		{"import from file", http.MethodPost, "/api/plugins/import-from-file"},
+		{"export", http.MethodGet, "/api/plugins/some-plugin/export"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("%s %s = %d, want 403 (no manager session, UT_AUTH not off)", tc.method, tc.path, rec.Code)
+			}
+		})
+	}
+}
+
+// The plugin STORE lifecycle API (/api/plugins/store/*) is a separate,
+// parallel route registration (registerPluginStoreAPI) from the main plugin
+// management API above — a live install path that was missed in an earlier
+// pass of this same fix (caught by independent review before merge) and
+// left a cashier able to install/download/delete plugins via the store page
+// despite the rest of this file being gated.
+func TestPluginStoreEndpoints_RejectWithoutManagerAuth(t *testing.T) {
+	chdirRoot(t)
+	db := openPagesTestDB(t)
+	defer db.Close()
+
+	dp := &common.Deps{Cfg: &config.Config{}, Db: db}
+	mux := http.NewServeMux()
+	registerPluginStoreAPI(mux, dp)
+
+	cases := []struct{ name, path string }{
+		{"download", "/api/plugins/store/download"},
+		{"install", "/api/plugins/store/install"},
+		{"delete-download", "/api/plugins/store/delete-download"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tc.path, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("POST %s = %d, want 403 (no manager session, UT_AUTH not off)", tc.path, rec.Code)
+			}
+		})
+	}
+}
+
+// The read-only catalog-browsing and update-check endpoints must NOT be
+// manager-gated — a cashier browsing the marketplace or checking for
+// updates is harmless and shouldn't need a manager PIN.
+func TestPluginCatalogBrowsing_DoesNotRequireManagerAuth(t *testing.T) {
+	chdirRoot(t)
+	db := openPagesTestDB(t)
+	defer db.Close()
+
+	dp := &common.Deps{Cfg: &config.Config{}, Db: db}
+	mux := http.NewServeMux()
+	registerPluginAPI(mux, dp)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/plugins/marketplace", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code == http.StatusForbidden {
+		t.Fatal("marketplace browsing must not require a manager session")
+	}
+}

--- a/internal/pages/plugin_export_test.go
+++ b/internal/pages/plugin_export_test.go
@@ -12,6 +12,7 @@ import (
 // behaviour is covered by internal/plugins exporter tests. Assert the validation
 // branch (which returns before touching the filesystem).
 func TestHandleExportPlugin_RequiresVersion(t *testing.T) {
+	t.Setenv("UT_AUTH", "off") // bypass the manager gate to reach the handler's own validation
 	h := handleExportPlugin(&common.Deps{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/plugins/com.x/export", nil)
@@ -27,6 +28,7 @@ func TestHandleExportPlugin_RequiresVersion(t *testing.T) {
 // The uninstall handler removes files under ./data/plugins keyed by the id, so a
 // traversal id must be rejected before any filesystem work.
 func TestHandleUninstallPlugin_RejectsTraversalID(t *testing.T) {
+	t.Setenv("UT_AUTH", "off") // bypass the manager gate to reach the handler's own validation
 	h := handleUninstallPlugin(&common.Deps{})
 	for _, badID := range []string{"../etc", "a/b", `..\win`} {
 		req := httptest.NewRequest(http.MethodPost, "/api/plugins/x/uninstall", nil)

--- a/internal/pages/plugins_status_test.go
+++ b/internal/pages/plugins_status_test.go
@@ -109,6 +109,7 @@ func TestStorePageShowsLifecycleStatusAndInstalledSplit(t *testing.T) {
 }
 
 func TestInstallFromMarketplaceFailurePersistsOperatorVisibleStatus(t *testing.T) {
+	t.Setenv("UT_AUTH", "off") // bypass the manager gate to reach the handler's own logic
 	chdirRoot(t)
 
 	db := openPagesTestDB(t)

--- a/internal/pages/plugins_store_page.go
+++ b/internal/pages/plugins_store_page.go
@@ -191,6 +191,10 @@ func registerPluginStoreAPI(mux *http.ServeMux, d *common.Deps) {
 	}
 
 	mux.HandleFunc("POST /api/plugins/store/download", func(w http.ResponseWriter, r *http.Request) {
+		if !isManagerOrAuthOff(r) {
+			respond(w, http.StatusForbidden, "manager or admin required")
+			return
+		}
 		listingID := listingFrom(r)
 		if listingID == "" {
 			respond(w, http.StatusBadRequest, "listing_id required")
@@ -218,6 +222,10 @@ func registerPluginStoreAPI(mux *http.ServeMux, d *common.Deps) {
 	})
 
 	mux.HandleFunc("POST /api/plugins/store/install", func(w http.ResponseWriter, r *http.Request) {
+		if !isManagerOrAuthOff(r) {
+			respond(w, http.StatusForbidden, "manager or admin required")
+			return
+		}
 		listingID := listingFrom(r)
 		if listingID == "" {
 			respond(w, http.StatusBadRequest, "listing_id required")
@@ -250,6 +258,10 @@ func registerPluginStoreAPI(mux *http.ServeMux, d *common.Deps) {
 	})
 
 	mux.HandleFunc("POST /api/plugins/store/delete-download", func(w http.ResponseWriter, r *http.Request) {
+		if !isManagerOrAuthOff(r) {
+			respond(w, http.StatusForbidden, "manager or admin required")
+			return
+		}
 		listingID := listingFrom(r)
 		if listingID == "" {
 			respond(w, http.StatusBadRequest, "listing_id required")

--- a/web/locales/ar.json
+++ b/web/locales/ar.json
@@ -337,6 +337,7 @@
   "plugins.import.warning": "ثبّت الإضافات من مصادر موثوقة فقط. الاستيراد اليدوي يتجاوز اعتماد المتجر.",
   "plugins.install": "تثبيت",
   "plugins.install.error.configuration": "تثبيت المتجر غير مهيّأ.",
+  "plugins.install.error.forbidden": "يمكن للمدير فقط تثبيت الإضافات.",
   "plugins.install.error.incompatible": "هذه الإضافة غير متوافقة مع هذا الصندوق.",
   "plugins.install.error.invalid_package": "فشل التحقق من حزمة الإضافة.",
   "plugins.install.error.invalid_request": "طلب التثبيت غير صالح.",

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -337,6 +337,7 @@
   "plugins.import.warning": "Only install plugins from trusted sources. Manual imports bypass marketplace verification.",
   "plugins.install": "Install",
   "plugins.install.error.configuration": "Marketplace installation is not configured.",
+  "plugins.install.error.forbidden": "Only a manager can install plugins.",
   "plugins.install.error.incompatible": "This plugin is not compatible with this till.",
   "plugins.install.error.invalid_package": "The plugin package failed verification.",
   "plugins.install.error.invalid_request": "The install request was invalid.",

--- a/web/locales/fa.json
+++ b/web/locales/fa.json
@@ -337,6 +337,7 @@
   "plugins.import.warning": "فقط افزونه‌های منابع مطمئن را نصب کنید. نصب دستی از تأیید فروشگاه عبور می‌کند.",
   "plugins.install": "نصب",
   "plugins.install.error.configuration": "نصب از بازارچه پیکربندی نشده است.",
+  "plugins.install.error.forbidden": "فقط مدیر می‌تواند افزونه نصب کند.",
   "plugins.install.error.incompatible": "این افزونه با این صندوق سازگار نیست.",
   "plugins.install.error.invalid_package": "بسته افزونه در اعتبارسنجی رد شد.",
   "plugins.install.error.invalid_request": "درخواست نصب معتبر نیست.",

--- a/web/locales/tr.json
+++ b/web/locales/tr.json
@@ -337,6 +337,7 @@
   "plugins.import.warning": "Yalnızca güvenilir kaynaklardan eklenti kurun. Elle içe aktarmalar market doğrulamasını atlar.",
   "plugins.install": "Kur",
   "plugins.install.error.configuration": "Market kurulumu yapılandırılmamış.",
+  "plugins.install.error.forbidden": "Eklentileri yalnızca yönetici kurabilir.",
   "plugins.install.error.incompatible": "Bu eklenti bu kasayla uyumlu değil.",
   "plugins.install.error.invalid_package": "Eklenti paketi doğrulanamadı.",
   "plugins.install.error.invalid_request": "Kurulum isteği geçersizdi.",

--- a/web/ui/partials/plugin_install_modal.html
+++ b/web/ui/partials/plugin_install_modal.html
@@ -74,7 +74,8 @@ const pluginInstallText = {
 	errorIncompatible: '{{ T "plugins.install.error.incompatible" }}',
 	errorConfiguration: '{{ T "plugins.install.error.configuration" }}',
 	errorInvalidRequest: '{{ T "plugins.install.error.invalid_request" }}',
-	errorNotFound: '{{ T "plugins.install.error.not_found" }}'
+	errorNotFound: '{{ T "plugins.install.error.not_found" }}',
+	errorForbidden: '{{ T "plugins.install.error.forbidden" }}'
 };
 
 function installMessage(messageKey, fallbackKey) {
@@ -103,6 +104,8 @@ function camelizeInstallKey(messageKey) {
 			return 'errorInvalidRequest';
 		case 'plugins.install.error.not_found':
 			return 'errorNotFound';
+		case 'plugins.install.error.forbidden':
+			return 'errorForbidden';
 		default:
 			return '';
 	}


### PR DESCRIPTION
## Summary
- Install, uninstall, enable, disable, update, rollback, permission grant/revoke, trust changes, upload, and import had **no role check at all** — any authenticated cashier could manage plugins.
- An existing backlog note claiming manager-PIN gating already worked was wrong — the `authorizer.go` `Authorizer` type it referenced is dead code, never wired to anything, confirmed by grep across the whole codebase.
- Applied the existing, already-proven `isManagerOrAuthOff` gate to every mutating handler in `plugin_api.go`.
- Independent (opus-model, adversarial) review caught that the first pass missed a **second, fully live install path**: `/api/plugins/store/*` (the actual install button on the `/plugins/store` page) is a separate route registration that would have stayed wide open to any cashier. Fixed in the same change, with test coverage.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `bash scripts/ci/guard-i18n.sh`, `go test ./...` (full repo) — all green
- [x] New tests: 13 routes in `plugin_api.go` + 3 routes in `plugins_store_page.go` all assert 403 with no manager session (`UT_AUTH` left unset, not "off", so a missing gate can't hide); a control test confirms read-only browsing stays ungated
- [x] Three pre-existing tests updated with the documented `UT_AUTH=off` bypass so they still exercise their own original logic post-gate
- [x] Review: `docs/code-reviews/2026-07-24-plugin-manager-gating.md`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>