### PR TITLE
Wire the plugin Supervisor into boot and shutdown (T023)

### DIFF
--- a/docs/code-reviews/2026-07-24-plugin-supervisor-boot-wiring.md
+++ b/docs/code-reviews/2026-07-24-plugin-supervisor-boot-wiring.md
@@ -1,0 +1,79 @@
+# 2026-07-24 — Wire the plugin Supervisor into boot and shutdown (T023)
+
+## Context
+`ut-docs/QUEUE.md` gap: `Supervisor.AutoStartPlugins()`
+(`internal/plugins/supervisor.go:292`, T023) was fully implemented and unit
+tested in isolation, but never constructed or called in production —
+`main.go` passed `nil` straight through to `server.Start` with a
+`// TODO: Initialize supervisor` comment. Two consequences, both silent
+(nil-guarded, so nothing crashed — it just never worked):
+1. A process-based (hardware) plugin left active from a previous run would
+   never restart on boot.
+2. `internal/plugins/revocation.go`'s `RevocationChecker.processRevocation`
+   calls `rc.supervisor.StopPlugin(...)` but only `if rc.supervisor != nil`
+   — revoking a process-based plugin never actually stopped its process.
+
+Zero observable effect today: every currently-shipped plugin is WASM, and
+`AutoStartPlugins` explicitly skips any runtime other than `"go"`/`"native"`.
+This closes the gap so it's ready before the first process-based plugin
+ships, rather than being rediscovered then.
+
+## Design
+- `main.go`: construct `supervisor := plugins.NewSupervisor(database.DB)`
+  and call `supervisor.AutoStartPlugins(ctx)` (non-fatal — logs a warning
+  and continues booting on error, matching this repo's offline-first
+  "checkout must never be blocked" philosophy), then pass the real
+  `supervisor` (not `nil`) into `server.Start`.
+- `internal/server/server.go`: the existing graceful-shutdown goroutine
+  (`<-ctx.Done()` → `srv.Shutdown`) now also calls
+  `supervisor.Shutdown(shutdownCtx)` when non-nil, so a running process
+  plugin doesn't outlive the till.
+- `internal/plugins/supervisor_test.go`: new `TestSupervisor_AutoStartPlugins`
+  — seeds a native-runtime active plugin, a wasm-runtime active plugin, and
+  an inactive go-runtime plugin; asserts only the native one actually
+  starts (real subprocess, checked via `IsRunning`/`ListRunning`).
+
+## Independent review
+Opus-model review, adversarial brief (verify independently, don't trust the
+implementer's summary).
+
+**Confirmed correct (reviewer verified independently):**
+- Construction ordering is safe: `NewSupervisor(database.DB)` runs after
+  `db.Open` (migrations), replica-identity, and `plugins.Init` — no
+  pre-migration/missing-table window.
+- Non-fatal error handling is the right call: `AutoStartPlugins` only
+  returns an error on the `ListAutoStartPlugins` query failing; individual
+  `StartPlugin` failures are swallowed and logged per-plugin.
+- `Supervisor.Shutdown`'s process-kill path (`proc.cancel()`) doesn't
+  actually depend on the passed context being unexpired — worst case if the
+  HTTP server's 5s shutdown budget is fully consumed first, only the
+  `plugin_shutdown` audit-log write is skipped (logged as a warning);
+  processes still die.
+- Zero behavior change for the current WASM fleet — WASM rows are fetched
+  but skipped before any `StartPlugin`/audit side effect; verified by
+  reading the runtime filter directly, not just trusting the claim.
+- The new test spawns a real subprocess and reads real process state, not
+  just a DB row — not vacuous.
+- `go build ./...`, `go test ./...`, `go vet ./...`,
+  `scripts/ci/guard-data-access.sh` all re-run independently and green.
+
+**Fixed:**
+- **LOW — orphan-process window**: the first pass constructed the
+  supervisor and called `AutoStartPlugins` before the marketplace
+  catalog-repository init step, which has its own `log.Fatalf` on error.
+  `os.Exit` (what `log.Fatalf` calls) runs no deferred functions, so a
+  `Fatalf` there would exit without ever reaching `server.Start`'s shutdown
+  wiring — orphaning any process a future go/native plugin had already
+  started. Purely theoretical today (no such plugin exists), but free to
+  close: moved both calls to immediately before `server.Start`, after every
+  other `log.Fatalf`-capable init step has already succeeded. Re-verified
+  with a live boot smoke test (`go build` + run against a scratch SQLite db)
+  that the "Auto-started 0 plugins" log line now appears in the new,
+  later position and the server still serves `200`/redirects normally.
+
+## Verification
+`go build ./...`, `go vet ./...`, `go test ./...`,
+`bash scripts/ci/guard-data-access.sh` — all green, both by me and
+independently by the reviewer. Live boot smoke test run twice (before and
+after the ordering fix) against a real built binary and scratch SQLite DB —
+clean startup, correct log ordering, HTTP server responds.

--- a/internal/plugins/supervisor_test.go
+++ b/internal/plugins/supervisor_test.go
@@ -177,6 +177,56 @@ func TestSupervisor_Shutdown(t *testing.T) {
 	}
 }
 
+// AutoStartPlugins starts active, installed process-based plugins left over
+// from a previous run (T023). WASM plugins (everything shipped today) sync
+// through a separate path (WasmRuntime.Sync) and must be skipped here, not
+// double-started.
+func TestSupervisor_AutoStartPlugins(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	setupAuditLog(t, db)
+
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "test.sh")
+	script := "#!/bin/sh\nsleep 10\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	ctx := context.Background()
+	seed := func(id, runtime string, active int) {
+		_, err := db.ExecContext(ctx, `
+			INSERT INTO plugins (id, name, version, install_state, entrypoint, runtime, is_active)
+			VALUES (?, ?, '1.0.0', 'installed', ?, ?, ?)
+		`, id, id, scriptPath, runtime, active)
+		if err != nil {
+			t.Fatalf("seed plugin %s: %v", id, err)
+		}
+	}
+	seed("com.test.native", "native", 1)
+	seed("com.test.wasm", "wasm", 1)   // must be skipped, not started as a process
+	seed("com.test.inactive", "go", 0) // must be excluded by ListAutoStartPlugins itself
+
+	supervisor := NewSupervisor(db)
+	if err := supervisor.AutoStartPlugins(ctx); err != nil {
+		t.Fatalf("AutoStartPlugins failed: %v", err)
+	}
+	defer supervisor.Shutdown(ctx)
+
+	if !supervisor.IsRunning("com.test.native") {
+		t.Error("expected native-runtime plugin to be auto-started")
+	}
+	if supervisor.IsRunning("com.test.wasm") {
+		t.Error("wasm-runtime plugin must not be started as a process")
+	}
+	if supervisor.IsRunning("com.test.inactive") {
+		t.Error("inactive plugin must not be auto-started")
+	}
+	if running := supervisor.ListRunning(); len(running) != 1 {
+		t.Errorf("expected exactly 1 running plugin, got %d: %v", len(running), running)
+	}
+}
+
 func TestSupervisor_GetProcessInfo_NotRunning(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -252,6 +252,9 @@ func Start(ctx context.Context, cfg *config.Config, handler http.Handler, catalo
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		_ = srv.Shutdown(shutdownCtx)
+		if supervisor != nil {
+			_ = supervisor.Shutdown(shutdownCtx)
+		}
 	}()
 
 	log.Printf("listening on %s", cfg.ListenAddr)

--- a/main.go
+++ b/main.go
@@ -101,16 +101,6 @@ func main() {
 		log.Fatalf("plugin init failed: %v", err)
 	}
 
-	// Process-based (hardware) plugins: start any active ones left over from
-	// a previous run. WASM plugins (everything shipped today) sync via
-	// pluginManager above and are unaffected — AutoStartPlugins skips any
-	// runtime other than "go"/"native". Best-effort: a plugin failing to
-	// restart shouldn't block the till from booting.
-	supervisor := plugins.NewSupervisor(database.DB)
-	if err := supervisor.AutoStartPlugins(ctx); err != nil {
-		log.Warnf("plugin auto-start failed: %v", err)
-	}
-
 	// 3b) Marketplace: OAuth client and catalog repository (T004, T010 - 009-cloud-marketplace)
 	var catalogRepo *marketplace.CatalogRepository
 	if cfg.Marketplace.EndpointURL != "" {
@@ -139,6 +129,20 @@ func main() {
 
 	// 4) Pages: pass db and catalog repo so handlers can use them
 	mux := pages.Init(ctx, cfg, pluginManager, database.DB, catalogRepo)
+
+	// Process-based (hardware) plugins: start any active ones left over from
+	// a previous run. WASM plugins (everything shipped today) sync via
+	// pluginManager above and are unaffected — AutoStartPlugins skips any
+	// runtime other than "go"/"native". Best-effort: a plugin failing to
+	// restart shouldn't block the till from booting. Deliberately placed
+	// last, right before server.Start's shutdown wiring takes over — every
+	// other log.Fatalf-capable init step has already run, so a process
+	// started here is never orphaned by a later Fatalf exiting without
+	// running the supervisor's shutdown path.
+	supervisor := plugins.NewSupervisor(database.DB)
+	if err := supervisor.AutoStartPlugins(ctx); err != nil {
+		log.Warnf("plugin auto-start failed: %v", err)
+	}
 
 	// 5) Server with background jobs (T011 - 009-cloud-marketplace)
 	if err := server.Start(ctx, cfg, mux, catalogRepo, database.DB, supervisor); err != nil {

--- a/main.go
+++ b/main.go
@@ -101,6 +101,16 @@ func main() {
 		log.Fatalf("plugin init failed: %v", err)
 	}
 
+	// Process-based (hardware) plugins: start any active ones left over from
+	// a previous run. WASM plugins (everything shipped today) sync via
+	// pluginManager above and are unaffected — AutoStartPlugins skips any
+	// runtime other than "go"/"native". Best-effort: a plugin failing to
+	// restart shouldn't block the till from booting.
+	supervisor := plugins.NewSupervisor(database.DB)
+	if err := supervisor.AutoStartPlugins(ctx); err != nil {
+		log.Warnf("plugin auto-start failed: %v", err)
+	}
+
 	// 3b) Marketplace: OAuth client and catalog repository (T004, T010 - 009-cloud-marketplace)
 	var catalogRepo *marketplace.CatalogRepository
 	if cfg.Marketplace.EndpointURL != "" {
@@ -131,8 +141,7 @@ func main() {
 	mux := pages.Init(ctx, cfg, pluginManager, database.DB, catalogRepo)
 
 	// 5) Server with background jobs (T011 - 009-cloud-marketplace)
-	// TODO: Initialize supervisor and pass it to server.Start for revocation handling
-	if err := server.Start(ctx, cfg, mux, catalogRepo, database.DB, nil); err != nil {
+	if err := server.Start(ctx, cfg, mux, catalogRepo, database.DB, supervisor); err != nil {
 		log.Fatalf("server stopped: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- `Supervisor.AutoStartPlugins` (T023) was fully implemented and tested in isolation but never constructed or called in production — `main.go` passed `nil` straight through to `server.Start`. Fixes it: constructs the real supervisor, calls `AutoStartPlugins` at boot (non-fatal), and shuts it down gracefully alongside the HTTP server.
- Side effect fixed for free: `RevocationChecker`'s stop-on-revoke path was a silent no-op for process-based plugins (nil-guarded supervisor) — now wired for real.
- Zero behavior change for the current fleet (all WASM; `AutoStartPlugins` explicitly skips non-go/native runtimes) — this closes the gap before the first process-based plugin ships.
- Independent review flagged a theoretical orphan-process window (a later `log.Fatalf` between the original call site and `server.Start` would skip supervisor shutdown via `os.Exit`); fixed by moving both calls to immediately before `server.Start`, after every other fatal-capable init step.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `bash scripts/ci/guard-data-access.sh` all green
- [x] New test: `TestSupervisor_AutoStartPlugins`
- [x] Live boot smoke test against a real built binary + scratch SQLite DB (before and after the reordering fix)
- [x] Independent opus-model adversarial review, one real (low-severity) finding fixed (`docs/code-reviews/2026-07-24-plugin-supervisor-boot-wiring.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BLqeqAh51ZRQ2UPpAHJXgH