### PR TITLE
Render a plugin's manifest icon on the buttons it contributes

### DIFF
--- a/docs/code-reviews/2026-07-24-plugin-button-icons.md
+++ b/docs/code-reviews/2026-07-24-plugin-button-icons.md
@@ -1,0 +1,103 @@
+# 2026-07-24 — Render a plugin's manifest icon on the buttons it contributes
+
+## Context
+`ut-docs/QUEUE.md` gap: "Buttons can carry icons — tender/menu buttons show
+an icon; a plugin can ship its own icon in the manifest and it shows on the
+plugin card AND on the button it contributes." Scoping (via an Explore
+subagent) found the data plumbing already existed but was write-only:
+`manifest.json`'s per-entry `icon_path` gets persisted into
+`plugin_entries.icon_path` at install time (`PersistManifest`), and
+`PluginRepo.ListButtonEntries` already scanned it back out — but no template
+anywhere ever rendered it, and no route existed to serve the file.
+
+**Scoped down from the full backlog item.** The full ask has two other
+pieces, both genuinely needing a design decision first, not just a render
+fix:
+- Tender-button icons — `payment_methods` (the table backing the pay-grid)
+  has no icon column or any plumbing to one at all; would need new schema.
+- The plugin manage-card icon (`/plugins`) — `Manifest` has no plugin-level
+  icon field, only a per-entry one; showing "the" icon for a plugin with
+  multiple entries needs a semantics decision (which entry's icon, or a
+  separate manifest field) before any code.
+
+This change ships only the well-defined subset: action/menu buttons
+(`plugin_buttons.html`, the sale-screen panel), which already had a
+per-entry icon field with nowhere to decide "which one" — it's exactly one
+icon per button.
+
+## Design
+- `internal/data/plugin_repo.go`: `ButtonEntryRow` gains `PluginVersion`
+  (added `p.version` to `ListButtonEntries`'s SELECT) — needed to build the
+  on-disk path `{pluginID}/{version}/{icon_path}`.
+- New `internal/pages/plugin_icons.go`: `GET /plugin-icons/{plugin}/{version}/
+  {file...}`, guarded with `filepath.Clean` + prefix-check against the
+  plugin's own resolved directory — the same pattern
+  `resolvePluginThemeCSS` (`themes.go`) already uses for theme CSS, itself
+  plugin-shipped, semi-trusted content.
+- `internal/auth/middleware.go`: `/plugin-icons/` added to the exempt-prefix
+  list alongside the existing `/themes/` exemption — static plugin assets,
+  not sensitive.
+- `plugin_buttons.html`: renders the `<img>` when `.IconPath` is set, none
+  otherwise.
+
+## Independent review
+Opus-model review, adversarial brief, explicitly weighted toward the
+path-traversal question since that's the highest-stakes part of a new
+plugin-supplied-input file-serving route.
+
+**Confirmed correct (reviewer verified independently):**
+- Path traversal guard is sound against encoded (`%2e%2e`) and segment-level
+  (`pluginID`/`version` containing `..`) attempts — `http.ServeMux`'s
+  `{file...}` wildcard decodes before the handler sees it, and
+  `Clean`+prefix-check catches what reaches the handler. Symlink escape
+  isn't caught (no `EvalSymlinks`) — same limitation the existing theme-CSS
+  guard already has; plugins are Ed25519-verified at install, consistent
+  risk posture, not a new hole.
+- Auth exemption is justified the same way `/themes/` already is; only
+  leaks a plugin id/version existence oracle to an unauthenticated prober,
+  matching the pre-existing theme route's exposure.
+- The new `p.version` column doesn't break any other `ListButtonEntries`
+  caller or `ButtonEntryRow{}` literal — checked every call site directly.
+- Test schema additions (`icon_path`, `parent_page_key`, `target_action`,
+  `trigger_event` on the hand-rolled test `plugin_entries` table) don't
+  diverge from the real migration in a way that would make the test pass
+  falsely — `ListButtonEntries` selects by name, not position.
+- Template interpolation of `.IconPath`/`.PluginID`/`.PluginVersion` is
+  safe — plain `html/template` auto-escaping, no `template.HTML`/`URL`
+  bypass.
+- Scope claim is honest: tender-button and plugin-card icons are genuinely
+  untouched, not silently incomplete.
+
+**Fixed:**
+- **HIGH — the new icon route silently ignored `UT_DATA_DIR` on every real
+  deployment.** `pluginPagesDir` and `pluginThemesDir` both get repointed
+  at `paths.Plugins()` inside `pages.Init`, once `paths.Init` has actually
+  run — but the matching line for the new `pluginIconsDir` was missing, so
+  it stayed frozen on the `"./data"` cwd-relative fallback forever. The
+  original code comment's justification ("a package var initializer runs
+  before `paths.Init`, so `paths.Plugins()` would just freeze anyway") was
+  only true in isolation — it ignored that `pages.Init` already re-assigns
+  the two sibling vars *after* `paths.Init` runs, and the implementer had
+  simply forgotten to add the third line. On any real install (macOS
+  Application Support dir, the `.deb`'s `/var/lib/unitill`), every plugin
+  icon would have 404'd while themes and plugin pages worked, because those
+  two do get repointed. The implementer's own live-verification happened to
+  use `UT_DATA_DIR=./data`, which coincidentally matched the frozen
+  literal — masking the bug. Fixed by adding
+  `pluginIconsDir = paths.Plugins()` to `pages.Init` alongside its two
+  siblings, and re-verified live with `UT_DATA_DIR` pointed at a directory
+  that is *not* `./data` relative to the process's cwd — the icon route now
+  resolves correctly (confirmed it would have 404'd before the fix).
+
+## Verification
+`go build ./...`, `go vet ./...`, `go test ./...`,
+`bash scripts/ci/guard-data-access.sh`, `bash scripts/ci/guard-i18n.sh` —
+all green, both before and after the review-driven fix, and independently
+by the reviewer. Live-verified twice against a real built binary and
+scratch SQLite DB: once with `UT_DATA_DIR=./data` (before the fix — passed
+coincidentally) and once with `UT_DATA_DIR` pointed at an unrelated
+directory (after the fix — the case that actually matters, and the case
+the first pass would have failed). New tests:
+`TestPluginRepo_ListButtonEntries`, `TestPluginIcons_ServesFileUnderPluginDir`,
+`TestPluginIcons_BlocksPathTraversal`, `TestPluginIcons_MissingFileIs404`,
+`TestPluginButtonsTemplate_RendersIconOnlyWhenSet`.

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -32,7 +32,7 @@ func exempt(path string) bool {
 		"/api/sync/assets", "/api/sync/assets/file", "/api/setup/join":
 		return true
 	}
-	for _, p := range []string{"/api/auth/", "/public/", "/themes/"} {
+	for _, p := range []string{"/api/auth/", "/public/", "/themes/", "/plugin-icons/"} {
 		if strings.HasPrefix(path, p) {
 			return true
 		}

--- a/internal/data/plugin_repo.go
+++ b/internal/data/plugin_repo.go
@@ -1132,6 +1132,7 @@ ORDER BY pe.sort_order, pe.plugin_id, pe.key
 // when the button is pressed.
 type ButtonEntryRow struct {
 	PluginID      string
+	PluginVersion string
 	PluginName    string
 	EntryKey      string
 	Label         string
@@ -1148,6 +1149,7 @@ func (r *PluginRepo) ListButtonEntries(ctx context.Context) ([]ButtonEntryRow, e
 	rows, err := r.db.QueryContext(ctx, `
 SELECT
     p.id,
+    p.version,
     p.name,
     pe.key,
     pe.label,
@@ -1169,7 +1171,7 @@ ORDER BY pe.sort_order, pe.plugin_id, pe.key
 	var res []ButtonEntryRow
 	for rows.Next() {
 		var row ButtonEntryRow
-		if err := rows.Scan(&row.PluginID, &row.PluginName, &row.EntryKey, &row.Label, &row.IconPath, &row.ParentPageKey, &row.TargetAction, &row.TriggerEvent, &row.SortOrder, &row.ConfigJSON); err != nil {
+		if err := rows.Scan(&row.PluginID, &row.PluginVersion, &row.PluginName, &row.EntryKey, &row.Label, &row.IconPath, &row.ParentPageKey, &row.TargetAction, &row.TriggerEvent, &row.SortOrder, &row.ConfigJSON); err != nil {
 			return nil, pluginObs.wrap("list_button_entries", err)
 		}
 		res = append(res, row)

--- a/internal/data/plugin_repo_test.go
+++ b/internal/data/plugin_repo_test.go
@@ -18,7 +18,7 @@ func newPluginRepoTestDB(t *testing.T) *sql.DB {
 	stmts := []string{
 		`PRAGMA foreign_keys = ON;`,
 		`CREATE TABLE plugins (id TEXT PRIMARY KEY, name TEXT, version TEXT, is_active INTEGER NOT NULL DEFAULT 1, install_state TEXT DEFAULT 'installed', runtime TEXT DEFAULT 'go', entrypoint TEXT DEFAULT '');`,
-		`CREATE TABLE plugin_entries (id TEXT PRIMARY KEY, plugin_id TEXT NOT NULL, type TEXT, key TEXT, route TEXT, label TEXT, menu_group TEXT, config_json TEXT, sort_order INTEGER DEFAULT 0, is_active INTEGER NOT NULL DEFAULT 1);`,
+		`CREATE TABLE plugin_entries (id TEXT PRIMARY KEY, plugin_id TEXT NOT NULL, type TEXT, key TEXT, route TEXT, label TEXT, menu_group TEXT, icon_path TEXT, parent_page_key TEXT, target_action TEXT, trigger_event TEXT, config_json TEXT, sort_order INTEGER DEFAULT 0, is_active INTEGER NOT NULL DEFAULT 1);`,
 		`CREATE TABLE plugin_permissions (id TEXT PRIMARY KEY, plugin_id TEXT NOT NULL, permission TEXT NOT NULL, granted INTEGER NOT NULL DEFAULT 0);`,
 	}
 	for _, s := range stmts {
@@ -128,6 +128,43 @@ func TestPluginRepo_ListThemeEntries(t *testing.T) {
 	r := rows[0]
 	if r.PluginID != "t1" || r.PluginVersion != "1.0.0" || r.EntryKey != "midnight" ||
 		r.Label != "Midnight (dark)" || r.ConfigJSON != `{"css":"assets/theme.css"}` {
+		t.Fatalf("unexpected row: %+v", r)
+	}
+}
+
+func TestPluginRepo_ListButtonEntries(t *testing.T) {
+	ctx := context.Background()
+	db := newPluginRepoTestDB(t)
+	repo := NewPluginRepo(db)
+
+	if _, err := db.Exec(`INSERT INTO plugins(id,name,version,is_active) VALUES('b1','Stripe','1.2.0',1)`); err != nil {
+		t.Fatalf("seed plugin: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO plugin_entries(id,plugin_id,type,key,label,icon_path,sort_order,is_active) VALUES('be1','b1','button','tender','Card','icons/card.svg',1,1)`); err != nil {
+		t.Fatalf("seed button entry: %v", err)
+	}
+	// Inactive plugin: its button must be filtered out.
+	if _, err := db.Exec(`INSERT INTO plugins(id,name,version,is_active) VALUES('b2','Old','0.1',0)`); err != nil {
+		t.Fatalf("seed plugin2: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO plugin_entries(id,plugin_id,type,key,label,is_active) VALUES('be2','b2','button','old','Old',1)`); err != nil {
+		t.Fatalf("seed button entry2: %v", err)
+	}
+	// Non-button entry: excluded.
+	if _, err := db.Exec(`INSERT INTO plugin_entries(id,plugin_id,type,key,label,is_active) VALUES('be3','b1','page','p','P',1)`); err != nil {
+		t.Fatalf("seed page entry: %v", err)
+	}
+
+	rows, err := repo.ListButtonEntries(ctx)
+	if err != nil {
+		t.Fatalf("ListButtonEntries: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 button, got %d: %+v", len(rows), rows)
+	}
+	r := rows[0]
+	if r.PluginID != "b1" || r.PluginVersion != "1.2.0" || r.EntryKey != "tender" ||
+		r.Label != "Card" || r.IconPath != "icons/card.svg" {
 		t.Fatalf("unexpected row: %+v", r)
 	}
 }

--- a/internal/pages/init.go
+++ b/internal/pages/init.go
@@ -145,6 +145,7 @@ func Init(ctx context.Context, cfg *config.Config, pm *plugins.Manager, db *sql.
 	registerDesigner(mux, dp)
 	registerSettings(mux, dp)
 	registerThemes(mux, dp)
+	registerPluginIcons(mux)
 	registerPluginsPage(mux, dp)
 	registerPluginAPI(mux, dp)
 	registerPluginPages(mux, dp)

--- a/internal/pages/init.go
+++ b/internal/pages/init.go
@@ -30,11 +30,13 @@ func Init(ctx context.Context, cfg *config.Config, pm *plugins.Manager, db *sql.
 	log := logging.L()
 	mux := http.NewServeMux()
 
-	// Point the plugin page/theme asset dirs at the resolved data directory
-	// (paths.Init ran in config.Init). These stay package vars so tests can
-	// override them, but production reads them from the stable data dir.
+	// Point the plugin page/theme/icon asset dirs at the resolved data
+	// directory (paths.Init ran in config.Init). These stay package vars so
+	// tests can override them, but production reads them from the stable
+	// data dir.
 	pluginPagesDir = paths.Plugins()
 	pluginThemesDir = paths.Plugins()
+	pluginIconsDir = paths.Plugins()
 
 	// settings + state
 	setStore := settings.NewStore(db)

--- a/internal/pages/plugin_icons.go
+++ b/internal/pages/plugin_icons.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 )
 
-// Overridable in tests, same convention (and same "./data/plugins" literal,
-// not paths.Plugins()) as pluginThemesDir/pluginPagesDir — a package var
-// initializer runs before main() calls paths.Init, so paths.Plugins() would
-// just freeze in the pre-Init fallback anyway.
+// Overridable in tests, same convention as pluginThemesDir/pluginPagesDir.
+// The "./data/plugins" literal is only the pre-Init fallback; pages.Init
+// repoints this at paths.Plugins() (the resolved, per-platform data dir)
+// once paths.Init has run.
 var pluginIconsDir = "./data/plugins"
 
 // registerPluginIcons serves icon files an installed plugin ships alongside

--- a/internal/pages/plugin_icons.go
+++ b/internal/pages/plugin_icons.go
@@ -1,0 +1,48 @@
+package pages
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Overridable in tests, same convention (and same "./data/plugins" literal,
+// not paths.Plugins()) as pluginThemesDir/pluginPagesDir — a package var
+// initializer runs before main() calls paths.Init, so paths.Plugins() would
+// just freeze in the pre-Init fallback anyway.
+var pluginIconsDir = "./data/plugins"
+
+// registerPluginIcons serves icon files an installed plugin ships alongside
+// its bundle (manifest.json "icon_path" on an entry) — the icon shown on the
+// button that entry contributes. Route: GET /plugin-icons/{plugin}/{version}/{file...}.
+//
+// icon_path is plugin-supplied input (it lands in plugin_entries.icon_path
+// unsanitized at install time — internal/plugins/manifest.go PersistManifest);
+// the resolved path is Clean()'d and checked against the plugin's own base
+// dir before serving, the same guard resolvePluginThemeCSS uses for theme CSS.
+func registerPluginIcons(mux *http.ServeMux) {
+	mux.HandleFunc("GET /plugin-icons/{plugin}/{version}/{file...}", func(w http.ResponseWriter, r *http.Request) {
+		pluginID := r.PathValue("plugin")
+		version := r.PathValue("version")
+		file := r.PathValue("file")
+		if pluginID == "" || version == "" || file == "" ||
+			strings.Contains(pluginID, "..") || strings.Contains(version, "..") {
+			http.NotFound(w, r)
+			return
+		}
+
+		base := filepath.Clean(filepath.Join(pluginIconsDir, pluginID, version))
+		path := filepath.Clean(filepath.Join(base, file))
+		if path != base && !strings.HasPrefix(path, base+string(os.PathSeparator)) {
+			http.NotFound(w, r)
+			return
+		}
+
+		if info, err := os.Stat(path); err != nil || info.IsDir() {
+			http.NotFound(w, r)
+			return
+		}
+		http.ServeFile(w, r, path)
+	})
+}

--- a/internal/pages/plugin_icons_test.go
+++ b/internal/pages/plugin_icons_test.go
@@ -1,0 +1,115 @@
+package pages
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/data"
+	"github.com/universaltill/universal-till/internal/httpx"
+)
+
+func withPluginIconsDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	orig := pluginIconsDir
+	pluginIconsDir = dir
+	t.Cleanup(func() { pluginIconsDir = orig })
+	return dir
+}
+
+func TestPluginIcons_ServesFileUnderPluginDir(t *testing.T) {
+	base := withPluginIconsDir(t)
+	iconPath := filepath.Join(base, "com.x.stripe", "1.0.0", "icons", "card.svg")
+	if err := os.MkdirAll(filepath.Dir(iconPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(iconPath, []byte("<svg/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	registerPluginIcons(mux)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/plugin-icons/com.x.stripe/1.0.0/icons/card.svg", nil)
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Body.String() != "<svg/>" {
+		t.Errorf("unexpected body: %q", rec.Body.String())
+	}
+}
+
+func TestPluginIcons_BlocksPathTraversal(t *testing.T) {
+	base := withPluginIconsDir(t)
+	// A secret file that lives OUTSIDE any plugin's own directory — must
+	// never be reachable through the icon route.
+	secretDir := filepath.Join(base, "..", "outside")
+	if err := os.MkdirAll(secretDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	secretPath := filepath.Join(secretDir, "secret.txt")
+	if err := os.WriteFile(secretPath, []byte("top secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(secretDir) })
+
+	mux := http.NewServeMux()
+	registerPluginIcons(mux)
+
+	for _, path := range []string{
+		"/plugin-icons/com.x.stripe/1.0.0/../../../outside/secret.txt",
+		"/plugin-icons/..%2f..%2foutside/1.0.0/secret.txt",
+	} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", path, nil)
+		mux.ServeHTTP(rec, req)
+		if rec.Code == http.StatusOK {
+			t.Errorf("traversal path %q must not be served, got 200: %s", path, rec.Body.String())
+		}
+	}
+}
+
+// A button entry with an icon renders an <img> pointing at the guarded
+// route; a button with no icon renders no <img> at all.
+func TestPluginButtonsTemplate_RendersIconOnlyWhenSet(t *testing.T) {
+	chdirRoot(t)
+
+	buttons := []data.ButtonEntryRow{
+		{PluginID: "com.x.stripe", PluginVersion: "1.0.0", PluginName: "Stripe", EntryKey: "tender", Label: "Card", IconPath: "icons/card.svg"},
+		{PluginID: "com.x.plain", PluginVersion: "2.0.0", PluginName: "Plain", EntryKey: "noop", Label: "No Icon"},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/ui/plugin-buttons", nil)
+	httpx.RenderPartial("ui/partials/plugin_buttons.html", map[string]any{"Buttons": buttons})(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `/plugin-icons/com.x.stripe/1.0.0/icons/card.svg`) {
+		t.Error("expected the icon <img> src for the button with icon_path")
+	}
+	if strings.Count(body, "<img") != 1 {
+		t.Errorf("expected exactly 1 <img> (only the button with an icon), got %d", strings.Count(body, "<img"))
+	}
+}
+
+func TestPluginIcons_MissingFileIs404(t *testing.T) {
+	withPluginIconsDir(t)
+
+	mux := http.NewServeMux()
+	registerPluginIcons(mux)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/plugin-icons/com.x.nope/1.0.0/missing.svg", nil)
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", rec.Code)
+	}
+}

--- a/web/ui/partials/plugin_buttons.html
+++ b/web/ui/partials/plugin_buttons.html
@@ -10,6 +10,7 @@
         hx-trigger="click"
         hx-swap="none"
         title="{{ .PluginName }}">
+        {{ if .IconPath }}<img src="/plugin-icons/{{ .PluginID }}/{{ .PluginVersion }}/{{ .IconPath }}" alt="" width="20" height="20" style="vertical-align:middle; margin-inline-end:.4rem" loading="lazy">{{ end }}
         {{ .Label }}
       </button>
     </div>


### PR DESCRIPTION
## Summary
- Closes the well-defined subset of QUEUE.md's "Buttons can carry icons" item: `plugin_entries.icon_path` was persisted at install time but never rendered anywhere (write-only). Now rendered on the sale-screen action/menu buttons (`plugin_buttons.html`).
- New guarded static route `GET /plugin-icons/{plugin}/{version}/{file...}`, same traversal-guard pattern as the existing `/themes/` CSS route; added to the auth-exempt prefix list alongside `/themes/`.
- **Deliberately NOT included** (both need a design decision first, disclosed in the review doc): tender-button icons (no icon field exists anywhere in the `payment_methods` path) and the plugin manage-card icon (no plugin-level icon field in the manifest, only per-entry).
- Independent review caught a real bug pre-merge: the new `pluginIconsDir` var was never repointed at the resolved data directory the way its two siblings (`pluginPagesDir`/`pluginThemesDir`) already are — every plugin icon would have silently 404'd on any real deployment where `UT_DATA_DIR` isn't literally `./data` relative to the process's cwd (i.e. every real install). Fixed and re-verified live against a data dir that isn't `./data`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `guard-data-access.sh`, `guard-i18n.sh` all green
- [x] New tests: `TestPluginRepo_ListButtonEntries`, `TestPluginIcons_ServesFileUnderPluginDir`, `TestPluginIcons_BlocksPathTraversal`, `TestPluginIcons_MissingFileIs404`, `TestPluginButtonsTemplate_RendersIconOnlyWhenSet`
- [x] Live-verified against a real built binary + scratch SQLite DB, including the data-dir bug found by review (confirmed it would 404 before the fix, works after)
- [x] Independent opus-model adversarial review focused on path-traversal safety — no traversal hole found; one real (now-fixed) data-dir bug caught (`docs/code-reviews/2026-07-24-plugin-button-icons.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BLqeqAh51ZRQ2UPpAHJXgH