### PR TITLE
Add item modifiers: schema, repo, and basket-engine plumbing (ADR-0020)

### DIFF
--- a/docs/code-reviews/2026-07-24-item-modifiers-phase1.md
+++ b/docs/code-reviews/2026-07-24-item-modifiers-phase1.md
@@ -1,0 +1,112 @@
+# 2026-07-24 — Item modifiers, Phase 1: schema + repo + basket-engine plumbing (ADR-0020)
+
+## Context
+Farshid (2026-07-24): a self-order kiosk is top priority, and it needs item
+customization (his examples: extra shot in a coffee, build-your-own
+sandwich) — without which a cafe kiosk is close to useless. He also
+confirmed the cashier till needs this too, not just the kiosk, so Phase 1
+ships it on the existing cashier POS first. Full design:
+`ut-docs/adr/0020-self-order-kiosk-and-item-modifiers.md`,
+`specs/011-self-order-kiosk/spec.md`.
+
+This is Phase 1 only: catalog data model + repo + basket-engine plumbing.
+Deliberately headless — no cashier-facing UI yet (that's the next task);
+this slice is fully covered by unit/integration tests instead of manual
+click-through, since nothing user-facing exists to click through.
+
+## Design
+**The core decision**: rather than adding a parallel "modifiers total"
+that every money computation would need to know about, a chosen
+modifier's price delta is folded directly into the basket line's existing
+`PriceCents` at add-time (`Service.AddLineWithModifiers`,
+`internal/pos/service.go`). `Modifiers []data.SelectedModifier` rides
+alongside purely as a display/persistence snapshot. This means the entire
+downstream money pipeline — `recomputeTotals`, `computeSaleTotals`,
+`CompleteSale`'s persistence loop, the receipt-fallback duplicate calc in
+`pos_api.go` — needed **zero changes**, because none of them care where a
+line's unit price came from.
+
+Other pieces:
+- Migration 017: `item_modifier_groups`/`item_modifier_options` (the
+  catalog-declared customization menu, additive-only price deltas in v1)
+  and `sale_line_modifiers` (immutable snapshot of what was actually
+  chosen — never a live FK to the option, so a later catalog edit can't
+  rewrite a past receipt).
+- `internal/data/modifier_repo.go`: full CRUD for groups/options (ready for
+  the admin catalog UI in the next task) + `ListGroupsForItem` +
+  `InsertSaleLineModifiers`.
+- Merge behavior extended (`BasketLine.ModifierSignature()`) so two
+  differently-customized instances of the same item stay distinct lines,
+  while identical customizations still merge quantity like today.
+- Hold/resume (`hold.go`) carries `Modifiers` through so a held sale
+  doesn't silently drop a customer's customization on recall.
+
+**A real gap this creates, documented and deliberately deferred, not
+fixed here**: `Service.Remove`/`UpdateLine` are SKU-keyed and match
+every/first line sharing a SKU — safe before modifiers existed (at most
+one line per SKU, guaranteed by the old merge logic), unsafe once two
+modifier-distinct lines can share a SKU. Nothing calls
+`AddLineWithModifiers` outside tests yet, so this has no live exposure.
+Documented via doc comments on both methods plus a regression test
+(`TestRemove_KnownGap_DeletesAllLinesSharingSKU`) that forces the next
+task (cashier UI) to deal with it explicitly — wiring "remove this line"
+to the existing SKU-keyed method for a modifier-bearing item would be a
+real, live bug.
+
+## Independent review
+Opus-model review, adversarial brief, explicitly weighted toward the
+"zero downstream changes" claim since that's the single load-bearing
+design decision of the whole change, plus the documented gap's "no live
+exposure" claim.
+
+**Confirmed correct (reviewer verified independently, traced the code
+directly rather than trusting the claim):**
+- Every money-path consumer reads a line's own stored price
+  (`PriceCents`/`UnitPrice`), never re-derives it from `ItemID` via a
+  fresh catalog lookup — checked `recomputeTotals`, `computeSaleTotals`,
+  the `CompleteSale` insert loop, the `pos_api.go` duplicate calc, **and
+  proactively checked the refund and sale-sync paths too**
+  (`refund_page.go`, `sync_sales.go`) since those were the real risk not
+  explicitly named in the brief — both read the stored line price, no
+  catalog re-lookup anywhere. The folded delta cannot be silently dropped.
+- Merge/identity logic is sound: identical selections merge (any order,
+  via sorted signature), different ones stay distinct; option-ID comma
+  collision is inert since option IDs are always UUIDs.
+- The documented `Remove`/`UpdateLine` gap is genuinely inert — grepped
+  every caller of `AddLineWithModifiers` repo-wide, zero non-test callers.
+- Hold/resume JSON round-trip is lossless (`SelectedModifier` fully
+  exported).
+- `sale_line_modifiers` persists correctly inside the same transaction,
+  same `lineID`, for every line; zero modifiers → zero rows, not a
+  garbage row.
+- Migration constraints and cascade behavior are exactly as intended:
+  option/group deletion never cascades into historical
+  `sale_line_modifiers` rows (only `sale_lines` deletion does) — the
+  snapshot really is immutable and independent of the source rows'
+  lifecycle.
+- `TestCompleteSale_PersistsModifiers`'s assertions are meaningful, not
+  vacuous — would fail on either a dropped or double-counted delta.
+
+**No findings requiring a fix.** Two non-bug notes from the reviewer:
+`SelectedModifier` uses PascalCase (not snake_case) JSON tags — fine,
+it's an internal hold-blob field, not a wire API, so the repo's
+snake_case JSON rule doesn't apply; and refund/sync don't forward the
+modifier snapshot rows themselves (only the folded price), acceptable for
+a headless v1 since money correctness doesn't depend on it.
+
+## Verification
+`go build ./...`, `go vet ./...`, `go test ./...` (full suite, 28
+packages, zero regressions), `bash scripts/ci/guard-data-access.sh` — all
+green, both by me and independently by the reviewer. New tests:
+`TestAddLineWithModifiers_FoldsDeltaIntoPrice`,
+`TestAddLineWithModifiers_IdenticalSelectionsMerge`,
+`TestAddLineWithModifiers_DifferentSelectionsDoNotMerge`,
+`TestModifierSignature_OrderIndependent`,
+`TestModifierSignature_EmptyForNoModifiers`,
+`TestRemove_KnownGap_DeletesAllLinesSharingSKU`,
+`TestSnapshotRestoreRoundTrip_PreservesModifiers`,
+`TestCompleteSale_PersistsModifiers`,
+`TestModifierRepo_CreateAndListGroups`,
+`TestModifierRepo_ListGroupsForItem_SkipsInactive`,
+`TestModifierRepo_DeleteGroupCascadesOptions`,
+`TestModifierRepo_CreateOption_RejectsNegativeDelta`.

--- a/internal/data/modifier_repo.go
+++ b/internal/data/modifier_repo.go
@@ -1,0 +1,261 @@
+package data
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// ModifierGroup is a customization choice attached to a catalog item (e.g.
+// "Extras", "Bread") — ADR-0020 / spec 011. Options are loaded alongside it.
+type ModifierGroup struct {
+	ID        string
+	ItemID    string
+	Name      string
+	Required  bool
+	MinSelect int
+	MaxSelect int
+	SortOrder int
+	IsActive  bool
+	Options   []ModifierOption
+}
+
+// ModifierOption is one selectable choice within a ModifierGroup. Price
+// deltas are additive-only in v1 (never negative — see migration 017).
+type ModifierOption struct {
+	ID              string
+	GroupID         string
+	Name            string
+	PriceDeltaMinor int64
+	SortOrder       int
+	IsActive        bool
+}
+
+type ModifierRepo struct {
+	db *sql.DB
+}
+
+func NewModifierRepo(db *sql.DB) *ModifierRepo {
+	return &ModifierRepo{db: db}
+}
+
+// ListGroupsForItem returns an item's active modifier groups (with their
+// active options nested), ordered for stable UI rendering. Used by both the
+// cashier POS customization step and the (future) kiosk flow.
+func (r *ModifierRepo) ListGroupsForItem(ctx context.Context, itemID string) ([]ModifierGroup, error) {
+	groupRows, err := r.db.QueryContext(ctx, `
+SELECT id, item_id, name, required, min_select, max_select, sort_order, is_active
+FROM item_modifier_groups
+WHERE item_id = ? AND is_active = 1
+ORDER BY sort_order, name
+`, itemID)
+	if err != nil {
+		return nil, fmt.Errorf("list modifier groups: %w", err)
+	}
+	defer groupRows.Close()
+
+	var groups []ModifierGroup
+	byID := map[string]*ModifierGroup{}
+	for groupRows.Next() {
+		var g ModifierGroup
+		var required, active int
+		if err := groupRows.Scan(&g.ID, &g.ItemID, &g.Name, &required, &g.MinSelect, &g.MaxSelect, &g.SortOrder, &active); err != nil {
+			return nil, fmt.Errorf("scan modifier group: %w", err)
+		}
+		g.Required = required == 1
+		g.IsActive = active == 1
+		groups = append(groups, g)
+	}
+	if err := groupRows.Err(); err != nil {
+		return nil, fmt.Errorf("list modifier groups: %w", err)
+	}
+	for i := range groups {
+		byID[groups[i].ID] = &groups[i]
+	}
+	if len(groups) == 0 {
+		return nil, nil
+	}
+
+	optRows, err := r.db.QueryContext(ctx, `
+SELECT o.id, o.group_id, o.name, o.price_delta_minor, o.sort_order, o.is_active
+FROM item_modifier_options o
+JOIN item_modifier_groups g ON g.id = o.group_id
+WHERE g.item_id = ? AND g.is_active = 1 AND o.is_active = 1
+ORDER BY o.sort_order, o.name
+`, itemID)
+	if err != nil {
+		return nil, fmt.Errorf("list modifier options: %w", err)
+	}
+	defer optRows.Close()
+	for optRows.Next() {
+		var o ModifierOption
+		var active int
+		if err := optRows.Scan(&o.ID, &o.GroupID, &o.Name, &o.PriceDeltaMinor, &o.SortOrder, &active); err != nil {
+			return nil, fmt.Errorf("scan modifier option: %w", err)
+		}
+		o.IsActive = active == 1
+		if g, ok := byID[o.GroupID]; ok {
+			g.Options = append(g.Options, o)
+		}
+	}
+	if err := optRows.Err(); err != nil {
+		return nil, fmt.Errorf("list modifier options: %w", err)
+	}
+	return groups, nil
+}
+
+// CreateGroup adds a modifier group to an item. Returns the new group id.
+func (r *ModifierRepo) CreateGroup(ctx context.Context, id string, itemID, name string, required bool, minSelect, maxSelect, sortOrder int) (string, error) {
+	if itemID == "" {
+		return "", errors.New("item_id required")
+	}
+	if name == "" {
+		return "", errors.New("name required")
+	}
+	req := 0
+	if required {
+		req = 1
+	}
+	_, err := r.db.ExecContext(ctx, `
+INSERT INTO item_modifier_groups (id, item_id, name, required, min_select, max_select, sort_order)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+`, id, itemID, name, req, minSelect, maxSelect, sortOrder)
+	if err != nil {
+		return "", fmt.Errorf("insert modifier group: %w", err)
+	}
+	return id, nil
+}
+
+// UpdateGroup edits an existing modifier group's fields.
+func (r *ModifierRepo) UpdateGroup(ctx context.Context, id, name string, required bool, minSelect, maxSelect, sortOrder int, isActive bool) error {
+	if id == "" {
+		return errors.New("id required")
+	}
+	if name == "" {
+		return errors.New("name required")
+	}
+	req, active := 0, 0
+	if required {
+		req = 1
+	}
+	if isActive {
+		active = 1
+	}
+	_, err := r.db.ExecContext(ctx, `
+UPDATE item_modifier_groups
+SET name = ?, required = ?, min_select = ?, max_select = ?, sort_order = ?, is_active = ?
+WHERE id = ?
+`, name, req, minSelect, maxSelect, sortOrder, active, id)
+	if err != nil {
+		return fmt.Errorf("update modifier group: %w", err)
+	}
+	return nil
+}
+
+// DeleteGroup removes a group and its options (ON DELETE CASCADE).
+func (r *ModifierRepo) DeleteGroup(ctx context.Context, id string) error {
+	if id == "" {
+		return errors.New("id required")
+	}
+	_, err := r.db.ExecContext(ctx, `DELETE FROM item_modifier_groups WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete modifier group: %w", err)
+	}
+	return nil
+}
+
+// CreateOption adds a selectable option to a modifier group.
+func (r *ModifierRepo) CreateOption(ctx context.Context, id, groupID, name string, priceDeltaMinor int64, sortOrder int) (string, error) {
+	if groupID == "" {
+		return "", errors.New("group_id required")
+	}
+	if name == "" {
+		return "", errors.New("name required")
+	}
+	if priceDeltaMinor < 0 {
+		return "", errors.New("price_delta_minor must be >= 0 (additive-only in v1)")
+	}
+	_, err := r.db.ExecContext(ctx, `
+INSERT INTO item_modifier_options (id, group_id, name, price_delta_minor, sort_order)
+VALUES (?, ?, ?, ?, ?)
+`, id, groupID, name, priceDeltaMinor, sortOrder)
+	if err != nil {
+		return "", fmt.Errorf("insert modifier option: %w", err)
+	}
+	return id, nil
+}
+
+// UpdateOption edits an existing option's fields.
+func (r *ModifierRepo) UpdateOption(ctx context.Context, id, name string, priceDeltaMinor int64, sortOrder int, isActive bool) error {
+	if id == "" {
+		return errors.New("id required")
+	}
+	if name == "" {
+		return errors.New("name required")
+	}
+	if priceDeltaMinor < 0 {
+		return errors.New("price_delta_minor must be >= 0 (additive-only in v1)")
+	}
+	active := 0
+	if isActive {
+		active = 1
+	}
+	_, err := r.db.ExecContext(ctx, `
+UPDATE item_modifier_options
+SET name = ?, price_delta_minor = ?, sort_order = ?, is_active = ?
+WHERE id = ?
+`, name, priceDeltaMinor, sortOrder, active, id)
+	if err != nil {
+		return fmt.Errorf("update modifier option: %w", err)
+	}
+	return nil
+}
+
+// DeleteOption removes a single option.
+func (r *ModifierRepo) DeleteOption(ctx context.Context, id string) error {
+	if id == "" {
+		return errors.New("id required")
+	}
+	_, err := r.db.ExecContext(ctx, `DELETE FROM item_modifier_options WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete modifier option: %w", err)
+	}
+	return nil
+}
+
+// SelectedModifier is one chosen option, snapshotted at sale time (name +
+// price delta as they were when the sale happened — never re-read from the
+// option row later). GroupID/OptionID are kept for reporting only.
+type SelectedModifier struct {
+	GroupID         string
+	OptionID        string
+	GroupName       string
+	OptionName      string
+	PriceDeltaMinor int64
+}
+
+// InsertSaleLineModifiers persists a sale line's chosen modifiers. Called
+// inside the same transaction as InsertSaleLine, after it, using the same
+// lineID.
+func (r *POSRepo) InsertSaleLineModifiers(ctx context.Context, tx *sql.Tx, lineID string, mods []SelectedModifier) error {
+	if len(mods) == 0 {
+		return nil
+	}
+	stmt, err := tx.PrepareContext(ctx, `
+INSERT INTO sale_line_modifiers (id, sale_line_id, group_id, option_id, group_name_snapshot, option_name_snapshot, price_delta_minor)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+`)
+	if err != nil {
+		return fmt.Errorf("prepare insert sale_line_modifiers: %w", err)
+	}
+	defer stmt.Close()
+	for _, m := range mods {
+		if _, err := stmt.ExecContext(ctx, uuid.NewString(), lineID, nullableString(m.GroupID), nullableString(m.OptionID), m.GroupName, m.OptionName, m.PriceDeltaMinor); err != nil {
+			return fmt.Errorf("insert sale_line_modifier: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/data/modifier_repo_test.go
+++ b/internal/data/modifier_repo_test.go
@@ -1,0 +1,132 @@
+package data_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/data"
+	"github.com/universaltill/universal-till/internal/db"
+)
+
+func openModifierTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	d, err := db.Open(filepath.Join(t.TempDir(), "mod.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	return d
+}
+
+func TestModifierRepo_CreateAndListGroups(t *testing.T) {
+	d := openModifierTestDB(t)
+	ctx := context.Background()
+	if _, err := d.DB.ExecContext(ctx, `INSERT INTO items (id, sku, name, base_price, is_active) VALUES ('itm1','SKU1','Flat White',320,1)`); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := data.NewModifierRepo(d.DB)
+	gid, err := repo.CreateGroup(ctx, "g1", "itm1", "Extras", false, 0, 2, 1)
+	if err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+	if _, err := repo.CreateOption(ctx, "o1", gid, "Extra shot", 50, 1); err != nil {
+		t.Fatalf("CreateOption: %v", err)
+	}
+	if _, err := repo.CreateOption(ctx, "o2", gid, "Oat milk", 40, 2); err != nil {
+		t.Fatalf("CreateOption: %v", err)
+	}
+
+	groups, err := repo.ListGroupsForItem(ctx, "itm1")
+	if err != nil {
+		t.Fatalf("ListGroupsForItem: %v", err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	g := groups[0]
+	if g.Name != "Extras" || g.Required || g.MaxSelect != 2 {
+		t.Fatalf("unexpected group: %+v", g)
+	}
+	if len(g.Options) != 2 || g.Options[0].Name != "Extra shot" || g.Options[0].PriceDeltaMinor != 50 {
+		t.Fatalf("unexpected options: %+v", g.Options)
+	}
+}
+
+// A deactivated group (or option) must not appear to the sale-time caller —
+// this is how a manager retires a customization without deleting sale
+// history that referenced it.
+func TestModifierRepo_ListGroupsForItem_SkipsInactive(t *testing.T) {
+	d := openModifierTestDB(t)
+	ctx := context.Background()
+	if _, err := d.DB.ExecContext(ctx, `INSERT INTO items (id, sku, name, base_price, is_active) VALUES ('itm1','SKU1','Flat White',320,1)`); err != nil {
+		t.Fatal(err)
+	}
+	repo := data.NewModifierRepo(d.DB)
+
+	activeID, _ := repo.CreateGroup(ctx, "g-active", "itm1", "Extras", false, 0, 1, 1)
+	inactiveID, _ := repo.CreateGroup(ctx, "g-inactive", "itm1", "Retired", false, 0, 1, 2)
+	if err := repo.UpdateGroup(ctx, inactiveID, "Retired", false, 0, 1, 2, false); err != nil {
+		t.Fatalf("UpdateGroup (deactivate): %v", err)
+	}
+	if _, err := repo.CreateOption(ctx, "o-active", activeID, "Extra shot", 50, 1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.CreateOption(ctx, "o-inactive-opt", activeID, "Retired option", 10, 2); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.UpdateOption(ctx, "o-inactive-opt", "Retired option", 10, 2, false); err != nil {
+		t.Fatalf("UpdateOption (deactivate): %v", err)
+	}
+
+	groups, err := repo.ListGroupsForItem(ctx, "itm1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(groups) != 1 || groups[0].ID != activeID {
+		t.Fatalf("expected only the active group, got %+v", groups)
+	}
+	if len(groups[0].Options) != 1 || groups[0].Options[0].ID != "o-active" {
+		t.Fatalf("expected only the active option, got %+v", groups[0].Options)
+	}
+}
+
+func TestModifierRepo_DeleteGroupCascadesOptions(t *testing.T) {
+	d := openModifierTestDB(t)
+	ctx := context.Background()
+	if _, err := d.DB.ExecContext(ctx, `INSERT INTO items (id, sku, name, base_price, is_active) VALUES ('itm1','SKU1','Flat White',320,1)`); err != nil {
+		t.Fatal(err)
+	}
+	repo := data.NewModifierRepo(d.DB)
+	gid, _ := repo.CreateGroup(ctx, "g1", "itm1", "Extras", false, 0, 1, 1)
+	if _, err := repo.CreateOption(ctx, "o1", gid, "Extra shot", 50, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.DeleteGroup(ctx, gid); err != nil {
+		t.Fatalf("DeleteGroup: %v", err)
+	}
+
+	var n int
+	if err := d.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM item_modifier_options WHERE group_id = ?`, gid).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("expected options cascade-deleted with their group, got %d remaining", n)
+	}
+}
+
+func TestModifierRepo_CreateOption_RejectsNegativeDelta(t *testing.T) {
+	d := openModifierTestDB(t)
+	ctx := context.Background()
+	if _, err := d.DB.ExecContext(ctx, `INSERT INTO items (id, sku, name, base_price, is_active) VALUES ('itm1','SKU1','Flat White',320,1)`); err != nil {
+		t.Fatal(err)
+	}
+	repo := data.NewModifierRepo(d.DB)
+	gid, _ := repo.CreateGroup(ctx, "g1", "itm1", "Extras", false, 0, 1, 1)
+
+	if _, err := repo.CreateOption(ctx, "o1", gid, "No cheese", -50, 1); err == nil {
+		t.Fatal("expected negative price_delta_minor to be rejected (additive-only in v1)")
+	}
+}

--- a/internal/db/migrations/017_item_modifiers.sql
+++ b/internal/db/migrations/017_item_modifiers.sql
@@ -1,0 +1,53 @@
+-- 017: item modifiers (ADR-0020, spec 011) — customization options attached
+-- to a catalog item (e.g. "Extras: add shot +£0.50", "Bread: white/wheat/rye"),
+-- shared by the cashier till and the (future) self-order kiosk. A sale
+-- line's chosen modifiers are SNAPSHOTTED at time of sale (name + price
+-- delta), never a live FK to the option row — a later catalog edit must
+-- never rewrite a past receipt.
+
+CREATE TABLE IF NOT EXISTS item_modifier_groups (
+    id          TEXT PRIMARY KEY,
+    item_id     TEXT NOT NULL,
+    name        TEXT NOT NULL,
+    required    INTEGER NOT NULL DEFAULT 0,   -- 1 = customer must pick within min/max
+    min_select  INTEGER NOT NULL DEFAULT 0,
+    max_select  INTEGER NOT NULL DEFAULT 1,   -- 1 = single-pick, >1 = multi-pick
+    sort_order  INTEGER NOT NULL DEFAULT 0,
+    is_active   INTEGER NOT NULL DEFAULT 1,
+    FOREIGN KEY (item_id) REFERENCES items (id) ON DELETE CASCADE,
+    CHECK (min_select >= 0 AND max_select >= min_select)
+);
+
+CREATE INDEX IF NOT EXISTS idx_item_modifier_groups_item
+    ON item_modifier_groups (item_id);
+
+CREATE TABLE IF NOT EXISTS item_modifier_options (
+    id                TEXT PRIMARY KEY,
+    group_id          TEXT NOT NULL,
+    name              TEXT NOT NULL,
+    price_delta_minor INTEGER NOT NULL DEFAULT 0,  -- minor units, additive-only (v1)
+    sort_order        INTEGER NOT NULL DEFAULT 0,
+    is_active         INTEGER NOT NULL DEFAULT 1,
+    FOREIGN KEY (group_id) REFERENCES item_modifier_groups (id) ON DELETE CASCADE,
+    CHECK (price_delta_minor >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_item_modifier_options_group
+    ON item_modifier_options (group_id);
+
+-- One row per chosen option on a sale line. Snapshotted, not FK'd to the
+-- option's current state — group_id/option_id are kept only for reporting
+-- ("how often was extra shot picked"), never re-read for pricing.
+CREATE TABLE IF NOT EXISTS sale_line_modifiers (
+    id                     TEXT PRIMARY KEY,
+    sale_line_id           TEXT NOT NULL,
+    group_id               TEXT,             -- nullable: source group may since be deleted
+    option_id              TEXT,             -- nullable: source option may since be deleted
+    group_name_snapshot    TEXT NOT NULL,
+    option_name_snapshot   TEXT NOT NULL,
+    price_delta_minor      INTEGER NOT NULL,
+    FOREIGN KEY (sale_line_id) REFERENCES sale_lines (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_sale_line_modifiers_line
+    ON sale_line_modifiers (sale_line_id);

--- a/internal/pages/pos_api.go
+++ b/internal/pages/pos_api.go
@@ -287,6 +287,7 @@ func registerPOSAPI(mux *http.ServeMux, d *common.Deps) {
 				TaxRateBasisPoints: taxBP,
 				LineDiscount:       l.LineDiscount,
 				LocationID:         locID,
+				Modifiers:          l.Modifiers,
 			})
 		}
 

--- a/internal/pos/hold.go
+++ b/internal/pos/hold.go
@@ -1,21 +1,25 @@
 package pos
 
-import "github.com/universaltill/universal-till/internal/money"
+import (
+	"github.com/universaltill/universal-till/internal/data"
+	"github.com/universaltill/universal-till/internal/money"
+)
 
 // SnapshotLine is a BasketLine with every field serialized — BasketLine hides
 // ItemID/VariantID/TaxRateBP/IsWeighed from the wire (json:"-"), but a held
 // sale must restore them so pricing and completion behave identically.
 type SnapshotLine struct {
-	SKU          string      `json:"sku"`
-	Name         string      `json:"name"`
-	Qty          float64     `json:"qty"`
-	PriceCents   money.Money `json:"price_cents"`
-	LineDiscount money.Money `json:"line_discount,omitempty"`
-	ImageURL     string      `json:"image_url,omitempty"`
-	ItemID       string      `json:"item_id,omitempty"`
-	VariantID    string      `json:"variant_id,omitempty"`
-	TaxRateBP    int         `json:"tax_rate_bp,omitempty"`
-	IsWeighed    bool        `json:"is_weighed,omitempty"`
+	SKU          string                  `json:"sku"`
+	Name         string                  `json:"name"`
+	Qty          float64                 `json:"qty"`
+	PriceCents   money.Money             `json:"price_cents"`
+	LineDiscount money.Money             `json:"line_discount,omitempty"`
+	ImageURL     string                  `json:"image_url,omitempty"`
+	ItemID       string                  `json:"item_id,omitempty"`
+	VariantID    string                  `json:"variant_id,omitempty"`
+	TaxRateBP    int                     `json:"tax_rate_bp,omitempty"`
+	IsWeighed    bool                    `json:"is_weighed,omitempty"`
+	Modifiers    []data.SelectedModifier `json:"modifiers,omitempty"` // ADR-0020: a held sale must not silently drop customizations on recall
 }
 
 // BasketSnapshot captures the full in-progress sale state for hold/resume.
@@ -51,6 +55,7 @@ func (s *Service) Snapshot() BasketSnapshot {
 			PriceCents: l.PriceCents, LineDiscount: l.LineDiscount,
 			ImageURL: l.ImageURL, ItemID: l.ItemID, VariantID: l.VariantID,
 			TaxRateBP: l.TaxRateBP, IsWeighed: l.IsWeighed,
+			Modifiers: l.Modifiers,
 		})
 	}
 	return snap
@@ -65,6 +70,7 @@ func (s *Service) Restore(snap BasketSnapshot) {
 			PriceCents: l.PriceCents, LineDiscount: l.LineDiscount,
 			ImageURL: l.ImageURL, ItemID: l.ItemID, VariantID: l.VariantID,
 			TaxRateBP: l.TaxRateBP, IsWeighed: l.IsWeighed,
+			Modifiers: l.Modifiers,
 		})
 	}
 	s.discountType = snap.DiscountType

--- a/internal/pos/hold_test.go
+++ b/internal/pos/hold_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/universaltill/universal-till/internal/data"
 	"github.com/universaltill/universal-till/internal/money"
 )
 
@@ -88,5 +89,40 @@ func TestHasItems(t *testing.T) {
 	s.Reset()
 	if s.HasItems() {
 		t.Fatal("expected empty after reset")
+	}
+}
+
+// ADR-0020: a held sale must not silently drop a customer's chosen
+// modifiers on recall — the whole point of hold/resume is serving another
+// customer without losing what's already in progress.
+func TestSnapshotRestoreRoundTrip_PreservesModifiers(t *testing.T) {
+	s := newHoldService()
+	base := BasketLine{SKU: "A", Name: "Apples", PriceCents: money.FromMinor(150), ItemID: "itm-a", TaxRateBP: 2000}
+	mods := []data.SelectedModifier{{GroupID: "g1", OptionID: "opt1", GroupName: "Size", OptionName: "Large", PriceDeltaMinor: 30}}
+	s.AddLineWithModifiers(base, 1, mods)
+	want := s.Basket()
+
+	snap := s.Snapshot()
+	raw, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back BasketSnapshot
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatal(err)
+	}
+
+	s.Reset()
+	s.Restore(back)
+	got := s.Basket()
+
+	if got.Total != want.Total {
+		t.Fatalf("restored total %v, want %v (modifier price delta lost?)", got.Total, want.Total)
+	}
+	if len(got.Lines) != 1 || len(got.Lines[0].Modifiers) != 1 {
+		t.Fatalf("expected 1 line with 1 modifier restored, got %+v", got.Lines)
+	}
+	if got.Lines[0].Modifiers[0].OptionName != "Large" || got.Lines[0].Modifiers[0].PriceDeltaMinor != 30 {
+		t.Fatalf("modifier snapshot corrupted on restore: %+v", got.Lines[0].Modifiers[0])
 	}
 }

--- a/internal/pos/modifiers_test.go
+++ b/internal/pos/modifiers_test.go
@@ -1,0 +1,111 @@
+package pos
+
+import (
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/data"
+)
+
+// FR/ADR-0020: a modifier's price delta is folded into the line's
+// PriceCents at add-time so the rest of the money pipeline (totals, tax,
+// receipts) needs no special-casing.
+func TestAddLineWithModifiers_FoldsDeltaIntoPrice(t *testing.T) {
+	s := NewServiceWithResolver(Config{TaxRateBasisPoints: 2000, TaxInclusive: false}, mapResolver{})
+
+	base := BasketLine{SKU: "COFFEE", ItemID: "item-coffee", Name: "Flat White", PriceCents: 320}
+	mods := []data.SelectedModifier{
+		{GroupID: "g1", OptionID: "extra-shot", GroupName: "Extras", OptionName: "Extra shot", PriceDeltaMinor: 50},
+	}
+	s.AddLineWithModifiers(base, 1, mods)
+
+	b := s.Basket()
+	if len(b.Lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(b.Lines))
+	}
+	if b.Lines[0].PriceCents != 370 {
+		t.Fatalf("expected effective price 370 (320+50), got %d", b.Lines[0].PriceCents)
+	}
+	if b.Subtotal != 370 {
+		t.Fatalf("expected subtotal 370, got %d", b.Subtotal)
+	}
+	if len(b.Lines[0].Modifiers) != 1 || b.Lines[0].Modifiers[0].OptionName != "Extra shot" {
+		t.Fatalf("expected modifier snapshot to be kept for display, got %+v", b.Lines[0].Modifiers)
+	}
+}
+
+// Two identical customizations of the same item must merge quantity into
+// one line, exactly like plain items do today.
+func TestAddLineWithModifiers_IdenticalSelectionsMerge(t *testing.T) {
+	s := NewServiceWithResolver(Config{TaxRateBasisPoints: 2000, TaxInclusive: false}, mapResolver{})
+	base := BasketLine{SKU: "COFFEE", ItemID: "item-coffee", Name: "Flat White", PriceCents: 320}
+	mods := []data.SelectedModifier{{OptionID: "extra-shot", OptionName: "Extra shot", PriceDeltaMinor: 50}}
+
+	s.AddLineWithModifiers(base, 1, mods)
+	s.AddLineWithModifiers(base, 1, mods)
+
+	b := s.Basket()
+	if len(b.Lines) != 1 {
+		t.Fatalf("expected identical selections to merge into 1 line, got %d: %+v", len(b.Lines), b.Lines)
+	}
+	if b.Lines[0].Qty != 2 {
+		t.Fatalf("expected merged qty 2, got %v", b.Lines[0].Qty)
+	}
+}
+
+// A plain "Flat White" and a "Flat White + extra shot" price and print
+// differently — they must never merge into one line even though they
+// share the same SKU/ItemID.
+func TestAddLineWithModifiers_DifferentSelectionsDoNotMerge(t *testing.T) {
+	s := NewServiceWithResolver(Config{TaxRateBasisPoints: 2000, TaxInclusive: false}, mapResolver{})
+	base := BasketLine{SKU: "COFFEE", ItemID: "item-coffee", Name: "Flat White", PriceCents: 320}
+
+	s.AddLineWithModifiers(base, 1, nil)
+	s.AddLineWithModifiers(base, 1, []data.SelectedModifier{{OptionID: "extra-shot", OptionName: "Extra shot", PriceDeltaMinor: 50}})
+
+	b := s.Basket()
+	if len(b.Lines) != 2 {
+		t.Fatalf("expected 2 distinct lines (plain vs. customized), got %d: %+v", len(b.Lines), b.Lines)
+	}
+}
+
+// Selection order must not affect the merge signature — "extra shot +
+// oat milk" and "oat milk + extra shot" are the same customization.
+func TestModifierSignature_OrderIndependent(t *testing.T) {
+	a := BasketLine{Modifiers: []data.SelectedModifier{{OptionID: "shot"}, {OptionID: "oat"}}}
+	b := BasketLine{Modifiers: []data.SelectedModifier{{OptionID: "oat"}, {OptionID: "shot"}}}
+	if a.ModifierSignature() != b.ModifierSignature() {
+		t.Fatalf("expected order-independent signatures to match: %q vs %q", a.ModifierSignature(), b.ModifierSignature())
+	}
+}
+
+func TestModifierSignature_EmptyForNoModifiers(t *testing.T) {
+	if got := (BasketLine{}).ModifierSignature(); got != "" {
+		t.Fatalf("expected empty signature for a plain line, got %q", got)
+	}
+}
+
+// DOCUMENTS A KNOWN GAP (see Remove's doc comment in service.go), it does
+// not assert desired behavior: Remove(sku) deletes EVERY line sharing that
+// SKU, which is unsafe once two modifier-distinct lines can share one SKU.
+// This test exists so task #2's UI work cannot wire "remove this line" to
+// Remove(sku) for a modifier-bearing item without this test forcing an
+// explicit, deliberate decision (fail loudly here, not silently in
+// production). If this test starts failing because Remove became
+// line-specific, that's progress — update/delete this test as part of that
+// fix, don't just patch it to pass again.
+func TestRemove_KnownGap_DeletesAllLinesSharingSKU(t *testing.T) {
+	s := NewServiceWithResolver(Config{TaxRateBasisPoints: 2000, TaxInclusive: false}, mapResolver{})
+	base := BasketLine{SKU: "COFFEE", ItemID: "item-coffee", Name: "Flat White", PriceCents: 320}
+
+	s.AddLineWithModifiers(base, 1, nil)
+	s.AddLineWithModifiers(base, 1, []data.SelectedModifier{{OptionID: "extra-shot", OptionName: "Extra shot", PriceDeltaMinor: 50}})
+	if len(s.Basket().Lines) != 2 {
+		t.Fatalf("setup: expected 2 distinct lines before Remove")
+	}
+
+	s.Remove("COFFEE")
+
+	if len(s.Basket().Lines) != 0 {
+		t.Fatalf("known-gap assumption changed: expected Remove(sku) to still delete ALL same-SKU lines (got %d remaining) — if this is now line-specific, update this test and task #2's blocker note", len(s.Basket().Lines))
+	}
+}

--- a/internal/pos/sales.go
+++ b/internal/pos/sales.go
@@ -41,10 +41,11 @@ type SaleLineInput struct {
 	Barcode            string
 	Name               string
 	Qty                float64     // REAL; supports weighed items
-	UnitPrice          money.Money // minor units, before discount
+	UnitPrice          money.Money // minor units, before discount; already includes any modifier price deltas (ADR-0020)
 	TaxRateBasisPoints int
 	LineDiscount       money.Money // fixed minor units
 	LocationID         string      // stock movement location
+	Modifiers          []data.SelectedModifier
 }
 
 type PaymentInput struct {
@@ -244,6 +245,10 @@ func CompleteSale(ctx context.Context, sqlDB *sql.DB, in SaleInput) (string, err
 				}
 
 				if err := repo.InsertSaleLine(ctx, tx, lineID, saleID, i+1, l.ItemID, l.VariantID, l.Name, l.SKU, l.Barcode, l.Qty, l.UnitPrice.Minor(), l.LineDiscount.Minor(), l.TaxRateBasisPoints, lineTax.Minor(), totalBeforeTax.Minor(), totalAfterTax.Minor()); err != nil {
+					return err
+				}
+
+				if err := repo.InsertSaleLineModifiers(ctx, tx, lineID, l.Modifiers); err != nil {
 					return err
 				}
 

--- a/internal/pos/sales_test.go
+++ b/internal/pos/sales_test.go
@@ -38,6 +38,7 @@ func setupSaleDB(t *testing.T) *sql.DB {
 		`CREATE TABLE item_variants (id TEXT PRIMARY KEY, item_id TEXT NOT NULL, price INTEGER NOT NULL, is_active INTEGER NOT NULL DEFAULT 1);`,
 		`CREATE TABLE sales (id TEXT PRIMARY KEY, receipt_no TEXT NOT NULL UNIQUE, status TEXT NOT NULL, sale_type TEXT NOT NULL, tender_type TEXT NOT NULL DEFAULT 'unknown', offline INTEGER NOT NULL DEFAULT 0, sync_status TEXT NOT NULL DEFAULT 'queued', sync_attempts INTEGER NOT NULL DEFAULT 0, sync_next_attempt_at TEXT, sync_last_error TEXT, register_id TEXT, cashier_id TEXT, customer_id TEXT, currency TEXT NOT NULL, subtotal INTEGER NOT NULL, discount_total INTEGER NOT NULL, tax_total INTEGER NOT NULL, total INTEGER NOT NULL, rounding INTEGER NOT NULL DEFAULT 0, note TEXT, created_at TEXT NOT NULL, completed_at TEXT, voided_at TEXT);`,
 		`CREATE TABLE sale_lines (id TEXT PRIMARY KEY, sale_id TEXT NOT NULL, line_no INTEGER NOT NULL, item_id TEXT, variant_id TEXT, name_snapshot TEXT NOT NULL, sku_snapshot TEXT, barcode_snapshot TEXT, quantity REAL NOT NULL, unit_price INTEGER NOT NULL, line_discount INTEGER NOT NULL DEFAULT 0, tax_rate_bp INTEGER NOT NULL, tax_amount INTEGER NOT NULL, total_before_tax INTEGER NOT NULL, total_after_tax INTEGER NOT NULL, FOREIGN KEY (sale_id) REFERENCES sales(id));`,
+		`CREATE TABLE sale_line_modifiers (id TEXT PRIMARY KEY, sale_line_id TEXT NOT NULL, group_id TEXT, option_id TEXT, group_name_snapshot TEXT NOT NULL, option_name_snapshot TEXT NOT NULL, price_delta_minor INTEGER NOT NULL, FOREIGN KEY (sale_line_id) REFERENCES sale_lines(id));`,
 		`CREATE TABLE sale_discounts (id TEXT PRIMARY KEY, sale_id TEXT NOT NULL, line_id TEXT, type TEXT NOT NULL, value INTEGER NOT NULL, amount INTEGER NOT NULL, reason TEXT);`,
 		`CREATE TABLE payments (id TEXT PRIMARY KEY, sale_id TEXT NOT NULL, method_id TEXT NOT NULL, amount INTEGER NOT NULL, currency TEXT NOT NULL, reference TEXT, change_given INTEGER NOT NULL DEFAULT 0, paid_at TEXT NOT NULL, FOREIGN KEY (sale_id) REFERENCES sales(id));`,
 		`CREATE TABLE sale_links (id TEXT PRIMARY KEY, sale_id TEXT NOT NULL, original_sale_id TEXT NOT NULL, reason TEXT);`,
@@ -118,6 +119,77 @@ func TestCompleteSale_SucceedsAndWritesRows(t *testing.T) {
 	_ = db.QueryRow(`SELECT quantity FROM inventory WHERE item_id='itm1' AND location_id='loc1'`).Scan(&qty)
 	if qty != 3 {
 		t.Fatalf("expected inventory 3, got %v", qty)
+	}
+}
+
+// ADR-0020: a sale line's chosen modifiers persist as their own rows,
+// snapshotted (name + delta) rather than FK'd to the live option, and the
+// line's unit_price already reflects the folded-in delta — no separate
+// modifier-total column, no double-counting.
+func TestCompleteSale_PersistsModifiers(t *testing.T) {
+	ctx := context.Background()
+	db := setupSaleDB(t)
+	defer db.Close()
+
+	_, _ = db.Exec(`INSERT INTO stock_locations(id,name) VALUES('loc1','Main')`)
+	_, _ = db.Exec(`INSERT INTO items(id, sku, name, base_price, is_active) VALUES('itm1','COFFEE','Flat White', 320, 1)`)
+	_, _ = db.Exec(`INSERT INTO inventory(id, item_id, variant_id, location_id, quantity, updated_at) VALUES('inv1','itm1',NULL,'loc1',5,datetime('now'))`)
+	_, _ = db.Exec(`INSERT INTO payment_methods(id,name,type,is_active) VALUES('cash','Cash','cash',1)`)
+
+	in := SaleInput{
+		SaleType:     "sale",
+		RegisterID:   "reg1",
+		CashierID:    "user1",
+		Currency:     "GBP",
+		TaxInclusive: false,
+		Lines: []SaleLineInput{
+			{
+				ItemID:             "itm1",
+				SKU:                "COFFEE",
+				Name:               "Flat White",
+				Qty:                1,
+				UnitPrice:          370, // 320 base + 50 extra-shot delta, already folded in by the engine
+				TaxRateBasisPoints: 2000,
+				LocationID:         "loc1",
+				Modifiers: []data.SelectedModifier{
+					{GroupID: "g1", OptionID: "opt1", GroupName: "Extras", OptionName: "Extra shot", PriceDeltaMinor: 50},
+				},
+			},
+		},
+		Payments: []PaymentInput{
+			{MethodID: "cash", Amount: 500, Currency: "GBP"},
+		},
+	}
+
+	saleID, err := CompleteSale(ctx, db, in)
+	if err != nil {
+		t.Fatalf("CompleteSale error: %v", err)
+	}
+
+	var lineID string
+	if err := db.QueryRow(`SELECT id FROM sale_lines WHERE sale_id = ?`, saleID).Scan(&lineID); err != nil {
+		t.Fatalf("query sale_line id: %v", err)
+	}
+
+	var groupName, optionName string
+	var delta int64
+	if err := db.QueryRow(`SELECT group_name_snapshot, option_name_snapshot, price_delta_minor FROM sale_line_modifiers WHERE sale_line_id = ?`, lineID).
+		Scan(&groupName, &optionName, &delta); err != nil {
+		t.Fatalf("expected 1 sale_line_modifiers row: %v", err)
+	}
+	if groupName != "Extras" || optionName != "Extra shot" || delta != 50 {
+		t.Fatalf("unexpected modifier row: group=%q option=%q delta=%d", groupName, optionName, delta)
+	}
+
+	// No double-counting: the persisted unit_price (and before-tax total,
+	// exclusive-tax mode) reflect the already-folded 370, not 320 with the
+	// +50 delta counted again anywhere else.
+	var unitPrice, totalBeforeTax int64
+	if err := db.QueryRow(`SELECT unit_price, total_before_tax FROM sale_lines WHERE id = ?`, lineID).Scan(&unitPrice, &totalBeforeTax); err != nil {
+		t.Fatal(err)
+	}
+	if unitPrice != 370 || totalBeforeTax != 370 {
+		t.Fatalf("expected unit_price/total_before_tax 370, got unit_price=%d total_before_tax=%d", unitPrice, totalBeforeTax)
 	}
 }
 

--- a/internal/pos/service.go
+++ b/internal/pos/service.go
@@ -1,8 +1,10 @@
 package pos
 
 import (
+	"sort"
 	"strings"
 
+	"github.com/universaltill/universal-till/internal/data"
 	"github.com/universaltill/universal-till/internal/money"
 )
 
@@ -56,17 +58,35 @@ func (s *Service) SetConfig(cfg Config) {
 func (s *Service) Config() Config { return s.cfg }
 
 type BasketLine struct {
-	SKU          string      `json:"sku"`
-	Name         string      `json:"name"`
-	Qty          float64     `json:"qty"`
-	PriceCents   money.Money `json:"priceCents"`
-	LineDiscount money.Money `json:"lineDiscount,omitempty"`
-	LineTotal    money.Money `json:"lineTotal,omitempty"`
-	ImageURL     string      `json:"imageUrl,omitempty"`
-	ItemID       string      `json:"-"`
-	VariantID    string      `json:"-"`
-	TaxRateBP    int         `json:"-"`
-	IsWeighed    bool        `json:"-"`
+	SKU          string                  `json:"sku"`
+	Name         string                  `json:"name"`
+	Qty          float64                 `json:"qty"`
+	PriceCents   money.Money             `json:"priceCents"` // effective unit price: base + sum(Modifiers deltas)
+	LineDiscount money.Money             `json:"lineDiscount,omitempty"`
+	LineTotal    money.Money             `json:"lineTotal,omitempty"`
+	ImageURL     string                  `json:"imageUrl,omitempty"`
+	ItemID       string                  `json:"-"`
+	VariantID    string                  `json:"-"`
+	TaxRateBP    int                     `json:"-"`
+	IsWeighed    bool                    `json:"-"`
+	Modifiers    []data.SelectedModifier `json:"modifiers,omitempty"` // ADR-0020: chosen customizations, already folded into PriceCents
+}
+
+// ModifierSignature is a stable key for two lines' modifier selections —
+// used to decide whether adding the same item again merges quantity into
+// an existing line or starts a new one. Two identical selections (same
+// options, any order) merge; anything else is a distinct line, since they
+// price and print differently.
+func (l BasketLine) ModifierSignature() string {
+	if len(l.Modifiers) == 0 {
+		return ""
+	}
+	ids := make([]string, len(l.Modifiers))
+	for i, m := range l.Modifiers {
+		ids[i] = m.OptionID
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, ",")
 }
 
 type Basket struct {
@@ -133,6 +153,27 @@ func (s *Service) scanQty(code string, qty float64) (*Basket, bool) {
 	return &s.basket, false
 }
 
+// AddLineWithModifiers adds a resolved base line to the basket with chosen
+// customizations applied (ADR-0020) — used by the modifier-selection step,
+// not the plain barcode-scan path. Price deltas are folded into PriceCents
+// here so the rest of the money pipeline (totals, tax, receipts, held-sale
+// snapshots) needs no changes; Modifiers is kept purely as a display/
+// persistence snapshot. base must already be resolved (via PriceResolver or
+// equivalent catalog lookup) with its plain, pre-modifier PriceCents.
+func (s *Service) AddLineWithModifiers(base BasketLine, qty float64, mods []data.SelectedModifier) *Basket {
+	if qty <= 0 {
+		qty = 1
+	}
+	line := base
+	line.Qty = qty
+	line.Modifiers = append([]data.SelectedModifier{}, mods...)
+	for _, m := range mods {
+		line.PriceCents = line.PriceCents.Add(money.FromMinor(m.PriceDeltaMinor))
+	}
+	s.mergeResolved(line)
+	return &s.basket
+}
+
 func (s *Service) HasLine(code string) bool {
 	code = strings.TrimSpace(code)
 	return code != "" && s.findLineIndex(code) >= 0
@@ -165,7 +206,14 @@ func (s *Service) cacheScan(code string, line BasketLine) {
 }
 
 func (s *Service) mergeResolved(line BasketLine) {
+	sig := line.ModifierSignature()
 	for i := range s.lines {
+		if s.lines[i].ModifierSignature() != sig {
+			// Same item/SKU but a different customization (e.g. "extra
+			// shot" vs. plain) prices and prints differently — must stay a
+			// distinct line, not merge quantity into the wrong one.
+			continue
+		}
 		if s.lines[i].SKU == line.SKU || (s.lines[i].ItemID == line.ItemID && s.lines[i].VariantID == line.VariantID) {
 			s.lines[i].Qty += line.Qty
 			s.lines[i].Name = line.Name
@@ -174,6 +222,7 @@ func (s *Service) mergeResolved(line BasketLine) {
 			s.lines[i].ItemID = line.ItemID
 			s.lines[i].VariantID = line.VariantID
 			s.lines[i].IsWeighed = line.IsWeighed
+			s.lines[i].Modifiers = line.Modifiers
 			if line.ImageURL != "" {
 				s.lines[i].ImageURL = line.ImageURL
 			}
@@ -261,6 +310,18 @@ func (s *Service) Basket() Basket {
 }
 
 // Remove removes a line by SKU (or item/variant ID fallback) and recomputes totals.
+//
+// KNOWN GAP (ADR-0020): this matches every line sharing sku, which was
+// always safe before modifiers existed (mergeResolved guaranteed at most
+// one line per SKU). Since AddLineWithModifiers can legitimately leave two
+// lines with the same SKU in the basket (e.g. plain "Flat White" and "Flat
+// White + extra shot" are different lines, see ModifierSignature), calling
+// Remove/UpdateLine with only a SKU/code now risks acting on the wrong one
+// of several same-SKU lines. Nothing calls AddLineWithModifiers yet, so
+// this has no live exposure — but the UI work that adds that call (spec
+// 011 Phase 1 UI, task #2) MUST NOT wire "remove"/"edit qty" buttons to
+// these SKU-keyed methods once an item can have multiple modifier-distinct
+// lines; it needs a line-index or line-ID-based variant instead.
 func (s *Service) Remove(sku string) {
 	filtered := s.lines[:0]
 	for _, l := range s.lines {
@@ -299,7 +360,11 @@ func (s *Service) clearCacheForCode(code string) {
 	}
 }
 
-// UpdateLine sets qty/discount for a given SKU (or item/variant match) and recomputes totals.
+// UpdateLine sets qty/discount for a given SKU (or item/variant match) and
+// recomputes totals. Matches only the FIRST line for code — same known gap
+// as Remove (see its doc comment): unsafe once multiple modifier-distinct
+// lines can share a SKU. Do not wire new UI to this for modifier-bearing
+// items without a line-index/line-ID variant first.
 func (s *Service) UpdateLine(code string, qty float64, discount money.Money) {
 	if qty < 0 {
 		qty = 0

--- a/specs/011-self-order-kiosk/spec.md
+++ b/specs/011-self-order-kiosk/spec.md
@@ -1,0 +1,83 @@
+# 011 — Self-order kiosk + item modifiers
+
+Decision record: `ut-docs/adr/0020-self-order-kiosk-and-item-modifiers.md`
+(read that first — this doc is the implementation breakdown, not the "why").
+
+## Goal
+A till installable as a self-order kiosk: customer browses/searches the
+catalog, customizes an item (modifiers), pays by card, order reaches
+whoever fulfills it. Connected to the shop's regular till and back-office
+via the existing multi-till sync (ADR-0011) — no new sync mechanism.
+
+## Phases (build and ship in this order — each is independently useful)
+
+### Phase 1 — Item modifiers (catalog data + cashier POS UI)
+Foundational: both the existing cashier till and the future kiosk need
+this. Ships value on its own (cashier can already ring up "flat white,
+extra shot" correctly) before the kiosk exists.
+
+- Migration (append-only): `item_modifier_groups` (id, item_id, name,
+  required, min_select, max_select, sort_order), `item_modifier_options`
+  (id, group_id, name, price_delta_minor, sort_order, is_active).
+- Sale line items: a snapshot of chosen options (name + price_delta at
+  time of sale — never a live FK to the option row, so a later catalog
+  edit can't rewrite history), stored as its own table
+  (`sale_line_modifiers` or similar) keyed to the sale line.
+- `ItemRepo`/`POSRepo` methods: list modifier groups+options for an item,
+  compute a line's total (base price + sum of chosen deltas).
+- Cashier POS UI: when an item with modifier groups is tapped, show a
+  selection step (respecting required/min/max) before it lands in the
+  cart; receipt shows the chosen modifiers as sub-lines.
+- Admin catalog UI: manage groups/options per item (add/edit/reorder/
+  deactivate).
+
+### Phase 2 — Self-order kiosk till mode (shell)
+- `display.mode` gains `self_order`. Settings UI: new option in the
+  existing mode selector (`web/ui/pages/settings.html`), manager-gated
+  like the existing `backoffice` option.
+- New route(s) for the self-order flow, locked behind the mode: a
+  self-order-mode till landing on `/` gets the kiosk flow, not the cashier
+  screen or a 403 — same role-aware-fallthrough pattern the backoffice-mode
+  review already established (audit every existing `mode == "backoffice"`
+  branch for a kiosk-mode gap while touching this).
+- No admin/settings surface reachable from the kiosk UI itself.
+- Idle timeout → reset to the start screen: extend the existing
+  `auth.idle_lock_minutes`/idle-lock mechanism rather than a second timer.
+
+### Phase 3 — Browse, search, customize, cart
+- Catalog browse (category chips + item grid, reusing existing catalog
+  data) sized for a customer-facing touchscreen, not the cashier's dense
+  button grid.
+- A real search box — doesn't exist anywhere in the sale flow today (only
+  the admin catalog editor has one). This is also the eventual target for
+  the keyboard-layout-plugin transliteration option, if/when that's built
+  (separate item, not blocking this phase).
+- Tapping an item with modifier groups shows the Phase 1 customization
+  step before add-to-cart; cart shows line + chosen modifiers + running
+  total.
+
+### Phase 4 — Checkout
+- Card/contactless payment only for v1 (existing payment plugin
+  taxonomy — no new extension point). No cash drawer interaction.
+- Order confirmation screen; receipt (print or on-screen, shop-configurable
+  like existing receipt settings).
+
+### Phase 5 — Order handoff / kitchen ticket
+- Shared mechanism with the phone/table-QR ordering backlog item (not
+  built twice). Scope this phase once Phase 1-4 are live and the shape of
+  a "kiosk order" is concrete — premature to design the ticket format
+  before real orders exist to look at.
+
+## Explicitly out of scope for v1
+- Cash acceptance at the kiosk (card/contactless only; cash-handling
+  hardware plugin is a later addition if a real shop needs it).
+- Negative/substitution modifiers ("no cheese" style) — price deltas are
+  additive-only for v1.
+- OS-level kiosk packaging (chromium --kiosk boot cage) — tracked
+  separately in QUEUE.md ("Pi kiosk" boot test), orthogonal to this spec.
+
+## Open questions to revisit once Phase 1-2 are live
+- Does a kiosk order need its own receipt-numbering prefix (like replica
+  tills already get, ADR-0011) for reporting clarity?
+- Multi-language: does the kiosk need an explicit language picker at the
+  start screen, or does it inherit the till's configured locale?


### PR DESCRIPTION
## Summary
- Phase 1 of spec 011 (self-order kiosk + item modifiers, ADR-0020) — top priority per Farshid. Headless: catalog data model + repo + basket-engine plumbing, no cashier UI yet (next task).
- New migration: `item_modifier_groups`/`item_modifier_options` (customization menu per catalog item, additive-only price deltas in v1) + `sale_line_modifiers` (immutable snapshot of what was chosen, never a live FK).
- Core design decision: a chosen modifier's price delta is folded into the basket line's existing `PriceCents` at add-time, so the entire downstream money pipeline (totals, tax, receipts, held-sale snapshots, refunds, sale-sync) needed **zero changes** — independently verified by the reviewer tracing every consumer, including the refund and sync paths not explicitly named in the review brief.
- Documents (doesn't fix — deliberately deferred, with a regression test forcing the next task to deal with it) a real gap this creates: `Service.Remove`/`UpdateLine` are SKU-keyed and unsafe once two modifier-distinct lines can share a SKU. No live exposure today (nothing calls the new `AddLineWithModifiers` outside tests) — confirmed by the reviewer grepping every caller repo-wide.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` (full suite, 28 packages, zero regressions), `guard-data-access.sh` all green
- [x] 12 new tests covering: price-folding correctness, merge/identity behavior (same vs. different customizations), hold/resume round-trip, sale-completion persistence + no-double-counting, full modifier-repo CRUD + cascade-delete + additive-only-price validation
- [x] Independent opus-model adversarial review, explicitly weighted toward money-correctness — no bugs found (`docs/code-reviews/2026-07-24-item-modifiers-phase1.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BLqeqAh51ZRQ2UPpAHJXgH