### PR TITLE
Carry item modifiers through to the kitchen ticket — ADR-0020 Phase 5

### DIFF
--- a/docs/code-reviews/2026-07-25-kitchen-ticket-modifiers.md
+++ b/docs/code-reviews/2026-07-25-kitchen-ticket-modifiers.md
@@ -1,0 +1,89 @@
+# 2026-07-25 — Kitchen ticket carries item modifiers (ADR-0020 Phase 5)
+
+## Context
+While scoping Phase 5 ("order handoff / kitchen ticket"), found that the
+kitchen-ticket mechanism (`internal/pages/kitchen_print.go`, fired async
+after every completed sale — cashier or kiosk, via `printKitchenAsync`
+inside `completeTender`) built its ticket from `POSRepo.GetSaleDetail`,
+which loaded each line's name/qty/price but never re-read the line's
+chosen modifiers (`sale_line_modifiers`, added in Phase 1) after the sale
+completed. Meanwhile `internal/print/kitchen.go`'s `KitchenItem` struct
+already had a `Modifiers []string` field with full ESC/POS rendering
+support (indented `- modifier` lines under each item, already tested) —
+that plumbing existed and was simply never fed real data. A customer's
+"extra shot" or "no onions" was silently dropped before it ever reached
+the kitchen printer, for both cashier and kiosk orders — directly
+undercutting the reason item modifiers exist at all (a real ask: "customer
+should be able to add extra shot to the coffee or customize the
+sandwich").
+
+This turned out to be nearly all of Phase 5's substance: the shared
+kitchen-ticket mechanism ADR-0020 called for already exists and already
+fires for kiosk orders (since kiosk checkout goes through the same
+`completeTender` pipeline as the cashier), so Phase 5 didn't need new
+plumbing — just this one real gap closed.
+
+## Design
+`SaleDetailLine` gained a `Modifiers []string` field. `GetSaleDetail`'s
+line query now also selects `sl.id` (previously unselected — nothing
+needed it), and a second, single query joins `sale_line_modifiers` to
+`sale_lines` on `sale_id = ?` (one query for the whole sale, not one per
+line) and groups `option_name_snapshot` by `sale_line_id` into a map;
+each line's modifiers are attached by looking up its own primary-key ID
+in that map — not by positional/index matching between two independently-
+ordered result sets, so there's no ordering assumption to get wrong.
+`buildKitchenTicket` (`kitchen_print.go`) now passes `l.Modifiers`
+through to `print.KitchenItem.Modifiers`, which the print layer already
+knew how to render.
+
+## Independent review
+Opus-model review, proportionate to a read-then-print change (no
+payment/inventory/tax logic touched) but with the join/index-matching
+and "no regression in refund/journal/invoice/sync" claims verified for
+real rather than assumed.
+
+**Confirmed correct:**
+- The modifier attachment is genuinely map-keyed by each line's own
+  `sale_lines.id` (a `TEXT PRIMARY KEY`, so no collision risk possible),
+  not an index pairing between two separately-ordered queries — reviewer
+  traced this precisely and confirmed the two queries' `ORDER BY` clauses
+  are irrelevant to correctness, only to display order within a line.
+- A line with zero modifiers gets a `nil` `Modifiers` (missing map key),
+  never an error or a misattributed neighbor.
+- The `defer`→explicit-`.Close()` refactor of `lineRows`/`modRows` has no
+  leak and no double-close on any exit path (traced every early return).
+- Every other `GetSaleDetail`/`GetSaleDetailByID` caller
+  (`journal_page.go`, `invoice_page.go`, `refund_page.go`, `pos_api.go`,
+  `sync_sales.go`) reads `SaleDetailLine` by named field only, none
+  references `.Modifiers`, and no template renders it — confirmed zero
+  behavior change for any of them, not just "should be fine."
+- The modifier fetch is one query for the whole sale (not N+1).
+- `RenderKitchenTicket`/`RenderKitchenTicketText` already correctly
+  skip empty/whitespace-only modifier strings and produce zero output
+  for a `nil` or empty `Modifiers` slice — no stray blank line risk.
+- **Reviewer ran a mutation test**: broke the map-grouping key, both new
+  tests failed with the expected wrong-output shape; reverted, both
+  passed — direct evidence the tests bite a real regression, not just
+  exercise the happy path.
+
+**No findings.** One minor, no-action observation: modifier display
+order relies on SQLite `rowid` (insertion order), since
+`sale_line_modifiers` has no snapshotted `sort_order` column — fine for
+a kitchen ticket's purposes, noted for awareness only.
+
+## Verification
+`go build ./...`, `go vet ./...`, `go test ./...` (full suite, zero
+regressions), `bash scripts/ci/guard-data-access.sh`,
+`bash scripts/ci/guard-i18n.sh` — all green, both by me and independently
+by the reviewer.
+
+Live-verified against a real built binary: seeded a real modifier
+group/option on a real catalog item via direct SQL, added it to a kiosk
+cart through the real HTTP modifier-picker flow, pointed
+`printer.kitchen_addr` at a local file (device-transport mode), completed
+the kiosk checkout for real, and inspected the raw ESC/POS bytes written
+— confirmed `Instant Coffee 200g` followed by `  - Extra shot` on the
+next line, exactly matching the expected ticket format.
+
+New tests: `TestPOSRepo_GetSaleDetail_IncludesLineModifiers`,
+`TestBuildKitchenTicket_IncludesLineModifiers`.

--- a/internal/data/pos_repo.go
+++ b/internal/data/pos_repo.go
@@ -2370,6 +2370,7 @@ type SaleDetailLine struct {
 	LineDiscount int64
 	TaxAmount    int64
 	LineTotal    int64
+	Modifiers    []string // chosen customization option names (ADR-0020), e.g. "Extra shot"
 }
 
 type SaleDetailPayment struct {
@@ -2414,23 +2415,57 @@ FROM sales WHERE receipt_no = ?`, receiptNo).Scan(
 	}
 
 	lineRows, err := r.db.QueryContext(ctx, `
-SELECT name_snapshot, COALESCE(sku_snapshot, ''), COALESCE(item_id, ''),
+SELECT id, name_snapshot, COALESCE(sku_snapshot, ''), COALESCE(item_id, ''),
        COALESCE(variant_id, ''), COALESCE(tax_rate_bp, 0), quantity, unit_price,
        line_discount, tax_amount, total_after_tax
 FROM sale_lines WHERE sale_id = ? ORDER BY line_no`, d.ID)
 	if err != nil {
 		return SaleDetail{}, false, fmt.Errorf("get sale lines: %w", err)
 	}
-	defer lineRows.Close()
+	var lineIDs []string
 	for lineRows.Next() {
+		var id string
 		var l SaleDetailLine
-		if err := lineRows.Scan(&l.Name, &l.SKU, &l.ItemID, &l.VariantID, &l.TaxRateBP, &l.Qty, &l.UnitPrice, &l.LineDiscount, &l.TaxAmount, &l.LineTotal); err != nil {
+		if err := lineRows.Scan(&id, &l.Name, &l.SKU, &l.ItemID, &l.VariantID, &l.TaxRateBP, &l.Qty, &l.UnitPrice, &l.LineDiscount, &l.TaxAmount, &l.LineTotal); err != nil {
+			lineRows.Close()
 			return SaleDetail{}, false, fmt.Errorf("scan sale line: %w", err)
 		}
+		lineIDs = append(lineIDs, id)
 		d.Lines = append(d.Lines, l)
 	}
 	if err := lineRows.Err(); err != nil {
+		lineRows.Close()
 		return SaleDetail{}, false, fmt.Errorf("iterate sale lines: %w", err)
+	}
+	lineRows.Close()
+
+	if len(lineIDs) > 0 {
+		modRows, err := r.db.QueryContext(ctx, `
+SELECT slm.sale_line_id, slm.option_name_snapshot
+FROM sale_line_modifiers slm
+JOIN sale_lines sl ON sl.id = slm.sale_line_id
+WHERE sl.sale_id = ?
+ORDER BY sl.line_no, slm.rowid`, d.ID)
+		if err != nil {
+			return SaleDetail{}, false, fmt.Errorf("get sale line modifiers: %w", err)
+		}
+		byLine := map[string][]string{}
+		for modRows.Next() {
+			var lineID, optName string
+			if err := modRows.Scan(&lineID, &optName); err != nil {
+				modRows.Close()
+				return SaleDetail{}, false, fmt.Errorf("scan sale line modifier: %w", err)
+			}
+			byLine[lineID] = append(byLine[lineID], optName)
+		}
+		if err := modRows.Err(); err != nil {
+			modRows.Close()
+			return SaleDetail{}, false, fmt.Errorf("iterate sale line modifiers: %w", err)
+		}
+		modRows.Close()
+		for i, id := range lineIDs {
+			d.Lines[i].Modifiers = byLine[id]
+		}
 	}
 
 	payRows, err := r.db.QueryContext(ctx, `

--- a/internal/data/pos_repo_sale_detail_test.go
+++ b/internal/data/pos_repo_sale_detail_test.go
@@ -1,0 +1,62 @@
+package data
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/db"
+)
+
+// GetSaleDetail must surface each line's chosen modifiers (ADR-0020) — the
+// kitchen ticket (internal/pages/kitchen_print.go) reads this to tell a cook
+// "extra shot" / "no onions" apply to a specific item, and nothing else in
+// the repo currently re-reads sale_line_modifiers after the sale completes.
+func TestPOSRepo_GetSaleDetail_IncludesLineModifiers(t *testing.T) {
+	t.Helper()
+	_, file, _, _ := runtime.Caller(0)
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	d, err := db.Open(filepath.Join(t.TempDir(), "sale_detail.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	ctx := context.Background()
+	mustExec := func(q string, args ...any) {
+		t.Helper()
+		if _, err := d.DB.Exec(q, args...); err != nil {
+			t.Fatalf("exec %s: %v", q, err)
+		}
+	}
+
+	mustExec(`INSERT INTO items (id, sku, name, base_price, is_active) VALUES ('itm-coffee','COFFEE','Flat White',370,1)`)
+	mustExec(`INSERT INTO items (id, sku, name, base_price, is_active) VALUES ('itm-tea','TEA','Tea',250,1)`)
+	mustExec(`INSERT INTO sales (id, receipt_no, status, sale_type, currency, subtotal, discount_total, tax_total, total, created_at) VALUES ('sale-1','R-0099','completed','sale','GBP',370,0,0,370,datetime('now'))`)
+	mustExec(`INSERT INTO sale_lines (id, sale_id, line_no, item_id, name_snapshot, quantity, unit_price, line_discount, tax_rate_bp, tax_amount, total_before_tax, total_after_tax) VALUES ('line-1','sale-1',1,'itm-coffee','Flat White',1,370,0,0,0,370,370)`)
+	mustExec(`INSERT INTO sale_lines (id, sale_id, line_no, item_id, name_snapshot, quantity, unit_price, line_discount, tax_rate_bp, tax_amount, total_before_tax, total_after_tax) VALUES ('line-2','sale-1',2,'itm-tea','Tea',1,250,0,0,0,250,250)`)
+	mustExec(`INSERT INTO sale_line_modifiers (id, sale_line_id, group_name_snapshot, option_name_snapshot, price_delta_minor) VALUES ('slm-1','line-1','Extras','Extra shot',50)`)
+	mustExec(`INSERT INTO sale_line_modifiers (id, sale_line_id, group_name_snapshot, option_name_snapshot, price_delta_minor) VALUES ('slm-2','line-1','Milk','Oat milk',0)`)
+
+	detail, ok, err := NewPOSRepo(d.DB).GetSaleDetail(ctx, "R-0099")
+	if err != nil {
+		t.Fatalf("GetSaleDetail: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected sale to be found")
+	}
+	if len(detail.Lines) != 2 {
+		t.Fatalf("want 2 lines, got %d", len(detail.Lines))
+	}
+	if got := detail.Lines[0].Modifiers; len(got) != 2 || got[0] != "Extra shot" || got[1] != "Oat milk" {
+		t.Fatalf("want [Extra shot, Oat milk] on line 1 (in insertion order), got %+v", got)
+	}
+	if got := detail.Lines[1].Modifiers; len(got) != 0 {
+		t.Fatalf("Tea line has no modifiers, got %+v", got)
+	}
+}

--- a/internal/pages/kitchen_print.go
+++ b/internal/pages/kitchen_print.go
@@ -39,8 +39,9 @@ func buildKitchenTicket(ctx context.Context, d *common.Deps, receiptNo string) (
 	}
 	for _, l := range detail.Lines {
 		t.Items = append(t.Items, print.KitchenItem{
-			Qty:  strconv.FormatFloat(l.Qty, 'f', -1, 64),
-			Name: l.Name,
+			Qty:       strconv.FormatFloat(l.Qty, 'f', -1, 64),
+			Name:      l.Name,
+			Modifiers: l.Modifiers,
 		})
 	}
 	return t, nil

--- a/internal/pages/kitchen_print_test.go
+++ b/internal/pages/kitchen_print_test.go
@@ -1,0 +1,50 @@
+package pages
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/db"
+	"github.com/universaltill/universal-till/internal/pages/common"
+	"github.com/universaltill/universal-till/internal/settings"
+)
+
+// buildKitchenTicket must carry each item's chosen modifiers through to the
+// cook — the whole point of ADR-0020's item modifiers (Farshid: "customer
+// should be able to add extra shot to the coffee or customize the
+// sandwich") is that the kitchen actually gets told. The print.KitchenTicket
+// rendering already supported per-item Modifiers (internal/print/kitchen.go)
+// before this change; the gap was that buildKitchenTicket never populated
+// them from the persisted sale.
+func TestBuildKitchenTicket_IncludesLineModifiers(t *testing.T) {
+	chdirRoot(t)
+	dbase, err := db.Open(filepath.Join(t.TempDir(), "kitchen.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbase.Close()
+
+	mustExec := func(q string, args ...any) {
+		t.Helper()
+		if _, err := dbase.DB.Exec(q, args...); err != nil {
+			t.Fatalf("exec %s: %v", q, err)
+		}
+	}
+	mustExec(`INSERT INTO items (id, sku, name, base_price, is_active) VALUES ('itm-coffee','COFFEE','Flat White',370,1)`)
+	mustExec(`INSERT INTO sales (id, receipt_no, status, sale_type, currency, subtotal, discount_total, tax_total, total, created_at) VALUES ('sale-1','R-0099','completed','sale','GBP',370,0,0,370,datetime('now'))`)
+	mustExec(`INSERT INTO sale_lines (id, sale_id, line_no, item_id, name_snapshot, quantity, unit_price, line_discount, tax_rate_bp, tax_amount, total_before_tax, total_after_tax) VALUES ('line-1','sale-1',1,'itm-coffee','Flat White',1,370,0,0,0,370,370)`)
+	mustExec(`INSERT INTO sale_line_modifiers (id, sale_line_id, group_name_snapshot, option_name_snapshot, price_delta_minor) VALUES ('slm-1','line-1','Extras','Extra shot',50)`)
+
+	dp := &common.Deps{Db: dbase.DB, Settings: settings.NewStore(dbase.DB)}
+	ticket, err := buildKitchenTicket(context.Background(), dp, "R-0099")
+	if err != nil {
+		t.Fatalf("buildKitchenTicket: %v", err)
+	}
+	if len(ticket.Items) != 1 {
+		t.Fatalf("want 1 item, got %d", len(ticket.Items))
+	}
+	if got := ticket.Items[0].Modifiers; len(got) != 1 || got[0] != "Extra shot" {
+		t.Fatalf("want kitchen ticket item to carry [Extra shot], got %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- `GetSaleDetail` never re-read a completed sale line's chosen modifiers (`sale_line_modifiers`, Phase 1) — so a customer's "extra shot" or "no onions" was silently dropped before reaching the kitchen printer, for both cashier and kiosk orders. `internal/print/kitchen.go` already had full `Modifiers []string` rendering support; it just never received real data.
- `SaleDetailLine` gains `Modifiers []string`; `GetSaleDetail` now joins `sale_line_modifiers` in one extra query per sale (not per line) and attaches each line's modifiers by its own primary-key ID (not positional/index matching).
- `buildKitchenTicket` now passes `l.Modifiers` through to the print layer.
- This closes out ADR-0020 Phase 5 — kiosk checkout already fires the shared kitchen-ticket mechanism via `completeTender` (Phase 4), so this one gap was effectively all that was left.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` — full suite green, zero regressions
- [x] `scripts/ci/guard-data-access.sh`, `scripts/ci/guard-i18n.sh` — green
- [x] New tests: `TestPOSRepo_GetSaleDetail_IncludesLineModifiers`, `TestBuildKitchenTicket_IncludesLineModifiers`
- [x] Live-verified against a real built binary: real modifier picker → kiosk checkout → inspected the raw ESC/POS bytes written to a file-backed kitchen printer, confirmed `  - Extra shot` prints under the item
- [x] Independent review (opus), including a mutation test proving the new tests catch a broken join — see `docs/code-reviews/2026-07-25-kitchen-ticket-modifiers.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BLqeqAh51ZRQ2UPpAHJXgH