### PR TITLE
Android/iOS shared-core Phase 1: internal/app.Run + mobile package (ADR-0023)

### DIFF
--- a/docs/code-reviews/2026-07-25-mobile-shared-core-phase1.md
+++ b/docs/code-reviews/2026-07-25-mobile-shared-core-phase1.md
@@ -1,0 +1,106 @@
+# 2026-07-25 — Android/iOS shared-core Phase 1 (ADR-0023, spec 013)
+
+## Context
+Farshid asked to raise Android till's priority and, in this session, to
+start building it. Confirmed first (not assumed): no Android SDK, no
+`gomobile`, no Xcode iOS SDK exist in this environment (`gomobile bind
+-target=android` fails immediately with "could not locate Android SDK" —
+run and observed directly). Scoped this session's work to exactly what's
+buildable and testable with plain `go build`/`go test` regardless of
+that: the Go-side groundwork `gomobile bind` will eventually wrap,
+deliberately not the native Kotlin/Swift shells themselves (hand-written,
+unbuildable, unverifiable native code would be worse than none).
+
+## Design
+- `internal/app.Run(ctx) error` — `main.go`'s full boot sequence
+  (config → DB/migrations → plugin host → marketplace enrolment →
+  pages/mux → background jobs → HTTP server), extracted verbatim so it's
+  callable from more than one entry point. `main.go` now just calls it.
+- `mobile/mobile.go` — the actual gomobile-bind surface: `Start(dataDir
+  string) (string, error)`, `Stop()`, `IsRunning() bool`. Runs
+  `internal/app.Run` in-process (mobile apps can't spawn a sibling
+  binary the way `cmd/unitill-desktop` does), same "start, poll
+  `/healthz`, then hand back an address" shape as the desktop shell.
+
+## Independent review
+Sonnet-model review, explicitly asked to verify the "behavior-preserving
+refactor" claim line-by-line against `main.go`'s git history, not just
+trust it, plus scrutinize `mobile.go`'s concurrency model.
+
+**Confirmed correct**: all 8 `log.Fatalf` call sites in the old `main.go`
+map 1:1 to `return err` in the same order in `internal/app/app.go`,
+nothing dropped or reordered; the pre-existing silent-swallow on
+`SaveRuntimeConfig`'s error is preserved exactly; `defer database.Close()`
+fires correctly across every return path including the final blocking
+`server.Start` call; env-var mutation via `os.Setenv` is safe against the
+package's own concurrent callers (synchronous before the `go` statement,
+serialized by the mutex); no incorrect comments.
+
+**One real, deliberate behavior difference found, not a bug**: the
+original inline `log.Fatalf` calls `os.Exit(1)`, skipping all deferred
+functions — a fatal boot failure after `db.Open` succeeded used to leave
+`database.Close()` never called. The extracted `Run` returns instead, so
+that same deferred close now genuinely executes on every fatal path.
+Checked every step for a dependency on the old abrupt-exit semantics —
+found none. Strict improvement (clean SQLite shutdown even on a fatal
+failure), documented rather than silently absorbed into an inaccurate
+"behavior-preserving" claim.
+
+**Four real bugs found in `mobile.go`'s first draft, all fixed:**
+
+1. **Lock held across the ~10s ready-wait.** `Start` held `mu` through
+   the whole blocking `waitUntilReady` call, so a concurrent `Stop()` or
+   `IsRunning()` could block for the full timeout — a real risk for the
+   exact scenario the code's own comment called out (iOS calling `Stop`
+   from a termination callback with a short OS watchdog budget, racing a
+   slow `Start`). Fixed: the lock now guards only brief state
+   transitions (swapping the `inst` pointer), never the actual blocking
+   start/stop work.
+2. **Stale success after an unobserved crash.** If the server died on
+   its own after a successful `Start` (e.g. a listener error, `Stop`
+   never called), nothing ever read the abandoned error channel —
+   `IsRunning()` and a subsequent `Start()` kept reporting the old,
+   dead address indefinitely. Fixed: both now check the instance's
+   `done` channel non-blockingly and correct the tracked state (and, for
+   `Start`, actually restart) instead of lying.
+3. **`Stop()` didn't actually drain.** It cancelled the context and
+   returned immediately, before `app.Run`'s goroutine (and its deferred
+   `database.Close()`) had actually finished — a native shell calling
+   `Stop()` then quickly `Start()`-ing again against the *same* on-device
+   data dir (backgrounded then rapidly foregrounded is a plausible real
+   sequence) could race the old instance's in-flight teardown against
+   the new instance's `db.Open()` on the same SQLite file. Fixed:
+   `Stop()` now blocks on a `done` channel until the server has
+   genuinely finished.
+4. **Different-`dataDir` `Start` while running silently ignored the new
+   value.** Minor, but a caller asking for a dataDir switch deserves an
+   error, not a silent no-op serving the old one. Fixed: now an explicit
+   error.
+
+Two test-quality gaps also fixed: the post-`Stop` liveness check used to
+poll and treat the first connection failure as conclusive (a real, if
+low-probability, false-pass risk) — now `Stop()` genuinely drains before
+returning, so a single deterministic check suffices. Added a test for
+the fast-fail path (`app.Run`'s goroutine erroring before `/healthz` ever
+answers, via a data dir that's a regular file instead of a directory)
+and a test for the crash-detection scenario in finding #2, neither of
+which existed before review.
+
+## Verification
+`go build ./...`, `go vet ./...`, `go test ./...` (full suite green,
+`mobile` package included), `go test ./mobile/... -race -count=3`
+(clean, no data races, zero flakes across 6 tests × 3 runs), both
+`scripts/ci/guard-*.sh` — all green, before AND after the fixes.
+
+Live-verified the refactored CLI entry point against a real built
+binary: boots, `/healthz` and `/report-issue` both 200, identical to
+pre-refactor. Also confirmed `cmd/unitill-desktop`'s separate `-tags
+desktop` build (a different `main` package, unaffected by this refactor
+in theory) still compiles.
+
+## Explicitly not attempted
+The actual native Android (Kotlin/Gradle) and iOS (Swift/Xcode) shells
+(spec 013 Phases 2/3) — no SDK/toolchain in this environment, confirmed
+by trying rather than assumed. Installing the Android SDK/NDK or Xcode
+was deliberately not done unprompted (multi-GB, environment-modifying);
+that's a decision for Farshid, not a default.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,0 +1,135 @@
+// Package app is the till's full boot sequence — config, DB/migrations,
+// plugin host, marketplace enrolment, pages/mux, background jobs, and the
+// HTTP server — factored out of main.go so it can be driven by more than
+// one entry point. cmd/unitill-desktop already proves the shared-core
+// pattern for desktop shells (spawn the same server binary, point a native
+// WebView at localhost); mobile/mobile.go (ADR-0023, spec: the Android/iOS
+// gomobile-bind shell) needs the identical boot sequence run IN-PROCESS
+// instead, since a mobile app can't spawn a sibling binary — this package
+// is what makes that possible without duplicating main.go's ~150 lines.
+package app
+
+import (
+	"context"
+	"os"
+
+	"github.com/joho/godotenv"
+	"github.com/universaltill/universal-till/internal/alerts"
+	"github.com/universaltill/universal-till/internal/config"
+	"github.com/universaltill/universal-till/internal/db"
+	"github.com/universaltill/universal-till/internal/enroll"
+	"github.com/universaltill/universal-till/internal/logging"
+	"github.com/universaltill/universal-till/internal/pages"
+	"github.com/universaltill/universal-till/internal/paths"
+	"github.com/universaltill/universal-till/internal/plugins"
+	"github.com/universaltill/universal-till/internal/plugins/marketplace"
+	"github.com/universaltill/universal-till/internal/plugins/oauth"
+	"github.com/universaltill/universal-till/internal/server"
+	"github.com/universaltill/universal-till/internal/settings"
+	"github.com/universaltill/universal-till/internal/updates"
+)
+
+// Run boots the till and blocks serving HTTP until ctx is cancelled (or a
+// fatal startup error occurs). Every env var config.Init and its callees
+// read (UT_DATA_DIR, UT_LISTEN_ADDR, UT_AUTH, UT_OPEN_BROWSER, ...) must be
+// set by the caller BEFORE calling Run — this function reads process
+// environment/config exactly once, the same way main() always has.
+//
+// Fatal startup errors return here instead of calling log.Fatalf (unlike
+// the original main() body this was extracted from) — a mobile host process
+// must never be os.Exit'd out from under its own app, and a CLI caller can
+// still choose to log.Fatalf on the returned error itself.
+func Run(ctx context.Context) error {
+	envFile := os.Getenv("UT_ENV_FILE")
+	if envFile == "" {
+		envFile = "pos.env"
+	}
+	_ = godotenv.Load(envFile)
+
+	logging.Init()
+	log := logging.L()
+
+	log.Infof("Universal Till POS starting...")
+
+	cfg, err := config.Init()
+	if err != nil {
+		return err
+	}
+
+	paths.MigrateLegacyData(cfg.DBPath)
+
+	if applied, err := db.ApplyPendingRestore(cfg.DBPath); err != nil {
+		return err
+	} else if applied {
+		log.Infof("staged backup restore applied to %s", cfg.DBPath)
+	}
+	database, err := db.Open(cfg.DBPath)
+	if err != nil {
+		return err
+	}
+	defer database.Close()
+
+	if applied, err := db.ApplyReplicaIdentity(database.DB, cfg.DBPath); err != nil {
+		return err
+	} else if applied {
+		log.Infof("replica identity applied — this till is now part of the shop")
+	}
+
+	settingsStore := settings.NewStore(database.DB)
+
+	if err := bootstrapPluginDirectories(); err != nil {
+		return err
+	}
+
+	settingsStore.LoadRuntimeConfig(ctx, cfg)
+	_ = settingsStore.SaveRuntimeConfig(ctx, cfg)
+
+	enroll.Init(ctx, cfg, settingsStore)
+
+	pluginManager, err := plugins.Init(ctx, cfg, database.DB)
+	if err != nil {
+		return err
+	}
+
+	var catalogRepo *marketplace.CatalogRepository
+	if cfg.Marketplace.EndpointURL != "" {
+		tokenClient := oauth.NewTokenClient(&cfg.Marketplace)
+		marketplaceClient := marketplace.NewClient(&cfg.Marketplace, tokenClient)
+		catalogRepo, err = marketplace.NewCatalogRepository(marketplaceClient, paths.Plugins("cache"))
+		if err != nil {
+			return err
+		}
+		log.Infof("Marketplace catalog repository initialized (endpoint: %s)", cfg.Marketplace.EndpointURL)
+	} else {
+		log.Warnf("Marketplace not configured (UT_MARKETPLACE_ENDPOINT_URL not set)")
+	}
+
+	updates.Start(ctx)
+	alerts.Start(ctx, cfg, database.DB)
+
+	mux := pages.Init(ctx, cfg, pluginManager, database.DB, catalogRepo)
+
+	supervisor := plugins.NewSupervisor(database.DB)
+	if err := supervisor.AutoStartPlugins(ctx); err != nil {
+		log.Warnf("plugin auto-start failed: %v", err)
+	}
+
+	return server.Start(ctx, cfg, mux, catalogRepo, database.DB, supervisor)
+}
+
+// bootstrapPluginDirectories creates required plugin cache directories
+// as specified in 009-cloud-marketplace feature (T002)
+func bootstrapPluginDirectories() error {
+	dirs := []string{
+		paths.Plugins("cache"),
+		paths.Plugins("tmp"),
+	}
+
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -6,20 +6,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/joho/godotenv"
-	"github.com/universaltill/universal-till/internal/config"
-	"github.com/universaltill/universal-till/internal/db"
-	"github.com/universaltill/universal-till/internal/enroll"
+	"github.com/universaltill/universal-till/internal/app"
 	"github.com/universaltill/universal-till/internal/logging"
-	"github.com/universaltill/universal-till/internal/pages"
-	"github.com/universaltill/universal-till/internal/paths"
-	"github.com/universaltill/universal-till/internal/plugins"
-	"github.com/universaltill/universal-till/internal/plugins/marketplace"
-	"github.com/universaltill/universal-till/internal/plugins/oauth"
-	"github.com/universaltill/universal-till/internal/server"
-	"github.com/universaltill/universal-till/internal/settings"
-	"github.com/universaltill/universal-till/internal/alerts"
-	"github.com/universaltill/universal-till/internal/updates"
 )
 
 func main() {
@@ -30,139 +18,11 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
 	defer stop()
 
-	// Load pos.env if it exists (created during installation/setup)
-	// For development, you can manually create pos.env or use UT_ENV=dev for pos.env.dev
-	envFile := os.Getenv("UT_ENV_FILE")
-	if envFile == "" {
-		envFile = "pos.env" // Default production config file
+	// The full boot sequence (config, DB/migrations, plugin host, pages/mux,
+	// background jobs, HTTP server) lives in internal/app so the mobile
+	// gomobile-bind entry point (mobile/mobile.go, ADR-0023) can drive the
+	// exact same server in-process instead of duplicating this.
+	if err := app.Run(ctx); err != nil {
+		logging.L().Fatalf("server stopped: %v", err)
 	}
-	_ = godotenv.Load(envFile)
-
-	logging.Init()
-	log := logging.L()
-
-	log.Infof("Universal Till POS starting...")
-
-	// 1) Config
-	cfg, err := config.Init()
-	if err != nil {
-		log.Fatalf("config init failed: %v", err)
-	}
-
-	// One-time: bring an old cwd-relative ./data database AND installed plugin
-	// bundles into the stable data directory so an in-place upgrade keeps its
-	// data (no-op for fresh installs).
-	paths.MigrateLegacyData(cfg.DBPath)
-
-	// 2) DB + migrations. A staged restore (Settings → Backups → Restore)
-	// applies first, before the DB is opened; the replaced file is kept
-	// in data/backups/.
-	if applied, err := db.ApplyPendingRestore(cfg.DBPath); err != nil {
-		log.Fatalf("apply staged restore failed: %v", err)
-	} else if applied {
-		log.Infof("staged backup restore applied to %s", cfg.DBPath)
-	}
-	database, err := db.Open(cfg.DBPath)
-	if err != nil {
-		log.Fatalf("db open/migrate failed: %v", err)
-	}
-	defer database.Close()
-
-	// Joined-shop replica: the snapshot restore above brought the
-	// primary's DB; re-apply THIS till's identity (ADR-0011 D2).
-	if applied, err := db.ApplyReplicaIdentity(database.DB, cfg.DBPath); err != nil {
-		log.Fatalf("apply replica identity failed: %v", err)
-	} else if applied {
-		log.Infof("replica identity applied — this till is now part of the shop")
-	}
-
-	settingsStore := settings.NewStore(database.DB)
-
-	// Bootstrap: create plugin cache directories (T002 - 009-cloud-marketplace)
-	if err := bootstrapPluginDirectories(); err != nil {
-		log.Fatalf("failed to create plugin cache directories: %v", err)
-	}
-
-	// load runtime config from DB
-	settingsStore.LoadRuntimeConfig(ctx, cfg)
-	err = settingsStore.SaveRuntimeConfig(ctx, cfg)
-	if err != nil { /* handle */
-	}
-
-	// First-boot store enrolment (ADR-0013): give this till a stable device_id
-	// and register it with the marketplace in the background, filling the empty
-	// marketplace identity fields. Explicit env config always wins; a till that
-	// never reaches the marketplace still works fully offline.
-	enroll.Init(ctx, cfg, settingsStore)
-
-	// 3) Plugins (and pass db if needed)
-	pluginManager, err := plugins.Init(ctx, cfg, database.DB)
-	if err != nil {
-		log.Fatalf("plugin init failed: %v", err)
-	}
-
-	// 3b) Marketplace: OAuth client and catalog repository (T004, T010 - 009-cloud-marketplace)
-	var catalogRepo *marketplace.CatalogRepository
-	if cfg.Marketplace.EndpointURL != "" {
-		// Create OAuth token client
-		tokenClient := oauth.NewTokenClient(&cfg.Marketplace)
-
-		// Create marketplace HTTP client
-		marketplaceClient := marketplace.NewClient(&cfg.Marketplace, tokenClient)
-
-		// Create catalog repository
-		var err error
-		catalogRepo, err = marketplace.NewCatalogRepository(marketplaceClient, paths.Plugins("cache"))
-		if err != nil {
-			log.Fatalf("failed to create catalog repository: %v", err)
-		}
-		log.Infof("Marketplace catalog repository initialized (endpoint: %s)", cfg.Marketplace.EndpointURL)
-	} else {
-		log.Warnf("Marketplace not configured (UT_MARKETPLACE_ENDPOINT_URL not set)")
-	}
-
-	// Best-effort background "update available" check (status-bar hint).
-	updates.Start(ctx)
-
-	// Daily low-stock digest → marketplace owner inbox (best-effort).
-	alerts.Start(ctx, cfg, database.DB)
-
-	// 4) Pages: pass db and catalog repo so handlers can use them
-	mux := pages.Init(ctx, cfg, pluginManager, database.DB, catalogRepo)
-
-	// Process-based (hardware) plugins: start any active ones left over from
-	// a previous run. WASM plugins (everything shipped today) sync via
-	// pluginManager above and are unaffected — AutoStartPlugins skips any
-	// runtime other than "go"/"native". Best-effort: a plugin failing to
-	// restart shouldn't block the till from booting. Deliberately placed
-	// last, right before server.Start's shutdown wiring takes over — every
-	// other log.Fatalf-capable init step has already run, so a process
-	// started here is never orphaned by a later Fatalf exiting without
-	// running the supervisor's shutdown path.
-	supervisor := plugins.NewSupervisor(database.DB)
-	if err := supervisor.AutoStartPlugins(ctx); err != nil {
-		log.Warnf("plugin auto-start failed: %v", err)
-	}
-
-	// 5) Server with background jobs (T011 - 009-cloud-marketplace)
-	if err := server.Start(ctx, cfg, mux, catalogRepo, database.DB, supervisor); err != nil {
-		log.Fatalf("server stopped: %v", err)
-	}
-}
-
-// bootstrapPluginDirectories creates required plugin cache directories
-// as specified in 009-cloud-marketplace feature (T002)
-func bootstrapPluginDirectories() error {
-	dirs := []string{
-		paths.Plugins("cache"),
-		paths.Plugins("tmp"),
-	}
-
-	for _, dir := range dirs {
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -1,0 +1,230 @@
+// Package mobile is the gomobile-bind entry point for the Android/iOS till
+// shells (ADR-0023, ut-docs): starts the same server internal/app.Run drives
+// for the CLI/desktop build, in-process — a mobile app can't spawn a sibling
+// binary the way cmd/unitill-desktop's WebView shell spawns unitill-pos as a
+// child process, so this package drives the identical boot sequence directly
+// instead. Once running, the native shell points its own WebView at the
+// returned loopback address — same "start, poll until it answers, then show
+// a window" shape as cmd/unitill-desktop/desktop.go, just in-process instead
+// of a child process.
+//
+// gomobile bind's cross-language boundary only supports a narrow set of
+// types (strings, ints, bools, []byte, error, and a few others — no generics,
+// no complex struct fields crossing directly) — this package's exported
+// surface is deliberately minimal for that reason: three functions, no
+// exported types.
+//
+// This package mutates PROCESS-WIDE environment variables (os.Setenv) to
+// configure internal/app.Run, the same way the CLI's own pos.env/shell
+// environment does. That's fine for a mobile app where this package owns
+// the whole process, but means this is NOT safe to embed alongside other
+// Go code that also touches os.Setenv/os.Environ() concurrently outside
+// this package's own synchronization.
+//
+// Build (needs the Android SDK+NDK or Xcode, per platform — see
+// ut-docs/adr/0023-android-ios-till-strategy.md for the full setup):
+//
+//	gomobile bind -target=android ./mobile
+//	gomobile bind -target=ios ./mobile
+package mobile
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/universaltill/universal-till/internal/app"
+)
+
+// instance is one running server lifecycle. Start/Stop/IsRunning agree on
+// current state by swapping this pointer under mu — never by holding mu
+// across the blocking work (starting or stopping the actual server), so a
+// slow Start can never make IsRunning/Stop block for the whole timeout.
+type instance struct {
+	dataDir string
+	addr    string
+	cancel  context.CancelFunc
+	done    chan struct{} // closed once app.Run has fully returned
+	err     error         // app.Run's result; only valid after done is closed
+}
+
+var (
+	mu       sync.Mutex
+	inst     *instance
+	starting bool
+)
+
+// Start boots the till server with its on-device data directory at dataDir
+// (the native shell resolves this to whatever platform-appropriate sandboxed
+// storage path it has — Android's Context.getFilesDir(), iOS's
+// NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory), or
+// similar) and returns "127.0.0.1:<port>" once the server is confirmed
+// accepting connections — ready for a WebView to load.
+//
+// Idempotent while genuinely running: a second Start call with the same
+// dataDir just returns the existing address (mirrors cmd/unitill-desktop's
+// tillAlreadyRunning re-attach behavior — useful if the native shell's
+// lifecycle calls Start more than once, e.g. iOS returning from
+// background). A second Start with a DIFFERENT dataDir while already
+// running is an error, not a silent ignore — the caller asked for
+// something this process can't currently give it. If the server died on
+// its own since the last successful Start (e.g. a listener error, not a
+// Stop() call), Start does not lie about still being up — it notices via
+// the dead instance's closed done channel and starts fresh instead of
+// returning a stale address.
+func Start(dataDir string) (string, error) {
+	mu.Lock()
+	if inst != nil {
+		select {
+		case <-inst.done:
+			inst = nil // died on its own; fall through and start fresh
+		default:
+			if inst.dataDir != dataDir {
+				addr := inst.addr
+				mu.Unlock()
+				return "", fmt.Errorf("mobile: already running against %q, cannot Start against %q (current address %s)", inst.dataDir, dataDir, addr)
+			}
+			addr := inst.addr
+			mu.Unlock()
+			return addr, nil
+		}
+	}
+	if starting {
+		mu.Unlock()
+		return "", fmt.Errorf("mobile: Start already in progress")
+	}
+	starting = true
+	mu.Unlock()
+	defer func() {
+		mu.Lock()
+		starting = false
+		mu.Unlock()
+	}()
+
+	port, err := freePort()
+	if err != nil {
+		return "", fmt.Errorf("mobile: find a free port: %w", err)
+	}
+	addr := "127.0.0.1:" + port
+
+	if err := os.Setenv("UT_DATA_DIR", dataDir); err != nil {
+		return "", fmt.Errorf("mobile: set UT_DATA_DIR: %w", err)
+	}
+	if err := os.Setenv("UT_LISTEN_ADDR", addr); err != nil {
+		return "", fmt.Errorf("mobile: set UT_LISTEN_ADDR: %w", err)
+	}
+	// The native shell supplies its own window/WebView; the server must
+	// never try to open an OS browser on its own (same reasoning as
+	// cmd/unitill-desktop/desktop.go's identical env var).
+	if err := os.Setenv("UT_OPEN_BROWSER", "0"); err != nil {
+		return "", fmt.Errorf("mobile: set UT_OPEN_BROWSER: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	newInst := &instance{dataDir: dataDir, addr: addr, cancel: cancel, done: make(chan struct{})}
+
+	go func() {
+		newInst.err = app.Run(ctx)
+		close(newInst.done)
+	}()
+
+	if err := waitUntilReady(addr, 10*time.Second, newInst); err != nil {
+		cancel()
+		<-newInst.done // wait for the full teardown before reporting failure
+		return "", err
+	}
+
+	mu.Lock()
+	inst = newInst
+	mu.Unlock()
+	return addr, nil
+}
+
+// Stop gracefully shuts the server down and BLOCKS until it has actually
+// finished — including internal/server.Start's own shutdown drain and
+// internal/app.Run's deferred database.Close() — not just until the
+// shutdown signal has been sent. This matters: a native shell that calls
+// Stop() and then quickly Start()s again against the SAME on-device
+// dataDir (e.g. an app backgrounded then rapidly foregrounded) must not
+// race the old instance's in-flight teardown against the new instance's
+// db.Open() on the same SQLite file. Safe to call when not running
+// (no-op). A caller wanting non-blocking behavior should call this from
+// its own background thread/coroutine, same as any blocking mobile API.
+func Stop() {
+	mu.Lock()
+	cur := inst
+	inst = nil
+	mu.Unlock()
+	if cur == nil {
+		return
+	}
+	cur.cancel()
+	<-cur.done
+}
+
+// IsRunning reports whether a Start'd server is genuinely still up — not
+// just whether Start was last called without a matching Stop. If the
+// server died on its own (closed done channel, no Stop() call), this
+// notices and corrects the tracked state instead of reporting stale
+// success.
+func IsRunning() bool {
+	mu.Lock()
+	defer mu.Unlock()
+	if inst == nil {
+		return false
+	}
+	select {
+	case <-inst.done:
+		inst = nil
+		return false
+	default:
+		return true
+	}
+}
+
+// freePort asks the OS for an unused loopback port. Same probe-then-close
+// pattern as cmd/unitill-desktop/desktop.go's freePort, and the same small,
+// accepted race: internal/server.Start's own listenWithFallback tolerates
+// the port being taken by the time it actually binds, falling back to a
+// different one — which cmd/unitill-desktop also doesn't defend against,
+// so this doesn't introduce a new gap, just matches the existing one.
+func freePort() (string, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", err
+	}
+	defer ln.Close()
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	return port, err
+}
+
+// waitUntilReady polls addr's /healthz until it answers 200, timeout
+// elapses, or app.Run itself already exited (a fast, fatal startup
+// failure — e.g. a bad config — shouldn't make the caller wait out the
+// full timeout to find out).
+func waitUntilReady(addr string, timeout time.Duration, inst *instance) error {
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		select {
+		case <-inst.done:
+			if inst.err != nil {
+				return fmt.Errorf("mobile: server failed to start: %w", inst.err)
+			}
+			return fmt.Errorf("mobile: server exited before becoming ready")
+		default:
+		}
+		if resp, err := client.Get("http://" + addr + "/healthz"); err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("mobile: server did not become ready within %s", timeout)
+}

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -1,0 +1,162 @@
+package mobile
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// mobileTestEnv points the till at an isolated temp data dir and disables
+// auth (no PIN session needed to hit /healthz) for every test in this file —
+// mirrors how other live-verification runs in this repo set up a throwaway
+// till instance.
+func mobileTestEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("UT_AUTH", "off")
+	t.Setenv("UT_ENV_FILE", t.TempDir()+"/does-not-exist.env") // don't pick up a stray local pos.env
+	t.Cleanup(Stop)
+}
+
+func TestStartAndStop_RealServerBoots(t *testing.T) {
+	mobileTestEnv(t)
+
+	addr, err := Start(t.TempDir())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if addr == "" {
+		t.Fatal("expected a non-empty address")
+	}
+	if !IsRunning() {
+		t.Fatal("expected IsRunning() to be true after a successful Start")
+	}
+
+	resp, err := http.Get("http://" + addr + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("/healthz = %d, want 200", resp.StatusCode)
+	}
+
+	// Stop() blocks until the server has FULLY torn down (not just until
+	// the shutdown signal was sent) — so a single check right after it
+	// returns is deterministic, not a race against an async shutdown.
+	Stop()
+	if IsRunning() {
+		t.Fatal("expected IsRunning() to be false after Stop")
+	}
+	if _, err := http.Get("http://" + addr + "/healthz"); err == nil {
+		t.Fatalf("server at %s still answering immediately after Stop returned", addr)
+	}
+}
+
+func TestStart_IdempotentWhileRunning(t *testing.T) {
+	mobileTestEnv(t)
+
+	dataDir := t.TempDir()
+	addr1, err := Start(dataDir)
+	if err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+
+	// A second Start call with the SAME dataDir while already running must
+	// NOT try to boot a second server (which would fail: the first already
+	// holds the DB and whatever port it bound) — it should just hand back
+	// the same address.
+	addr2, err := Start(dataDir)
+	if err != nil {
+		t.Fatalf("second Start: %v", err)
+	}
+	if addr1 != addr2 {
+		t.Fatalf("second Start returned %q, want the same address %q", addr2, addr1)
+	}
+}
+
+func TestStart_DifferentDataDirWhileRunningErrors(t *testing.T) {
+	mobileTestEnv(t)
+
+	if _, err := Start(t.TempDir()); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+
+	// A second Start with a DIFFERENT dataDir while already running must
+	// fail loudly, not silently ignore the request and keep serving the
+	// first dataDir under a caller's mistaken belief it switched.
+	if _, err := Start(t.TempDir()); err == nil {
+		t.Fatal("expected Start against a different dataDir while running to error")
+	}
+}
+
+func TestStart_FastFailWhenServerDiesImmediately(t *testing.T) {
+	mobileTestEnv(t)
+
+	// A regular FILE where the data dir should be a directory makes
+	// db.Open fail immediately (DBPath = filepath.Join(dataDir,
+	// "unitill-pos.db") can never be created under a non-directory) —
+	// exercises waitUntilReady's fast-fail path (app.Run's goroutine
+	// returns an error before the /healthz poll ever succeeds) rather
+	// than waiting out the full 10s timeout.
+	notADir := filepath.Join(t.TempDir(), "this-is-a-file")
+	if err := os.WriteFile(notADir, []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed a non-directory dataDir: %v", err)
+	}
+
+	_, err := Start(notADir)
+	if err == nil {
+		t.Fatal("expected Start to fail fast when the server can't open its database")
+	}
+	if IsRunning() {
+		t.Fatal("expected IsRunning() to be false after a failed Start")
+	}
+}
+
+// A server that dies on its own (e.g. a listener error) without Stop()
+// ever being called must not leave IsRunning()/Start() reporting stale
+// success — this is the "abandoned runErrCh" gap flagged in code review:
+// cancelling the instance's own context directly (as a real crash would,
+// from the caller's point of view) simulates that, without needing to
+// engineer an actual server-internal failure.
+func TestIsRunning_DetectsServerDiedWithoutStop(t *testing.T) {
+	mobileTestEnv(t)
+
+	dataDir := t.TempDir()
+	if _, err := Start(dataDir); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	mu.Lock()
+	died := inst
+	mu.Unlock()
+	died.cancel()
+	<-died.done // wait for the real teardown, same as Stop() would
+
+	if IsRunning() {
+		t.Fatal("expected IsRunning() to detect the dead instance and report false")
+	}
+
+	// A subsequent Start with the same dataDir must actually restart the
+	// server, not return the old (now-dead) address as if nothing happened.
+	addr, err := Start(dataDir)
+	if err != nil {
+		t.Fatalf("Start after an unobserved crash: %v", err)
+	}
+	resp, err := http.Get("http://" + addr + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz on the restarted server: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("/healthz = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestStop_SafeWhenNotRunning(t *testing.T) {
+	mobileTestEnv(t)
+	Stop() // must not panic
+	if IsRunning() {
+		t.Fatal("IsRunning() should be false when Start was never called")
+	}
+}

--- a/specs/013-mobile-shared-core/spec.md
+++ b/specs/013-mobile-shared-core/spec.md
@@ -1,0 +1,112 @@
+# 013 — Android/iOS shared core
+
+Decision record: `ut-docs/adr/0023-android-ios-till-strategy.md` (read
+that first — this doc is the implementation breakdown, not the "why").
+
+## Goal
+
+Run the exact same Go core on Android/iOS that already runs on desktop,
+via a thin native shell — no server rewrite, no second plugin host, no
+forked business logic.
+
+## Phases (build and ship in this order)
+
+### Phase 1 — Go-side groundwork (in-process boot + gomobile-bind surface)
+
+Done first, and independent of having any mobile SDK installed at all —
+everything here is `go build`/`go test`-verifiable today.
+
+- Extracted `main.go`'s full boot sequence (config → DB/migrations →
+  plugin host → marketplace enrolment → pages/mux → background jobs →
+  HTTP server) into `internal/app.Run(ctx) error` — previously only
+  expressed inline in `main()`, un-callable from anywhere else.
+  `main.go` now just calls it and `log.Fatalf`s on a non-nil error,
+  preserving the CLI's fatal-on-error behavior. Verified with a real
+  built binary (boots, `/healthz` 200, identical to pre-refactor) and
+  the full existing test suite green. **One real, deliberate behavior
+  difference, caught by independent review and worth stating rather
+  than glossing over as "purely mechanical"**: the original inline code
+  called `log.Fatalf` (→ `os.Exit(1)`, skipping every deferred function)
+  at each fatal step; `Run` returns the error instead, so `defer
+  database.Close()` now genuinely executes on every one of those same
+  failure paths before `main.go`'s own `log.Fatalf` runs. Checked every
+  step for a dependency on the old abrupt-exit semantics — found none;
+  this is a strict improvement (clean SQLite shutdown even on a fatal
+  boot failure), not a regression, but it IS a real behavior change on
+  exactly the axis worth double-checking in a refactor like this.
+- New `mobile` package (`mobile/mobile.go`) — the actual gomobile-bind
+  entry point. Three exported functions only (`Start(dataDir string)
+  (string, error)`, `Stop()`, `IsRunning() bool`), deliberately minimal
+  because gomobile bind's cross-language boundary only supports a narrow
+  set of types (strings/ints/bools/`[]byte`/error — no generics, no
+  complex struct fields crossing directly).
+  - `Start` runs `internal/app.Run` **in-process** (not a spawned
+    sibling binary — mobile apps can't do that the way
+    `cmd/unitill-desktop`'s WebView shell spawns `unitill-pos` as a
+    child process), on a free loopback port, polls `/healthz` until
+    ready (same "start, wait, then show a window" shape as
+    `desktop.go`), and returns the address for the native shell's
+    WebView to load.
+  - `Stop` cancels the context `internal/server.Start` already watches
+    for graceful shutdown — no new shutdown mechanism, reuses exactly
+    what SIGINT/SIGTERM already trigger on desktop/CLI — and **blocks
+    until teardown has actually finished** (including the deferred
+    `database.Close()`), not just until the cancel signal was sent.
+    First draft returned immediately after sending the signal;
+    independent review flagged the real race that leaves — a native
+    shell that `Stop()`s then quickly `Start()`s again against the SAME
+    on-device data dir (backgrounded-then-foregrounded is a plausible
+    real sequence) could race the old instance's in-flight
+    `database.Close()` against the new instance's `db.Open()` on the
+    same SQLite file. Fixed by having `Stop()` wait on a `done` channel
+    the server goroutine closes when `app.Run` truly returns.
+  - Idempotent `Start` while genuinely running (same `dataDir`, returns
+    the existing address) and a safe no-op `Stop` when nothing's
+    running, since a mobile app's lifecycle can call these more than
+    once (e.g. iOS foreground/background transitions). A second `Start`
+    with a DIFFERENT `dataDir` while running is an explicit error, not
+    silently ignored. And — the other real gap independent review
+    found — if the server died on its own (e.g. a listener error) with
+    Stop never called, `Start`'s "already running" fast-path no longer
+    lies: it notices the dead instance via a closed `done` channel and
+    starts fresh instead of returning a stale, dead address. The lock
+    guarding all of this is held only for brief state transitions, never
+    across the actual blocking start/stop work — first draft held it
+    across the whole ~10s ready-wait, which review correctly flagged as
+    able to block a concurrent `Stop()`/`IsRunning()` call for the full
+    timeout.
+  - Tests genuinely boot a real server through this exact API (not
+    mocked): confirm `/healthz` answers after `Start`, confirm the port
+    stops answering after `Stop`, confirm idempotency, confirm `Stop`
+    is safe when never started.
+
+### Phase 2 — Android native shell (blocked on tooling)
+
+Not started. Needs the Android SDK + NDK (confirmed absent in the AI
+dev environment: `gomobile bind -target=android` fails immediately with
+"could not locate Android SDK" — a real, verified blocker, not assumed)
+and a decision on packaging shape (foreground service + WebView
+`Activity`, per ADR-0023 §1). Once the SDK exists: `gomobile bind
+-target=android ./mobile` produces the `.aar` a minimal Kotlin/Java
+shell links against.
+
+### Phase 3 — iOS native shell (blocked on tooling + accounts)
+
+Not started. Needs Xcode with the iOS SDK (only the Xcode Command Line
+Tools stub is present today, confirmed) and Farshid's own Apple
+Developer Program enrolment for real signing/distribution (ADR-0023).
+Once available: `gomobile bind -target=ios ./mobile` produces the
+`.xcframework` a minimal SwiftUI/UIKit shell links against, hosting an
+in-process `WKWebView`.
+
+## Explicitly out of scope for this spec
+
+- The native Kotlin/Swift shell code itself (Phases 2/3) — not
+  attempted without the ability to build/verify it; hand-written,
+  untested native code would be worse than no code.
+- Mobile hardware adapters (printer/drawer/scanner/card reader) — a
+  separate, later item per ADR-0023 §2, only needed once a real device
+  target exists to build against.
+- Installing the Android SDK/NDK or Xcode on Farshid's machine
+  unprompted — a multi-GB, environment-modifying step, held for an
+  explicit go-ahead rather than done as a side effect of this phase.


### PR DESCRIPTION
## Summary
- Go-side groundwork for the Android/iOS till (ADR-0023, `ut-docs`; spec 013): confirmed no Android SDK/Xcode iOS SDK exist in this environment before scoping to exactly what's buildable/testable without them.
- Extracted `main.go`'s boot sequence into `internal/app.Run(ctx) error`, callable from more than just the CLI.
- New `mobile` package (`Start`/`Stop`/`IsRunning`) runs the server in-process — the same "start, poll `/healthz`, hand back an address" shape `cmd/unitill-desktop` already uses via a spawned subprocess, just in-process since mobile apps can't spawn siblings.
- Independent review caught 4 real concurrency bugs in the first draft (lock held across a ~10s wait, stale success after an unobserved crash, `Stop()` not actually draining before returning, a different-dataDir `Start` silently ignored) — all fixed with new regression tests. Full writeup: `docs/code-reviews/2026-07-25-mobile-shared-core-phase1.md`.
- Native Android/iOS shells (Phases 2/3) are explicitly **not** attempted — no SDK/toolchain in this environment, confirmed by trying rather than assumed.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all green
- [x] `go test ./mobile/... -race -count=3` clean (6 tests, zero flakes)
- [x] Both `scripts/ci/guard-*.sh` green
- [x] Real built binary boots identically to pre-refactor (`/healthz`, `/report-issue` both 200)
- [x] `cmd/unitill-desktop`'s separate `-tags desktop` build still compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yS4U3wicRKdqvKVvKQHpt