### PR TITLE
Android release signing and CI build/publish pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,17 @@ jobs:
             if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
               echo "::error::tag ${TAG} already exists"; exit 1
             fi
+            # An explicit "version" input bypasses the bump logic above and
+            # goes straight to a human-typed string — validate it's plain
+            # MAJOR.MINOR.PATCH before it reaches anything downstream that
+            # assumes that shape (goreleaser's ldflags injection, the
+            # android-app job's versionCode arithmetic — a non-numeric
+            # component there silently computes a wrong, not failing,
+            # version code via bash's "unset var = 0" arithmetic).
+            if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::version '${VERSION}' must be plain MAJOR.MINOR.PATCH (no 'v' prefix, no suffix like -beta1)"
+              exit 1
+            fi
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git tag -a "${TAG}" -m "Release ${TAG}"
@@ -280,3 +291,115 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.version }}
           TAG: ${{ needs.prepare.outputs.tag }}
         run: gh release upload "${TAG}" "dist/macos/unitill-pos-${VERSION}-macOS-arm64.dmg" --clobber
+
+  # Android app (ADR-0023; android/README.md): the same embedded Go server
+  # (internal/app.Run via ./mobile, gomobile-bound) as every other platform,
+  # wrapped in a real Kotlin app (android/) with a foreground TillService +
+  # WebView, verified working on an emulator 2026-07-25/26. Self-signed APK,
+  # sideload distribution — no Google Play involvement, matching this app's
+  # "no Google contact" posture everywhere else. Own job like macos-app: only
+  # needs the release to exist, never blocks or is blocked by goreleaser.
+  android-app:
+    needs: [prepare, goreleaser]
+    if: ${{ !cancelled() && needs.prepare.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      # Installs cmdline-tools and sets ANDROID_HOME/ANDROID_SDK_ROOT.
+      - uses: android-actions/setup-android@v3
+      - name: Install NDK + platform + build-tools
+        # Versions match what this app was built/verified against locally
+        # (ut-docs/adr/0023-android-ios-till-strategy.md) — gomobile bind
+        # needs a concrete NDK, not "whatever's newest."
+        run: |
+          set -euo pipefail
+          sdkmanager --install "ndk;28.2.13676358" "platforms;android-36" "build-tools;36.1.0"
+          echo "ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/28.2.13676358" >> "$GITHUB_ENV"
+      - name: Install gomobile/gobind
+        run: |
+          set -euo pipefail
+          go install golang.org/x/mobile/cmd/gomobile@latest
+          go install golang.org/x/mobile/cmd/gobind@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - name: Wait for the GitHub release to exist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            gh release view "$TAG" --json tagName >/dev/null 2>&1 && exit 0
+            echo "release $TAG not visible yet (attempt $i/30)"; sleep 20
+          done
+          echo "::error::release $TAG does not exist — goreleaser failed before creating it; re-run goreleaser first"
+          exit 1
+      # Decode the signing keystore into the runner's temp dir (never the
+      # workspace — nothing here should end up in a build artifact or
+      # cache). No-op build-wise if these secrets are ever unset: the
+      # Gradle signing config (android/app/build.gradle.kts) leaves the
+      # release build type unsigned rather than silently falling back to
+      # anything, so an unsigned APK failing to upload/verify below would
+      # be the loud, correct failure mode, not a silent bad release.
+      - name: Decode signing keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ANDROID_KEYSTORE_BASE64:-}" ]; then
+            echo "::error::ANDROID_KEYSTORE_BASE64 is not set — cannot produce a signed release APK"
+            exit 1
+          fi
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/unitill-release.keystore"
+          echo "ANDROID_KEYSTORE_PATH=$RUNNER_TEMP/unitill-release.keystore" >> "$GITHUB_ENV"
+      - name: Build signed release APK
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          # versionCode must strictly increase across releases for Android's
+          # package manager to treat a new APK as an upgrade over an older
+          # one (sideloading included, not just Play) — derived
+          # deterministically from the semver tag rather than an
+          # incrementing counter, so it never depends on build history.
+          # Wide per-component headroom (patch/minor up to 999) rather than
+          # 100/10: this project's own tag history was already 20+ patch
+          # releases deep on a single minor line by the time this was
+          # written (v0.2.20…v0.2.39) — a narrower formula would have
+          # collided with the next minor bump the first time patch hit 100
+          # (independent review caught this in the first draft: 0.2.100 and
+          # 0.3.0 both hashed to the same code under MA*10000+MI*100+PA).
+          IFS=. read -r MA MI PA <<< "$VERSION"
+          VERSION_CODE=$((MA * 1000000 + MI * 1000 + PA))
+          cd android
+          ./gradlew assembleRelease -PversionName="$VERSION" -PversionCode="$VERSION_CODE"
+      - name: Verify the APK is actually signed with our key
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          BUILD_TOOLS="${ANDROID_HOME}/build-tools/36.1.0"
+          APK="android/app/build/outputs/apk/release/app-release.apk"
+          test -f "$APK"
+          "${BUILD_TOOLS}/apksigner" verify "$APK"
+          FINGERPRINT="$("${BUILD_TOOLS}/apksigner" verify --print-certs "$APK" | grep 'SHA-256 digest' | awk '{print $NF}')"
+          echo "signed with SHA-256: ${FINGERPRINT}"
+          mv "$APK" "unitill-pos_${VERSION}_android.apk"
+      - name: Attach the APK to the release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: gh release upload "${TAG}" "unitill-pos_${VERSION}_android.apk" --clobber

--- a/android/README.md
+++ b/android/README.md
@@ -105,10 +105,45 @@ independent review's 4 findings were fixed, not just before:
   proper Android notification-permission flow (best-effort — the
   service runs regardless of whether it's granted).
 
+## Signing & release (done 2026-07-26)
+
+Self-signed APK, direct sideload distribution — no Google Play involvement
+(Farshid's choice, matching this app's "no Google contact" posture
+everywhere else). `.github/workflows/release.yml`'s `android-app` job
+builds, signs, and attaches `unitill-pos_<version>_android.apk` to every
+GitHub release automatically, alongside the desktop builds; the site's
+`/download` page picks it up with zero code changes needed (same live
+GitHub Releases API mechanism the other platforms already use).
+
+- Signing key: a 4096-bit RSA key, self-signed, `keytool`-generated,
+  valid until 2053. **Two durable copies exist** — Azure Key Vault
+  (`kv-unitill-dev`, secrets `android-release-keystore-base64` /
+  `android-release-keystore-password` / `android-release-keystore-alias`)
+  and this repo's GitHub Actions secrets (`ANDROID_KEYSTORE_BASE64` /
+  `ANDROID_KEYSTORE_PASSWORD` / `ANDROID_KEY_ALIAS`, the ones CI actually
+  reads). **Losing this key is effectively unrecoverable**: Android
+  refuses to install an update signed with a different key over an
+  existing install, so every future release must be signed with this
+  exact key or every user who installed a prior release would need to
+  uninstall and reinstall from scratch. Deliberately NOT Terraform-managed
+  (a keystore isn't something `random_password` can generate, and
+  `unitill-infra`'s apply flow is manual/gated) — the Key Vault copy is a
+  plain secret, set directly, for disaster recovery only.
+- `android/app/build.gradle.kts`: a release build stays **unsigned**
+  (not silently debug-signed) unless `ANDROID_KEYSTORE_PATH`/
+  `ANDROID_KEYSTORE_PASSWORD`/`ANDROID_KEY_ALIAS` are all set — loud
+  failure (can't install) over a quiet trust gap. `versionCode`/
+  `versionName` are overridable via `-P` Gradle properties; CI derives
+  `versionCode` deterministically from the release's semver tag
+  (`MAJOR*10000 + MINOR*100 + PATCH`) so it always strictly increases,
+  which Android's package manager requires to treat a new APK as an
+  upgrade (true for sideloading too, not just Play).
+- Live-verified: a real signed release APK installed and launched on the
+  emulator, and upgrading an existing install with a newer signed build
+  (same key) succeeded with no uninstall needed.
+
 ## Not yet done
 
-- Release signing/distribution (Play Store or sideload APK signing —
-  needs Farshid's own signing keys/Play Console decisions, ADR-0023).
 - Physical hardware integrations (printer/scanner/card reader) — the
   `runtime:"go"` process-spawning plugin type doesn't port to mobile at
   all (ADR-0023 §2); needs native adapters, not attempted here.
@@ -116,6 +151,5 @@ independent review's 4 findings were fixed, not just before:
   keeps running once started, matching a real POS terminal's actual
   requirement — but there's no in-app way to deliberately stop it yet
   short of force-stopping the app from Android's own app settings).
-- CI build for this app (not wired into `.github/workflows` — the
-  Android SDK/NDK footprint is large and this hasn't been scoped for
-  CI yet).
+- A Play Store listing (deliberately not pursued — see "Signing &
+  release" above).

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -3,6 +3,20 @@ plugins {
     id("org.jetbrains.kotlin.android") version "2.0.21"
 }
 
+// Release signing (ADR-0023's "still open" item, closed 2026-07-26): a
+// self-signed key, not a Play Store cert — sideloaded APK distribution,
+// same "no Google contact" posture as the rest of this app. Read from env
+// vars (CI decodes ANDROID_KEYSTORE_BASE64 to a file and exports the path)
+// rather than gradle.properties/local.properties, so the real passwords
+// never touch disk in a form that could get committed by accident. PKCS12
+// keystores require identical store/key passwords (keytool enforces this),
+// so one password covers both.
+val releaseKeystorePath = System.getenv("ANDROID_KEYSTORE_PATH")
+val releaseKeystorePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
+val releaseKeyAlias = System.getenv("ANDROID_KEY_ALIAS")
+val releaseSigningConfigured =
+    !releaseKeystorePath.isNullOrBlank() && !releaseKeystorePassword.isNullOrBlank() && !releaseKeyAlias.isNullOrBlank()
+
 android {
     namespace = "com.universaltill.pos"
     compileSdk = 36
@@ -12,13 +26,39 @@ android {
         // Matches `gomobile bind -androidapi 24` below — keep these in sync.
         minSdk = 24
         targetSdk = 36
-        versionCode = 1
-        versionName = "0.1.0-dev"
+        // CI overrides both via -PversionName=/-PversionCode= from the real
+        // release tag (see release.yml); local/unconfigured builds keep
+        // these dev defaults. versionCode must strictly increase for
+        // Android's own package manager to treat a new APK as an upgrade
+        // (matters even for sideloading, not just Play) — release.yml
+        // derives it deterministically from the semver tag.
+        versionCode = (project.findProperty("versionCode") as String?)?.toIntOrNull() ?: 1
+        versionName = (project.findProperty("versionName") as String?) ?: "0.1.0-dev"
+    }
+
+    signingConfigs {
+        if (releaseSigningConfigured) {
+            create("release") {
+                storeFile = file(releaseKeystorePath!!)
+                storePassword = releaseKeystorePassword
+                keyAlias = releaseKeyAlias
+                keyPassword = releaseKeystorePassword
+            }
+        }
     }
 
     buildTypes {
         release {
             isMinifyEnabled = false
+            // Unconfigured (no ANDROID_KEYSTORE_* env vars — the local/dev
+            // default): leave unsigned rather than silently falling back to
+            // the debug key, so an accidental `assembleRelease` on a dev
+            // machine can't produce something that LOOKS like a real signed
+            // release build but isn't (an unsigned APK simply refuses to
+            // install, a clear/loud failure instead of a quiet trust gap).
+            if (releaseSigningConfigured) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
     compileOptions {

--- a/docs/code-reviews/2026-07-26-android-release-signing.md
+++ b/docs/code-reviews/2026-07-26-android-release-signing.md
@@ -1,0 +1,118 @@
+# 2026-07-26 — Android release signing & CI (ADR-0023)
+
+## Context
+The Android app (PR #62, merged 2026-07-25/26) was real and working but only
+ever built/verified locally against an emulator — no CI build, no release
+signing, nothing published anywhere a user could download it. Farshid's
+explicit choice when asked: self-signed APK, direct sideload distribution,
+no Google Play involvement (same "no Google contact" posture as the rest of
+this app's design). This closes that gap end-to-end: a signing key, a CI
+job that builds/signs/publishes on every release, and the website wired to
+offer the download automatically.
+
+## Design
+- **Signing key**: a 4096-bit RSA key, self-signed via `keytool`, valid
+  until 2053 (standard ~27-year validity for an Android release key — it
+  can never be rotated without breaking updates for everyone who already
+  installed the app, so it's generated once and kept indefinitely). Two
+  durable copies: Azure Key Vault (`kv-unitill-dev`,
+  `android-release-keystore-base64`/`-password`/`-alias`, disaster-recovery
+  only, not Terraform-managed — a keystore isn't something
+  `random_password` can generate, and this repo's IaC apply flow is
+  manual/gated) and this repo's GitHub Actions secrets
+  (`ANDROID_KEYSTORE_BASE64`/`ANDROID_KEYSTORE_PASSWORD`/
+  `ANDROID_KEY_ALIAS`, the ones CI actually reads).
+- `android/app/build.gradle.kts`: a `signingConfig` reads those three env
+  vars; a release build is left **unsigned** (not silently debug-signed)
+  when they're absent — a loud "can't install" failure beats a quiet trust
+  gap where a locally-built "release" APK looks real but isn't.
+  `versionCode`/`versionName` became overridable via Gradle `-P`
+  properties so CI can stamp the real release version instead of the
+  hardcoded dev default.
+- `.github/workflows/release.yml`: new `android-app` job, shaped like the
+  existing `macos-app` job (same `needs`/`if` resilience — runs whenever
+  the release exists, regardless of whether `goreleaser` itself succeeded,
+  so a goreleaser hiccup never costs the Android build either). Installs
+  the Android SDK/NDK/JDK 17/gomobile, decodes the keystore secret to
+  `$RUNNER_TEMP` (never the workspace), builds+signs via
+  `./gradlew assembleRelease`, verifies the result is genuinely signed with
+  `apksigner` before uploading, and attaches
+  `unitill-pos_<version>_android.apk` to the release.
+- `ut-website`: `download.html` gained an Android card and — the one
+  actual behavior change beyond "add a new option" — the `detect()`
+  function's Android branch changed from a deliberate `return null`
+  (placeholder, no download offered) to a real match, moved ahead of the
+  generic `/Linux/` check it would otherwise have been shadowed by
+  (Android's user-agent also matches `/Linux/`). No other site code
+  changes needed: the page already resolves real download URLs from the
+  live GitHub Releases API by matching a `SUFFIX` substring against
+  release asset names, so publishing `unitill-pos_<version>_android.apk`
+  is sufficient on its own.
+
+## Independent review
+Two rounds — the initial CI/Gradle/website diff, then the fix for what it
+found.
+
+**One real bug, fixed**: `versionCode = MAJOR*10000 + MINOR*100 + PATCH`
+collides once patch reaches 100 on a given minor line (`0.2.100` and
+`0.3.0` both hash to `300`). Not theoretical: this repo's own tag history
+was already 20+ patch releases deep on one minor line
+(`v0.2.20`…`v0.2.39`) by the time this was written. Fixed with wider
+per-component headroom, `MAJOR*1000000 + MINOR*1000 + PATCH` (patch/minor
+now have room to 999 each, comfortably beyond any realistic release
+cadence, still far inside Android's 32-bit versionCode range).
+
+**Secondary, fixed**: the `workflow_dispatch` explicit-version input had no
+format validation — a malformed value (e.g. `0.3.0-beta1`) would silently
+misparse in the `versionCode` bash arithmetic (`IFS=. read` +
+`$((...))` treats an unset/non-numeric captured group as `0`, no error)
+rather than failing loudly. Fixed: the `prepare` job now validates
+`^[0-9]+\.[0-9]+\.[0-9]+$` on any explicit version and fails the release
+immediately with a clear message if it doesn't match, before anything
+downstream (goreleaser's ldflags injection, the Android job) ever sees it.
+
+**Confirmed correct, not just assumed**: the keystore is decoded only to
+`$RUNNER_TEMP` and never echoed/logged anywhere; a missing/partial signing
+secret produces an unsigned APK that fails loudly at the `apksigner
+verify` step rather than silently uploading something broken; the
+`android-app` job's working-directory handling (`cd android` scoped to one
+step, `mv`/`gh release upload` back at repo root) is consistent; the
+`detect()` reorder doesn't regress any other platform branch.
+
+## Verification
+`actionlint`/`shellcheck` on `release.yml` — clean (one pre-existing,
+unrelated warning on a `macos-app` line dated 2026-07-16). Both inline
+`<script>` blocks in `download.html` parse. `yamllint` on both workflow
+files — no new warnings.
+
+**Live-verified against a real build, not just "the YAML looks right"**:
+built a real signed release APK locally (same Gradle invocation CI uses,
+same keystore), confirmed with `apksigner verify --print-certs` that the
+signature matches the exact key stored in Key Vault (SHA-256 fingerprint
+`8B:D8:...:B4`), confirmed `aapt dump badging` shows the injected
+version/versionCode landed correctly. Installed on a real (emulated)
+device: the app launched, `libgojni.so` loaded, the real embedded Go
+server booted (`Universal Till POS starting...` → `listening on
+127.0.0.1:36405` in logcat — genuinely running, not just "APK installed").
+**The actual upgrade guarantee this whole pipeline exists for** was tested
+directly: built a second signed APK with a higher versionCode (same key),
+installed it directly over the still-running first install with no
+uninstall — succeeded, `dumpsys package` confirmed the version bumped in
+place. This is the real-world scenario a shop's till needs to survive
+(update without losing local data), and it works.
+
+**One real environment gotcha worth recording**: the emulator hung
+indefinitely on first boot attempts in this sandboxed session — not a
+crash, just silently stuck at 0% CPU. Root cause: crashpad's opt-in
+crash-report consent dialog blocking headless startup, waiting for a GUI
+interaction that can never come without a display. Fixed by explicitly
+disabling crash-report collection (`-no-metrics` +
+`ANDROID_EMULATOR_ENABLE_CRASH_REPORTING=0`) — boots cleanly (~19s) once
+that's set. Worth remembering for any future headless emulator use in
+this kind of environment.
+
+## What's still true from before
+Physical hardware integrations, an in-app "stop the till" affordance, and
+all of iOS remain out of scope (unchanged from `android/README.md`'s
+existing "Not yet done" list). Everything about *signing and
+distribution* specifically is now closed.


### PR DESCRIPTION
## Summary
- Closes ADR-0023's last open item: signs and publishes the Android app (PR #62) automatically on every release. Self-signed APK, direct sideload — no Google Play involvement (Farshid's explicit choice).
- New `android-app` CI job in `release.yml`, mirrors `macos-app`'s resilience pattern (runs whenever the release exists, independent of `goreleaser`'s own success).
- Gradle `signingConfig` reads keystore path/password/alias from env vars; a release build stays unsigned (not silently debug-signed) when unconfigured.
- Independent review caught and fixed a real `versionCode` collision risk at patch ≥ 100, plus a missing format guard on manually-typed release versions.

## Test plan
- [x] `go build ./...`, `bash scripts/ci/guard-data-access.sh` — clean (no Go code touched, sanity check only)
- [x] `actionlint`/`shellcheck` on `release.yml` — clean
- [x] Live-verified: built a real signed release APK locally with the same keystore CI uses, confirmed the signature fingerprint matches Key Vault's stored copy, confirmed injected version/versionCode via `aapt dump badging`
- [x] Installed on a real emulator: app launches, embedded Go server boots (`listening on 127.0.0.1:...` in logcat)
- [x] **The actual upgrade guarantee**: built a second signed APK with a higher versionCode, installed directly over the running first install with no uninstall — succeeded, version bumped in place
- [x] Review doc: `docs/code-reviews/2026-07-26-android-release-signing.md`

**Signing key**: durable copies in Azure Key Vault (`kv-unitill-dev`) and this repo's GitHub Actions secrets — see the review doc for the disaster-recovery story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yS4U3wicRKdqvKVvKQHpt