### PR TITLE
fix: Android startup timeout too tight + APK bundling all 4 ABIs

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -71,9 +71,13 @@ android {
 }
 
 // Regenerates libs/unitill-mobile.aar from the Go source (../mobile) on every
-// build, via `gomobile bind` — the .aar itself is NOT committed to git (it's
-// a ~90MB build artifact; see .gitignore), this is the actual source of
-// truth. Needs the Android SDK/NDK (ANDROID_HOME) and `gomobile`/`gobind` on
+// build, via `gomobile bind` — the .aar itself is NOT committed to git (it
+// was a ~90MB build artifact when this task built all 4 gomobile-default
+// ABIs; expect meaningfully smaller now that -target below is restricted
+// to just arm64/arm — not yet re-measured on a real build, no Android
+// SDK/NDK available to build+verify from the session that made that
+// change, 2026-07-28); see .gitignore. This generated .aar is the actual
+// source of truth. Needs the Android SDK/NDK (ANDROID_HOME) and `gomobile`/`gobind` on
 // PATH — see ut-docs/adr/0023-android-ios-till-strategy.md for setup.
 // -androidapi MUST match defaultConfig.minSdk above.
 //
@@ -93,7 +97,18 @@ val generateAar =
         workingDir = file("../..")
         commandLine(
             "gomobile", "bind",
-            "-target=android",
+            // Bare "-target=android" builds shared libraries for ALL
+            // instruction sets gomobile supports (arm, arm64, 386, amd64) —
+            // confirmed via `gomobile bind -h`, not assumed — even though
+            // any single phone only ever uses one. 386/amd64 are
+            // effectively emulator-only; no real phone ships with them.
+            // Restricting to the two real-phone ABIs (arm64-v8a for
+            // anything reasonably recent, armeabi-v7a for older 32-bit
+            // devices still within minSdk 24's "Android 7.0+" range) is
+            // the single biggest lever on the ~90MB unstripped .aar this
+            // task produces (flagged after the app was reported as a
+            // 180MB install on a real device, 2026-07-28).
+            "-target=android/arm64,android/arm",
             "-androidapi", "24",
             "-o", "android/app/libs/unitill-mobile.aar",
             "./mobile",

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -132,7 +132,16 @@ func Start(dataDir string) (string, error) {
 		close(newInst.done)
 	}()
 
-	if err := waitUntilReady(addr, 10*time.Second, newInst); err != nil {
+	// 10s was too tight in practice: a real low/mid-range Android phone's
+	// first boot (fresh install: 18 migrations against a cold SQLite file,
+	// plus wazero compiling any bundled plugins' WASM with no cache yet)
+	// missed it and surfaced as "server did not become ready within 10s"
+	// (reported 2026-07-28, real device). Desktop's equivalent wait
+	// (cmd/unitill-desktop/desktop.go) made the same ~10s assumption, but
+	// phone hardware skews weaker and more variable than desktop/POS
+	// terminal hardware, so mobile gets more headroom than desktop rather
+	// than copying its number.
+	if err := waitUntilReady(addr, 30*time.Second, newInst); err != nil {
 		cancel()
 		<-newInst.done // wait for the full teardown before reporting failure
 		return "", err


### PR DESCRIPTION
## Summary
Real bug report from Farshid's friend testing the Android app on a Huawei Mate 20 Lite (SNE-LX1, Kirin 710, community EMUI 12):
1. App failed to start: `mobile: server did not become ready within 10s`
2. Separately: "the apk is 180mb, is it right?" — no, and here's why.

## Fix 1: startup timeout (`mobile/mobile.go`)
Traced `app.Run`'s boot sequence — DB open + 18 migrations, plugin WASM compilation (wazero, no cache on first boot), etc. all happen before the HTTP server starts listening, which is what the `/healthz` poll this timeout gates on needs. 10s assumed desktop-class hardware; a 2018 mid-range phone on a cold first-install can plausibly exceed that. Bumped to 30s.

## Fix 2: APK size (`android/app/build.gradle.kts`)
`gomobile bind -target=android` (no ABI qualifier) builds shared libraries for **all 4** supported instruction sets (arm, arm64, 386, amd64) — confirmed via `gomobile bind -h`, not assumed — even though a single phone only ever uses one. 386/amd64 are emulator-only, no real phone ships with them. Restricted to `-target=android/arm64,android/arm` (real phone ABIs; minSdk 24 = Android 7.0+ covers both).

## Verified / not verified
- ✅ `go build ./mobile/...` and `go test ./mobile/...` pass
- ❌ **Not verified**: the Android/Kotlin build change and actual resulting APK size — no Android SDK/NDK available in this session to run `gomobile bind` or assemble a real APK. This needs a real CI build (this repo's `release.yml` has the actual toolchain) or a local build on your end before merging — please don't merge this blind on my say-so for the Android half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yS4U3wicRKdqvKVvKQHpt