### PR TITLE
fix: self-update could attempt a redundant/stale "update"

### DIFF
--- a/internal/pages/update_api.go
+++ b/internal/pages/update_api.go
@@ -27,8 +27,34 @@ func registerUpdateAPI(mux *http.ServeMux, d *common.Deps) {
 			w.WriteHeader(status)
 			_ = json.NewEncoder(w).Encode(map[string]any{"success": ok, "message": msg})
 		}
+		respondCurrent := func() {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": true, "already_current": true,
+				"message": "already up to date (v" + buildinfo.Version + ")",
+			})
+		}
 		if !selfupdate.Supported() {
 			respond(http.StatusBadRequest, false, selfupdate.ErrUnsupported.Error())
+			return
+		}
+		// Re-check freshness before applying, don't trust the button's
+		// data-latest (baked from the status bar's cached updates.Current()
+		// at the PAGE'S last render/boot, up to 24h stale by design — see
+		// updates.Start's daily ticker). Without this, a till that's already
+		// on the latest version (e.g. just self-updated, or a new release
+		// landed after this page loaded but the running build is still
+		// current) can be told to "update" to a version that isn't actually
+		// newer — confirmed as a real user-visible bug 2026-07-28: the
+		// status bar showed "Update now v0.2.40" while v0.2.41 was already
+		// running. selfupdate.Apply has no equality guard of its own, so
+		// this would silently re-download+reinstall the same build instead
+		// of failing loudly, at best a wasted download, at worst whatever
+		// state applyMacApp's helper hits redoing a swap it just did.
+		st := updates.CheckNow(r.Context())
+		if !st.Available {
+			respondCurrent()
 			return
 		}
 		// Apply stages the swap and schedules the re-exec; the response flushes

--- a/web/ui/layouts/base.html
+++ b/web/ui/layouts/base.html
@@ -78,10 +78,20 @@
           fetch('/api/update/apply', { method: 'POST' })
             .then(function (r) { return r.json().catch(function () { return {}; }); })
             .then(function (res) {
+              // already_current: the status bar's cached "update available"
+              // was stale (checked up to 24h ago) and the backend re-verified
+              // right before applying that this build is already the latest
+              // — nothing was downloaded or restarted, so don't claim it was.
+              if (res && res.already_current) {
+                btn.textContent = 'Already up to date';
+                btn.disabled = false;
+                return;
+              }
               btn.textContent = (res && res.success === false) ? 'Update failed — see logs' : 'Restarting…';
             })
             .catch(function () { btn.textContent = 'Restarting…'; })
             .finally(function () {
+              if (btn.textContent === 'Already up to date') return;
               // Archive installs re-exec in place (reconnect + reload). The mac
               // .app quits and relaunches itself, so the window just closes and
               // reopens on the new version.


### PR DESCRIPTION
## Summary
Real bug report: Mac app showed "Update now v0.2.40" while already running v0.2.41, and clicking it failed.

## Root cause
The button's target version comes from `updates.Current()`'s cache, which only refreshes 30s after boot then every 24h. `/api/update/apply` had no freshness guard — it would call `selfupdate.Apply()` unconditionally, which itself has no equality check either, so it would just re-fetch and re-install whatever "latest" actually is, even if that's the build already running.

## Fix
- Backend: re-check freshness (real API call, not the cache) immediately before applying; short-circuit with a clear `already_current` response instead of attempting a pointless/stale update.
- Frontend: handle that response distinctly instead of unconditionally showing "Restarting…" (which was actively misleading — nothing restarts in this case), and skip the healthz-polling reload loop that has nothing to wait for.

## Verified
`go build ./...` and `go test` pass on every affected package (`updates`, `selfupdate`, `pages`, `mobile`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yS4U3wicRKdqvKVvKQHpt