### PR TITLE
fix: custom OSK never suppressed the native keyboard on Android

### DIFF
--- a/web/public/osk.js
+++ b/web/public/osk.js
@@ -175,15 +175,41 @@
     current = el;
     if (!osk) build();
     shift = false;
+    // isNumeric reads the REAL inputmode (numeric/decimal/tel) for layout
+    // selection — must happen before the inputmode="none" override below
+    // overwrites it.
     layer = isNumeric(el) ? 'num' : baseLayout();
     render();
     osk.classList.add('osk-open');
     document.body.classList.add('osk-padded');
+    // Suppress the native/OS on-screen keyboard while ours is up. Without
+    // this, a real Android WebView shows BOTH: the page has no way to tell
+    // Android "don't open your own IME," so it opens anyway on focus —
+    // which resizes the WebView's viewport and breaks position:sticky/
+    // fixed layout (confirmed live, real device, 2026-07-28: the status
+    // bar ended up floating mid-screen, overlapping content) — while this
+    // custom keyboard also tries to render in whatever space is left.
+    // inputmode="none" is the standard, widely-supported way to do this;
+    // insert()/backspace() below already write via setRangeText + a
+    // synthetic `input` event, never needed a real IME to begin with.
+    // Kiosk/desktop are unaffected (no OS virtual keyboard to suppress
+    // there in the first place). Save+restore, not just remove: the
+    // isNumeric() call above already needed the ORIGINAL inputmode.
+    if (el.dataset.oskPrevInputmode === undefined) {
+      el.dataset.oskPrevInputmode = el.getAttribute('inputmode') || '';
+    }
+    el.setAttribute('inputmode', 'none');
     // Keep the focused field visible above the keyboard.
     setTimeout(function () { el.scrollIntoView({ block: 'center', behavior: 'smooth' }); }, 60);
   }
 
   function hide() {
+    if (current) {
+      var prev = current.dataset.oskPrevInputmode;
+      if (prev) current.setAttribute('inputmode', prev);
+      else current.removeAttribute('inputmode');
+      delete current.dataset.oskPrevInputmode;
+    }
     current = null;
     if (!osk) return;
     osk.classList.remove('osk-open');


### PR DESCRIPTION
## Summary
Real bug report + screenshots: on a real Android phone (Huawei Mate 20 Lite), focusing the barcode field opened the phone's native keyboard, which resized the WebView viewport and broke `position:sticky`/`fixed` layout — the status bar ended up floating mid-screen, overlapping content.

## Root cause
The custom on-screen keyboard (`osk.js`, built for kiosk Pis with no OS keyboard at all) only ever adds its own UI on top of a focused input — it never told the browser to suppress the OS's own keyboard. Invisible on a kiosk Pi (nothing to conflict with); on real Android, both keyboards try to appear, and the native one's window-resize is what broke the layout.

## Fix
`inputmode="none"` on the focused field while the custom OSK is showing it — standard way to keep the input focusable while telling the browser not to open its own IME. Careful about ordering: `isNumeric()` reads the field's real `inputmode` to pick the keyboard layout, so that has to happen before the override; `hide()` saves/restores the original value.

## Verified / not verified
- ✅ Full e2e suite (12/12, including the existing OSK spec) passes against a real browser — no regression in show/type/hide.
- ❌ Not verified against an actual Android WebView/native IME — no device/emulator available. The mechanism is standard and well within this app's minSdk 24, but needs a real-device retest like the other Android fixes in this batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yS4U3wicRKdqvKVvKQHpt