### PR TITLE
fix: android/iOS self-update gap + stuck update-restart UI + Android marketplace endpoint

### DIFF
--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -51,6 +51,26 @@ func supportedFor(exe, goos string) bool {
 	if goos == "windows" {
 		return false // updates via the installer
 	}
+	if goos == "android" || goos == "ios" {
+		// Neither had a real self-update mechanism to begin with — this was
+		// falling through to the desktop default (true) with nothing to
+		// back it up. Apply() only ever fetches a
+		// unitill-pos_<version>_<goos>_<arch>.tar.gz release archive (or,
+		// on darwin, a .dmg via applyMacApp); no such archive is ever
+		// published for android/ios (mobile/mobile.go's release job
+		// attaches an .apk, nothing a self-swap could use), so tapping
+		// "Update now" here was guaranteed to fail with a confusing "no
+		// release archive" error — same user-visible symptom as the
+		// stale-cache Mac bug fixed alongside this, different root cause
+		// (a feature that was never actually built for this platform, not
+		// a timing bug). False here makes the status bar correctly fall
+		// back to the plain "Update available" download-page link instead
+		// (same fallback Windows already uses). A real mobile in-app
+		// updater (download the .apk, launch Android's package-install
+		// intent) is a genuine feature to build later, not implemented by
+		// this change.
+		return false
+	}
 	// Packaged installs update via their package manager, not a self-swap.
 	for _, p := range []string{"/usr/", "/opt/unitill/"} {
 		if strings.HasPrefix(exe, p) {

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -18,6 +18,8 @@ func TestSupportedFor(t *testing.T) {
 		{"deb /usr", "/usr/bin/unitill-pos", "linux", false},
 		{"deb /opt", "/opt/unitill/unitill-pos", "linux", false},
 		{"windows", `C:\\Program Files\\UniversalTill\\unitill-pos.exe`, "windows", false},
+		{"android", "/data/app/com.universaltill.pos/lib/arm64/libmobile.so", "android", false},
+		{"ios", "/var/containers/Bundle/Application/x/Universal Till.app/unitill-pos", "ios", false},
 	}
 	for _, c := range cases {
 		if got := supportedFor(c.exe, c.goos); got != c.want {

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -123,6 +123,24 @@ func Start(dataDir string) (string, error) {
 	if err := os.Setenv("UT_OPEN_BROWSER", "0"); err != nil {
 		return "", fmt.Errorf("mobile: set UT_OPEN_BROWSER: %w", err)
 	}
+	// Bug report, 2026-07-28 (real device): the plugin store showed
+	// "Marketplace: not connected" and registration failed with "dial tcp
+	// 127.0.0.1:8081: connection refused". Root cause: config.Init's
+	// UT_MARKETPLACE_ENDPOINT_URL default (internal/config/config.go) is a
+	// dev-only loopback pointing at scripts/mock-marketplace, meant to be
+	// overridden by a bundled pos.env in real distributions — the desktop
+	// installers get this from packaging/pos.env.example
+	// (UT_MARKETPLACE_ENDPOINT_URL=https://cloud.universaltill.com/api),
+	// but nothing sets it for Android: there's no pos.env on a fresh phone
+	// install, and this file never set it either. Only set it if the host
+	// process doesn't already have one configured (e.g. a future
+	// dev/staging override from the native Kotlin layer), same
+	// don't-override-explicit-config posture as enroll.go.
+	if os.Getenv("UT_MARKETPLACE_ENDPOINT_URL") == "" {
+		if err := os.Setenv("UT_MARKETPLACE_ENDPOINT_URL", "https://cloud.universaltill.com/api"); err != nil {
+			return "", fmt.Errorf("mobile: set UT_MARKETPLACE_ENDPOINT_URL: %w", err)
+		}
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	newInst := &instance{dataDir: dataDir, addr: addr, cancel: cancel, done: make(chan struct{})}

--- a/web/ui/layouts/base.html
+++ b/web/ui/layouts/base.html
@@ -87,11 +87,12 @@
                 btn.disabled = false;
                 return;
               }
-              btn.textContent = (res && res.success === false) ? 'Update failed — see logs' : 'Restarting…';
-            })
-            .catch(function () { btn.textContent = 'Restarting…'; })
-            .finally(function () {
-              if (btn.textContent === 'Already up to date') return;
+              var failed = res && res.success === false;
+              btn.textContent = failed ? 'Update failed — see logs' : 'Restarting…';
+              // A failed apply never left the server mid-restart — nothing to
+              // poll for, and polling anyway just leaves the failure message
+              // sitting there for 3 minutes before silently going stale.
+              if (failed) { btn.disabled = false; return; }
               // Archive installs re-exec in place (reconnect + reload). The mac
               // .app quits and relaunches itself, so the window just closes and
               // reopens on the new version.
@@ -101,7 +102,21 @@
                 fetch('/healthz', { cache: 'no-store' }).then(function (r) {
                   if (r.ok) { clearInterval(iv); location.reload(); }
                 }).catch(function () {});
-                if (tries > 90) { clearInterval(iv); }
+                if (tries > 90) {
+                  clearInterval(iv);
+                  // The swap itself already happened server-side before this
+                  // loop started (Apply() returns after staging it, not after
+                  // it's live) — a timeout here means the reconnect/reload
+                  // never observed it come back (a slow restart, a background
+                  // tab throttled by the browser, or a one-off blip), not that
+                  // the update failed. Leaving the button stuck on
+                  // "Restarting…" forever with no way out is what previously
+                  // read as "the update doesn't work" — offer a manual retry
+                  // instead of a silent, permanent dead end.
+                  btn.disabled = false;
+                  btn.textContent = 'Update installed — click to reload';
+                  btn.onclick = function () { location.reload(); };
+                }
               }, 2000);
             });
         });


### PR DESCRIPTION
## Summary
- `selfupdate.Supported()` now returns `false` for android/ios instead of falling through to the desktop default — those platforms never had a real self-update path (no archive/.dmg is ever published for them), so the button was guaranteed to fail.
- The status-bar "Update now" button could get permanently stuck on "Restarting…" if the post-update healthz reconnect loop timed out (background-tab throttling, a slow restart) — the backend swap had already succeeded, the UI just never told the user. Now falls back to a manual "click to reload" after ~3 minutes, and skips the pointless poll on an explicit failure response.
- `mobile.go` now explicitly sets `UT_MARKETPLACE_ENDPOINT_URL` for Android (previously fell back to the dev-only `127.0.0.1:8081` default — desktop gets the real value via `packaging/pos.env.example`, Android has no such file).

## Verification
- `go build ./...` and `go test ./...` pass.
- Reproduced the real self-update flow end-to-end locally on this Mac: built a real v0.2.41 macOS `.app`+`.dmg` and also downloaded the actual released `unitill-pos_0.2.41_darwin_arm64.tar.gz` archive, ran each, hit `/api/update/apply` for real against the live GitHub release (v0.2.43), and confirmed the backend swap + re-exec correctly rebinds the same port with no gap the browser can't recover from — the archive-path re-exec (`syscall.Exec`, CLOEXEC-released socket) worked cleanly in both cases. The remaining gap was purely the frontend's silent, un-recoverable stuck state on a poll timeout, which this PR fixes.
- New `TestSupportedFor` cases for android/ios pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)