### PR TITLE
refactor: move dine-in/takeaway tax rules out of core into a plugin hook

### DIFF
--- a/docs/code-reviews/2026-07-28-tax-rate-plugin-hook-refactor.md
+++ b/docs/code-reviews/2026-07-28-tax-rate-plugin-hook-refactor.md
@@ -1,0 +1,99 @@
+# 2026-07-28 — Move dine-in/takeaway tax rules out of core, into a plugin hook
+
+## Context
+Farshid's question, directly: "why everytime I ask something like changing
+the tax for germany... you change a lot in the pos core. I thought the core
+things doesn't need to change a lot and everything can be change by
+plugins." Fair — this session's earlier PR (`2026-07-28-order-type-tax-
+switching.md`) embedded Germany's specific §12 UStG dine-in/takeaway rule
+directly in core: a new `tax_codes.takeaway_rate_basis_points` column, a
+`Config.ReducedTaxRateBasisPoints` global setting, and the actual switching
+logic (`effectiveTaxRateBP`), plus a DE=7% seed hardcoded into the setup
+wizard. The UK has its own version of the same problem (hot takeaway food
+VAT), and every other country's quirk would have needed its own core PR
+under that design — exactly the pattern being pushed back on.
+
+## What blocked doing this the "obvious" way from the start
+There was no way for a plugin to answer core with a *computed value*. The
+only existing blocking hook (payment authorization) only supports
+accept/reject — `EventHandler` was `func(ctx, event) error`, and
+`WasmRuntime.HandleEvent` captured a WASM plugin's stdout but only logged
+it, never returned it to the caller. Building "ask a plugin to compute
+something" required extending the plugin runtime first.
+
+## What changed
+
+**Plugin runtime (`internal/plugins`)** — generic, reusable, not tax-specific:
+- `EventHandler` now returns `(json.RawMessage, error)` instead of just
+  `error`. `Publish`'s Blocking case discards the value (unchanged external
+  behavior — payment authorization still only cares about the error).
+- `WasmRuntime.HandleEvent` returns the plugin's trimmed stdout as the
+  response instead of only logging it.
+- New `EventBus.Ask(ctx, eventType, payload) (json.RawMessage, bool, error)`:
+  blocking, returns the first answering subscriber's response, `ok=false`
+  when nobody answers. Events ending in `.ask` auto-run Blocking, same
+  convention as the existing `.authorize` suffix rule.
+- This is genuinely reusable beyond tax — any future "ask an installed
+  plugin to compute X" hook (a pricing-rule plugin, say) can use it as-is.
+
+**Core (`internal/pos`)** — reverted to knowing nothing about any country's
+tax rules:
+- Removed: `BasketLine.TakeawayRateBP`, `Config.ReducedTaxRateBasisPoints`,
+  the pinned-vs-global-fallback branching logic, the DE=7% setup-wizard
+  seed, `common.RuntimeState.ReducedTaxRatePct` and its settings-key
+  plumbing (5 files: `common/deps.go`, `common/state.go`, `init.go`,
+  `settings_page.go`, `setup_page.go`) and the wizard's `reducedTax` Alpine
+  state (`web/ui/pages/setup.html`).
+- Added instead: `TaxRateAsker` interface (`AskTaxRateBP(l, orderType) (bp,
+  ok)`), `Service.SetTaxRateAsker`/`taxAsker` field. `effectiveTaxRateBP`
+  asks the installed asker first; `ok=false` (or no asker at all — the
+  default) falls back to the line's own configured rate, exactly today's
+  plain pre-Germany behavior.
+- `BasketLine.TaxCodeID` (new, replacing `TakeawayRateBP`): which tax code
+  a line's rate came from, so a plugin can tell item categories apart
+  without core interpreting what any of them mean. Threaded through the
+  same 5 SQL queries in `internal/data/pos_repo.go` that the previous PR
+  touched (`i.tax_code_id`, no JOIN needed — simpler than the column it
+  replaces).
+- `OrderType`/`OrderTypeTakeaway` stayed in core: dine-in vs. takeaway is a
+  genuinely universal POS concept (kitchen tickets already had it;
+  SumUp's own research confirms the same pattern), not a German invention.
+  What it does to *tax*, specifically, is now 100% a plugin's call.
+
+**Wiring (`internal/pages/tax_hook.go`, new)**: `pluginTaxRateAsker`
+implements `TaxRateAsker` by calling `EventBus.Ask("tax.rate.ask", …)` with
+the line's item/tax-code/rate and the sale's order type; installed on
+`d.Engine` once at boot (`init.go`). `internal/pos` still never imports
+the plugin subsystem — this file is the seam, matching how
+`blockingPaymentEvent` (`internal/pages/refund_page.go`) is the seam for
+payment authorization.
+
+## Judgment calls
+- **`TaxCodeID`, not the tax code's own rate data.** Passing an opaque ID
+  keeps core from needing to know or store anything about what a "takeaway
+  override" even is — a plugin can maintain its own mapping (tax code →
+  override rate) in its own settings/storage, entirely outside core's
+  schema. (Follow-up, not built here: that mapping currently has no admin
+  UI in the plugin either — same pre-existing gap flagged in the prior
+  PR's review, now on the plugin side instead of core's.)
+- **First answerer wins, not "ask everyone."** Mirrors how payment methods
+  are matched 1:1 by entry key — a tax plugin is expected to be
+  authoritative for lines it recognizes, not one of several competing
+  opinions.
+- **`.ask` suffix auto-blocks**, reusing the existing `.authorize` pattern
+  rather than inventing a new registration mechanism plugins would need to
+  opt into explicitly.
+
+## Verification
+`go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l`, both CI
+guard scripts all pass. New tests: `TestEventBus_Ask` (the generic
+mechanism: no subscriber, a subscriber that declines, one that answers, one
+that errors), `TestOrderTypeTaxSwitching` (rewritten — proves core is inert
+with no asker installed, then exercises a fake asker the same shape a real
+tax plugin would provide), `TestPriceResolverAdapter_TaxCodeID` (SQL-level,
+replacing the old TakeawayRateBP test).
+
+## Not done here
+`ut-plugin-tax-de` doesn't answer this hook yet — that's the next, separate
+change (different repo). Core's side is complete and testable independent
+of whether any plugin actually subscribes.

--- a/internal/data/pos_repo.go
+++ b/internal/data/pos_repo.go
@@ -36,20 +36,20 @@ type ShortcutSearchResult struct {
 
 // ShortcutLine represents a priced line derived from a barcode/lookup for shortcuts.
 type ShortcutLine struct {
-	SKU        string
-	Name       string
-	ItemID     string
-	VariantID  string
-	Price      int64
-	TaxRateBP  int
-	// TakeawayRateBP is the tax rate to use instead of TaxRateBP when the
-	// sale's order type is takeaway (0 = no override, e.g. an item pinned to
-	// one rate regardless of order type — see tax_codes.takeaway_rate_basis_points).
-	TakeawayRateBP int
-	IsWeighed      bool
-	ImageURL       string
-	Label          string
-	HasVariant     bool
+	SKU       string
+	Name      string
+	ItemID    string
+	VariantID string
+	Price     int64
+	TaxRateBP int
+	// TaxCodeID identifies which tax code this rate came from ("" if the
+	// item has none) — a tax plugin (internal/pos.TaxRateAsker) uses it to
+	// tell item categories apart; core itself never interprets it.
+	TaxCodeID  string
+	IsWeighed  bool
+	ImageURL   string
+	Label      string
+	HasVariant bool
 }
 
 // SaleLineSnapshot represents stored sale_line fields used by returns.
@@ -2819,24 +2819,24 @@ LIMIT 1
 }
 
 type shortcutPriceRow struct {
-	ItemID         string
-	ItemName       string
-	VariantID      string
-	Variant        string
-	SKU            string
-	Price          int64
-	Image          sql.NullString
-	TaxRateBP      sql.NullInt64
-	TakeawayRateBP sql.NullInt64
-	IsWeighed      sql.NullInt64
-	Label          sql.NullString
+	ItemID    string
+	ItemName  string
+	VariantID string
+	Variant   string
+	SKU       string
+	Price     int64
+	Image     sql.NullString
+	TaxRateBP sql.NullInt64
+	TaxCodeID sql.NullString
+	IsWeighed sql.NullInt64
+	Label     sql.NullString
 }
 
 func (r *POSRepo) resolveVariant(ctx context.Context, code string) (shortcutPriceRow, bool) {
 	row := r.db.QueryRowContext(ctx, `
 SELECT i.id, i.name, v.id, v.name, v.price, i.is_weighed,
        (SELECT path FROM item_images img WHERE img.item_id = i.id AND img.role = 'thumbnail' LIMIT 1),
-       COALESCE(t.rate_basis_points, 0), COALESCE(t.takeaway_rate_basis_points, 0)
+       COALESCE(t.rate_basis_points, 0), i.tax_code_id
 FROM variant_barcodes vb
 JOIN item_variants v ON v.id = vb.variant_id
 JOIN items i ON i.id = v.item_id
@@ -2846,7 +2846,7 @@ WHERE vb.barcode = ?
 LIMIT 1
 `, code)
 	var res shortcutPriceRow
-	if err := row.Scan(&res.ItemID, &res.ItemName, &res.VariantID, &res.Variant, &res.Price, &res.IsWeighed, &res.Image, &res.TaxRateBP, &res.TakeawayRateBP); err != nil {
+	if err := row.Scan(&res.ItemID, &res.ItemName, &res.VariantID, &res.Variant, &res.Price, &res.IsWeighed, &res.Image, &res.TaxRateBP, &res.TaxCodeID); err != nil {
 		return shortcutPriceRow{}, false
 	}
 	return res, true
@@ -2856,7 +2856,7 @@ func (r *POSRepo) resolveItem(ctx context.Context, code string) (shortcutPriceRo
 	row := r.db.QueryRowContext(ctx, `
 SELECT i.id, i.name, i.base_price, i.is_weighed,
        (SELECT path FROM item_images img WHERE img.item_id = i.id AND img.role = 'thumbnail' LIMIT 1),
-       COALESCE(t.rate_basis_points, 0), COALESCE(t.takeaway_rate_basis_points, 0)
+       COALESCE(t.rate_basis_points, 0), i.tax_code_id
 FROM item_barcodes ib
 JOIN items i ON i.id = ib.item_id
 LEFT JOIN tax_codes t ON t.id = i.tax_code_id
@@ -2865,7 +2865,7 @@ WHERE ib.barcode = ?
 LIMIT 1
 `, code)
 	var res shortcutPriceRow
-	if err := row.Scan(&res.ItemID, &res.ItemName, &res.Price, &res.IsWeighed, &res.Image, &res.TaxRateBP, &res.TakeawayRateBP); err != nil {
+	if err := row.Scan(&res.ItemID, &res.ItemName, &res.Price, &res.IsWeighed, &res.Image, &res.TaxRateBP, &res.TaxCodeID); err != nil {
 		return shortcutPriceRow{}, false
 	}
 	return res, true
@@ -2875,7 +2875,7 @@ func (r *POSRepo) resolveShortcut(ctx context.Context, code string) (shortcutPri
 	row := r.db.QueryRowContext(ctx, `
 SELECT sb.item_id, sb.label, i.base_price, i.is_weighed,
        (SELECT path FROM item_images img WHERE img.item_id = i.id AND img.role = 'thumbnail' LIMIT 1),
-       COALESCE(t.rate_basis_points, 0), COALESCE(t.takeaway_rate_basis_points, 0)
+       COALESCE(t.rate_basis_points, 0), i.tax_code_id
 FROM shortcut_buttons sb
 JOIN items i ON i.id = sb.item_id
 LEFT JOIN tax_codes t ON t.id = i.tax_code_id
@@ -2884,7 +2884,7 @@ WHERE sb.barcode = ?
 LIMIT 1
 `, code)
 	var res shortcutPriceRow
-	if err := row.Scan(&res.ItemID, &res.Label, &res.Price, &res.IsWeighed, &res.Image, &res.TaxRateBP, &res.TakeawayRateBP); err != nil {
+	if err := row.Scan(&res.ItemID, &res.Label, &res.Price, &res.IsWeighed, &res.Image, &res.TaxRateBP, &res.TaxCodeID); err != nil {
 		return shortcutPriceRow{}, false
 	}
 	res.ItemName = res.Label.String
@@ -2895,14 +2895,14 @@ func (r *POSRepo) resolveSKU(ctx context.Context, sku string) (shortcutPriceRow,
 	row := r.db.QueryRowContext(ctx, `
 SELECT i.id, i.sku, i.name, i.base_price, i.is_weighed,
        (SELECT path FROM item_images img WHERE img.item_id = i.id AND img.role = 'thumbnail' LIMIT 1),
-       COALESCE(t.rate_basis_points, 0), COALESCE(t.takeaway_rate_basis_points, 0)
+       COALESCE(t.rate_basis_points, 0), i.tax_code_id
 FROM items i
 LEFT JOIN tax_codes t ON t.id = i.tax_code_id
 WHERE i.is_active = 1 AND i.sku = ?
 LIMIT 1
 `, sku)
 	var res shortcutPriceRow
-	if err := row.Scan(&res.ItemID, &res.SKU, &res.ItemName, &res.Price, &res.IsWeighed, &res.Image, &res.TaxRateBP, &res.TakeawayRateBP); err != nil {
+	if err := row.Scan(&res.ItemID, &res.SKU, &res.ItemName, &res.Price, &res.IsWeighed, &res.Image, &res.TaxRateBP, &res.TaxCodeID); err != nil {
 		return shortcutPriceRow{}, false
 	}
 	return res, true
@@ -2912,7 +2912,7 @@ func (r *POSRepo) resolveNameLike(ctx context.Context, like string) (shortcutPri
 	row := r.db.QueryRowContext(ctx, `
 SELECT i.id, i.name, i.base_price, i.is_weighed,
        (SELECT path FROM item_images img WHERE img.item_id = i.id AND img.role = 'thumbnail' LIMIT 1),
-       COALESCE(t.rate_basis_points, 0), COALESCE(t.takeaway_rate_basis_points, 0)
+       COALESCE(t.rate_basis_points, 0), i.tax_code_id
 FROM items i
 LEFT JOIN tax_codes t ON t.id = i.tax_code_id
 WHERE i.is_active = 1 AND i.name LIKE ?
@@ -2920,7 +2920,7 @@ ORDER BY i.name
 LIMIT 1
 `, like)
 	var res shortcutPriceRow
-	if err := row.Scan(&res.ItemID, &res.ItemName, &res.Price, &res.IsWeighed, &res.Image, &res.TaxRateBP, &res.TakeawayRateBP); err != nil {
+	if err := row.Scan(&res.ItemID, &res.ItemName, &res.Price, &res.IsWeighed, &res.Image, &res.TaxRateBP, &res.TaxCodeID); err != nil {
 		return shortcutPriceRow{}, false
 	}
 	return res, true
@@ -2936,15 +2936,15 @@ func (r *POSRepo) resolvePrice(ctx context.Context, itemID, variantID string, fa
 
 func (r *POSRepo) toShortcutLine(code string, price int64, row shortcutPriceRow) ShortcutLine {
 	line := ShortcutLine{
-		SKU:            code,
-		Name:           row.ItemName,
-		ItemID:         row.ItemID,
-		VariantID:      row.VariantID,
-		Price:          price,
-		TaxRateBP:      int(row.TaxRateBP.Int64),
-		TakeawayRateBP: int(row.TakeawayRateBP.Int64),
-		IsWeighed:      row.IsWeighed.Int64 == 1,
-		HasVariant:     row.VariantID != "",
+		SKU:        code,
+		Name:       row.ItemName,
+		ItemID:     row.ItemID,
+		VariantID:  row.VariantID,
+		Price:      price,
+		TaxRateBP:  int(row.TaxRateBP.Int64),
+		TaxCodeID:  row.TaxCodeID.String,
+		IsWeighed:  row.IsWeighed.Int64 == 1,
+		HasVariant: row.VariantID != "",
 	}
 	if row.Image.Valid {
 		line.ImageURL = row.Image.String

--- a/internal/pages/common/deps.go
+++ b/internal/pages/common/deps.go
@@ -43,12 +43,6 @@ type RuntimeState struct {
 	Region                 string
 	TaxInclusive           bool
 	TaxRatePct             int
-	// ReducedTaxRatePct is the takeaway/reduced-rate VAT percentage (§12
-	// UStG in Germany: 7% takeaway vs. 19% eat-in on drinks) applied to
-	// order-type-eligible lines with no per-item tax code when the sale's
-	// order type is takeaway. 0 = not configured for this country/shop, so
-	// order type never changes the default rate.
-	ReducedTaxRatePct      int
 	AllowNegativeInventory bool
 	UIScale                float64 // interface scale for this till's screen (0 = unset)
 	IdleLockMinutes        int     // idle auto-lock window in minutes (0 = off)

--- a/internal/pages/common/state.go
+++ b/internal/pages/common/state.go
@@ -17,7 +17,6 @@ const (
 	KeyRegion         = "store.region"
 	KeyTaxInclusive   = "store.tax_inclusive"
 	KeyTaxRate        = "store.tax_rate"
-	KeyReducedTaxRate = "store.reduced_tax_rate"
 	KeyUIScale        = "display.ui_scale"
 	KeyOSK            = "display.osk"
 	KeyIdleLock       = "auth.idle_lock_minutes"
@@ -65,11 +64,6 @@ func LoadState(ctx context.Context, store *settings.Store, cfg *config.Config) R
 			st.TaxRatePct = n
 		}
 	}
-	if v := get(KeyReducedTaxRate, "0"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			st.ReducedTaxRatePct = n
-		}
-	}
 	if v := get("pos.allow_negative_inventory", strconv.FormatBool(st.AllowNegativeInventory)); v != "" {
 		st.AllowNegativeInventory, _ = strconv.ParseBool(v)
 	}
@@ -99,7 +93,6 @@ func SaveState(ctx context.Context, store *settings.Store, st RuntimeState) {
 	_ = store.Set(ctx, KeyRegion, st.Region)
 	_ = store.Set(ctx, KeyTaxInclusive, strconv.FormatBool(st.TaxInclusive))
 	_ = store.Set(ctx, KeyTaxRate, strconv.Itoa(st.TaxRatePct))
-	_ = store.Set(ctx, KeyReducedTaxRate, strconv.Itoa(st.ReducedTaxRatePct))
 	if st.UIScale > 0 {
 		_ = store.Set(ctx, KeyUIScale, strconv.FormatFloat(st.UIScale, 'f', -1, 64))
 	}

--- a/internal/pages/init.go
+++ b/internal/pages/init.go
@@ -85,10 +85,13 @@ func Init(ctx context.Context, cfg *config.Config, pm *plugins.Manager, db *sql.
 	btnStore := ui.NewButtonStore(db)
 	resolver := ui.PriceResolverAdapter{Store: btnStore}
 	engine := pos.NewServiceWithResolver(pos.Config{
-		TaxInclusive:              state.TaxInclusive,
-		TaxRateBasisPoints:        state.TaxRatePct * 100,
-		ReducedTaxRateBasisPoints: state.ReducedTaxRatePct * 100,
+		TaxInclusive:       state.TaxInclusive,
+		TaxRateBasisPoints: state.TaxRatePct * 100,
 	}, resolver)
+	// Country-specific tax rules (e.g. Germany's dine-in/takeaway VAT
+	// switch) are entirely a plugin's call — core has no built-in opinion,
+	// see pluginTaxRateAsker.
+	engine.SetTaxRateAsker(&pluginTaxRateAsker{db: db})
 
 	// Labels are locale keys; the nav renders them through T (unknown keys —
 	// e.g. plugin menu labels from manifests — pass through unchanged).
@@ -189,9 +192,8 @@ func Init(ctx context.Context, cfg *config.Config, pm *plugins.Manager, db *sql.
 		// In-place tax swap: replacing the engine (as the settings
 		// handlers do) would empty the basket of a sale in progress.
 		if newCfg := (pos.Config{
-			TaxInclusive:              applied.TaxInclusive,
-			TaxRateBasisPoints:        applied.TaxRatePct * 100,
-			ReducedTaxRateBasisPoints: applied.ReducedTaxRatePct * 100,
+			TaxInclusive:       applied.TaxInclusive,
+			TaxRateBasisPoints: applied.TaxRatePct * 100,
 		}); dp.Engine.Config() != newCfg {
 			dp.Engine.SetConfig(newCfg)
 		}

--- a/internal/pages/payment_event_test.go
+++ b/internal/pages/payment_event_test.go
@@ -2,6 +2,7 @@ package pages
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -49,11 +50,11 @@ func TestBlockingPaymentEventGate(t *testing.T) {
 	bus.SetEventMode("payment.stripe.refund", plugins.Blocking)
 	if _, err := bus.SubscribeWithHandler(ctx, "com.universaltill.payment-stripe",
 		[]string{"payment.stripe.refund"},
-		func(ctx context.Context, ev plugins.Event) error {
+		func(ctx context.Context, ev plugins.Event) (json.RawMessage, error) {
 			if decline {
-				return errors.New("stripe: refund failed")
+				return nil, errors.New("stripe: refund failed")
 			}
-			return nil
+			return nil, nil
 		}); err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}

--- a/internal/pages/self_order_shop_test.go
+++ b/internal/pages/self_order_shop_test.go
@@ -2,6 +2,7 @@ package pages
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -495,8 +496,8 @@ func TestSelfOrderShop_CheckoutDeclinedByPluginGateNeverCompletesSale(t *testing
 	bus.SetEventMode("payment.demopay.authorize", plugins.Blocking)
 	if _, err := bus.SubscribeWithHandler(context.Background(), "com.universaltill.payment-demo",
 		[]string{"payment.demopay.authorize"},
-		func(ctx context.Context, ev plugins.Event) error {
-			return errors.New("demopay: card declined")
+		func(ctx context.Context, ev plugins.Event) (json.RawMessage, error) {
+			return nil, errors.New("demopay: card declined")
 		}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pages/settings_page.go
+++ b/internal/pages/settings_page.go
@@ -390,9 +390,8 @@ func registerSettings(mux *http.ServeMux, d *common.Deps) {
 		httpx.InitCurrency(st.Currency)
 		// In place: replacing the engine would empty a basket in progress.
 		d.Engine.SetConfig(pos.Config{
-			TaxInclusive:              st.TaxInclusive,
-			TaxRateBasisPoints:        st.TaxRatePct * 100,
-			ReducedTaxRateBasisPoints: st.ReducedTaxRatePct * 100,
+			TaxInclusive:       st.TaxInclusive,
+			TaxRateBasisPoints: st.TaxRatePct * 100,
 		})
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -428,10 +427,6 @@ func registerSettings(mux *http.ServeMux, d *common.Deps) {
 				if n, err := strconv.Atoi(value); err == nil {
 					s.TaxRatePct = n
 				}
-			case common.KeyReducedTaxRate:
-				if n, err := strconv.Atoi(value); err == nil {
-					s.ReducedTaxRatePct = n
-				}
 			case "pos.allow_negative_inventory":
 				s.AllowNegativeInventory = truthy(value)
 			}
@@ -442,9 +437,8 @@ func registerSettings(mux *http.ServeMux, d *common.Deps) {
 		case common.KeyTaxInclusive:
 			// In place: replacing the engine would empty a basket in progress.
 			d.Engine.SetConfig(pos.Config{
-				TaxInclusive:              st.TaxInclusive,
-				TaxRateBasisPoints:        st.TaxRatePct * 100,
-				ReducedTaxRateBasisPoints: st.ReducedTaxRatePct * 100,
+				TaxInclusive:       st.TaxInclusive,
+				TaxRateBasisPoints: st.TaxRatePct * 100,
 			})
 		}
 		w.WriteHeader(http.StatusNoContent)

--- a/internal/pages/setup_page.go
+++ b/internal/pages/setup_page.go
@@ -22,31 +22,23 @@ type setupCountry struct {
 	Currency     string
 	TaxRatePct   int
 	TaxInclusive bool
-	// ReducedTaxRatePct is the takeaway/reduced VAT rate (0 = not modeled
-	// for this country yet — order type then never changes the default
-	// rate, a safe no-op, not a claim that the country has no such rate).
-	// Only DE is populated: real, verified German law (§12 UStG, 7%
-	// reduced rate — see docs/germany-pos-parity-backlog.md). Other
-	// countries' reduced/zero VAT rates were NOT researched for this
-	// change and are deliberately left at 0 rather than guessed.
-	ReducedTaxRatePct int
 }
 
 var setupCountries = []setupCountry{
-	{"GB", "setup.country.gb", "GBP", 20, true, 0},
-	{"IR", "setup.country.ir", "IRT", 10, true, 0},
-	{"US", "setup.country.us", "USD", 0, false, 0},
-	{"DE", "setup.country.de", "EUR", 19, true, 7},
-	{"FR", "setup.country.fr", "EUR", 20, true, 0},
-	{"ES", "setup.country.es", "EUR", 21, true, 0},
-	{"IT", "setup.country.it", "EUR", 22, true, 0},
-	{"NL", "setup.country.nl", "EUR", 21, true, 0},
-	{"TR", "setup.country.tr", "TRY", 20, true, 0},
-	{"AE", "setup.country.ae", "AED", 5, true, 0},
-	{"SA", "setup.country.sa", "SAR", 15, true, 0},
-	{"IN", "setup.country.in", "INR", 18, true, 0},
-	{"PK", "setup.country.pk", "PKR", 18, true, 0},
-	{"OTHER", "setup.country.other", "", 0, true, 0},
+	{"GB", "setup.country.gb", "GBP", 20, true},
+	{"IR", "setup.country.ir", "IRT", 10, true},
+	{"US", "setup.country.us", "USD", 0, false},
+	{"DE", "setup.country.de", "EUR", 19, true},
+	{"FR", "setup.country.fr", "EUR", 20, true},
+	{"ES", "setup.country.es", "EUR", 21, true},
+	{"IT", "setup.country.it", "EUR", 22, true},
+	{"NL", "setup.country.nl", "EUR", 21, true},
+	{"TR", "setup.country.tr", "TRY", 20, true},
+	{"AE", "setup.country.ae", "AED", 5, true},
+	{"SA", "setup.country.sa", "SAR", 15, true},
+	{"IN", "setup.country.in", "INR", 18, true},
+	{"PK", "setup.country.pk", "PKR", 18, true},
+	{"OTHER", "setup.country.other", "", 0, true},
 }
 
 // registerSetup wires the first-boot wizard: language → country (prefills
@@ -112,19 +104,13 @@ func registerSetup(mux *http.ServeMux, d *common.Deps, svc *auth.Service) {
 					s.TaxRatePct = n
 				}
 			}
-			if v := r.Form.Get("reduced_tax_rate_pct"); v != "" {
-				if n, err := strconv.Atoi(v); err == nil && n >= 0 && n <= 100 {
-					s.ReducedTaxRatePct = n
-				}
-			}
 			s.TaxInclusive = r.Form.Get("tax_inclusive") != "off"
 		})
 		common.SaveState(r.Context(), d.Settings, st)
 		httpx.InitCurrency(st.Currency)
 		d.Engine.SetConfig(pos.Config{
-			TaxInclusive:              st.TaxInclusive,
-			TaxRateBasisPoints:        st.TaxRatePct * 100,
-			ReducedTaxRateBasisPoints: st.ReducedTaxRatePct * 100,
+			TaxInclusive:       st.TaxInclusive,
+			TaxRateBasisPoints: st.TaxRatePct * 100,
 		})
 
 		if name := strings.TrimSpace(r.Form.Get("store_name")); name != "" {

--- a/internal/pages/tax_hook.go
+++ b/internal/pages/tax_hook.go
@@ -1,0 +1,59 @@
+package pages
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+
+	"github.com/universaltill/universal-till/internal/plugins"
+	"github.com/universaltill/universal-till/internal/pos"
+)
+
+// taxRateAskEvent is the generic "compute a tax rate override" hook
+// (EventBus.Ask). Any installed plugin — country-specific tax rules are
+// entirely a plugin's job, core has none built in (see pos.TaxRateAsker) —
+// may subscribe to it. The ".ask" suffix is what makes wasm_runtime.go
+// dispatch it as a blocking, value-returning hook rather than fire-and-forget.
+const taxRateAskEvent = "tax.rate.ask"
+
+// taxRateAskPayload is the event payload a subscribing plugin receives.
+type taxRateAskPayload struct {
+	ItemID    string `json:"item_id"`
+	TaxCodeID string `json:"tax_code_id"`
+	TaxRateBP int    `json:"tax_rate_bp"`
+	OrderType string `json:"order_type"`
+}
+
+// taxRateAskResponse is the JSON a plugin writes to stdout to answer.
+type taxRateAskResponse struct {
+	RateBP int `json:"rate_bp"`
+}
+
+// pluginTaxRateAsker implements pos.TaxRateAsker by asking installed
+// plugins via the event bus — internal/pos itself never depends on the
+// plugin subsystem, this is the seam where "does any plugin have an
+// opinion on this line's tax rate" is answered.
+type pluginTaxRateAsker struct {
+	db *sql.DB
+}
+
+func (a *pluginTaxRateAsker) AskTaxRateBP(l pos.BasketLine, orderType string) (int, bool) {
+	bus := plugins.SharedBus(a.db)
+	if !bus.HasSubscribers(taxRateAskEvent) {
+		return 0, false
+	}
+	resp, ok, err := bus.Ask(context.Background(), taxRateAskEvent, taxRateAskPayload{
+		ItemID:    l.ItemID,
+		TaxCodeID: l.TaxCodeID,
+		TaxRateBP: l.TaxRateBP,
+		OrderType: orderType,
+	})
+	if err != nil || !ok {
+		return 0, false
+	}
+	var parsed taxRateAskResponse
+	if json.Unmarshal(resp, &parsed) != nil || parsed.RateBP <= 0 {
+		return 0, false
+	}
+	return parsed.RateBP, true
+}

--- a/internal/plugins/ipc.go
+++ b/internal/plugins/ipc.go
@@ -127,8 +127,13 @@ type StockAdjustedEvent struct {
 	AdjustedAt time.Time `json:"adjusted_at"`
 }
 
-// EventHandler executes a blocking handler for an event; returning an error signals rollback.
-type EventHandler func(ctx context.Context, event Event) error
+// EventHandler executes a blocking handler for an event; returning a non-nil
+// error signals rollback/failure. The returned json.RawMessage is the
+// handler's answer for "ask" style hooks (EventBus.Ask) where a plugin
+// computes and returns a VALUE, e.g. a country-specific tax-rate override —
+// nil when the hook is accept/reject only (e.g. payment authorization,
+// which Publish's Blocking mode only ever inspects the error from).
+type EventHandler func(ctx context.Context, event Event) (json.RawMessage, error)
 
 // NewEventBus creates a new event bus
 func NewEventBus(db *sql.DB) *EventBus {
@@ -291,7 +296,10 @@ func (eb *EventBus) Publish(ctx context.Context, eventType string, payload inter
 				eb.auditDispatch(ctx, event.ID, eventType, sub.PluginID, "error", msg)
 				return "", fmt.Errorf("blocking event %s failed for plugin %s: %s", eventType, sub.PluginID, msg)
 			}
-			if err := sub.Handler(ctx, event); err != nil {
+			// Publish's callers only ever care about accept/reject (payment
+			// authorization); a response value from an "ask" style handler
+			// is discarded here — use Ask instead when the answer matters.
+			if _, err := sub.Handler(ctx, event); err != nil {
 				eb.auditDispatch(ctx, event.ID, eventType, sub.PluginID, "error", err.Error())
 				return "", fmt.Errorf("blocking event %s failed for plugin %s: %w", eventType, sub.PluginID, err)
 			}
@@ -314,6 +322,55 @@ func (eb *EventBus) Publish(ctx context.Context, eventType string, payload inter
 	}
 
 	return event.ID, nil
+}
+
+// Ask sends a blocking event to subscribed plugins and returns the first
+// answering plugin's response — for hooks where a plugin computes and
+// returns a VALUE rather than just accepting/rejecting (e.g. a country-
+// specific tax-rate override; core has no built-in notion of any country's
+// rules, see internal/pos.TaxRateAsker). (ok=false, nil error) means no
+// installed plugin answered — the caller falls back to its own default.
+// Unlike Publish, at most one plugin is expected to answer a given event
+// type (mirrors how e.g. payment methods are matched 1:1 by entry key); the
+// first subscriber that returns a non-empty response wins, others are not
+// consulted. A handler error still aborts the whole Ask (same failure
+// semantics as Publish's Blocking mode).
+func (eb *EventBus) Ask(ctx context.Context, eventType string, payload interface{}) (json.RawMessage, bool, error) {
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, false, fmt.Errorf("marshal payload: %w", err)
+	}
+	event := Event{
+		ID:        uuid.NewString(),
+		Type:      eventType,
+		Timestamp: time.Now().UTC(),
+		Payload:   payloadBytes,
+	}
+
+	eb.mu.RLock()
+	subscribers := eb.subscribers[eventType]
+	eb.mu.RUnlock()
+
+	for _, sub := range subscribers {
+		if sub.Handler == nil {
+			continue
+		}
+		if err := CheckPermission(ctx, eb.dbHandle(), sub.PluginID, "events:receive"); err != nil {
+			eb.auditDispatch(ctx, event.ID, eventType, sub.PluginID, "denied", err.Error())
+			continue
+		}
+		resp, err := sub.Handler(ctx, event)
+		if err != nil {
+			eb.auditDispatch(ctx, event.ID, eventType, sub.PluginID, "error", err.Error())
+			return nil, false, fmt.Errorf("ask %s failed for plugin %s: %w", eventType, sub.PluginID, err)
+		}
+		eb.auditDispatch(ctx, event.ID, eventType, sub.PluginID, "success", "")
+		if len(resp) == 0 {
+			continue // handler ran but declined to answer — try the next subscriber
+		}
+		return resp, true, nil
+	}
+	return nil, false, nil
 }
 
 // Acknowledge records event acknowledgment from a plugin

--- a/internal/plugins/ipc_test.go
+++ b/internal/plugins/ipc_test.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -375,8 +376,8 @@ func TestEventBus_BlockingRollsBackOnError(t *testing.T) {
 	bus.SetEventMode("sale.completed", Blocking)
 
 	handlerErr := errors.New("handler failed")
-	if _, err := bus.SubscribeWithHandler(ctx, manifest.ID, []string{"sale.completed"}, func(ctx context.Context, event Event) error {
-		return handlerErr
+	if _, err := bus.SubscribeWithHandler(ctx, manifest.ID, []string{"sale.completed"}, func(ctx context.Context, event Event) (json.RawMessage, error) {
+		return nil, handlerErr
 	}); err != nil {
 		t.Fatalf("subscribe with handler: %v", err)
 	}
@@ -398,6 +399,75 @@ func TestEventBus_BlockingRollsBackOnError(t *testing.T) {
 	}
 	if !strings.Contains(details, "status=error") {
 		t.Fatalf("expected error status in audit details, got %s", details)
+	}
+}
+
+// TestEventBus_Ask covers the value-returning hook (internal/pos.
+// TaxRateAsker's real-world use): no subscriber → (nil, false, nil), a
+// subscriber that declines (empty response) → also (nil, false, nil), a
+// subscriber that answers → its response, and a handler error aborts the
+// whole Ask instead of silently falling back.
+func TestEventBus_Ask(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	setupAuditLog(t, db)
+	ctx := context.Background()
+
+	manifest := &Manifest{
+		ID:          "plugin-asker",
+		Name:        "Asker",
+		Version:     "1.0.0",
+		Entrypoint:  "./test",
+		Hooks:       []ManifestHook{{Event: "tax.rate.ask", Action: "rate"}},
+		Permissions: []string{"events:receive"},
+	}
+	if err := PersistManifest(ctx, db, manifest, InstallOptions{}); err != nil {
+		t.Fatalf("persist manifest: %v", err)
+	}
+	if err := GrantPermission(ctx, db, manifest.ID, "events:receive"); err != nil {
+		t.Fatalf("grant permission: %v", err)
+	}
+
+	bus := NewEventBus(db)
+	bus.SetEventMode("tax.rate.ask", Blocking)
+
+	// No subscriber yet.
+	if resp, ok, err := bus.Ask(ctx, "tax.rate.ask", map[string]any{}); err != nil || ok || resp != nil {
+		t.Fatalf("expected no answer with no subscriber, got resp=%s ok=%v err=%v", resp, ok, err)
+	}
+
+	answer := json.RawMessage(`{"rate_bp":700}`)
+	decline := false
+	handlerErr := errors.New("asker: crashed")
+	fail := false
+	if _, err := bus.SubscribeWithHandler(ctx, manifest.ID, []string{"tax.rate.ask"}, func(ctx context.Context, event Event) (json.RawMessage, error) {
+		if fail {
+			return nil, handlerErr
+		}
+		if decline {
+			return nil, nil
+		}
+		return answer, nil
+	}); err != nil {
+		t.Fatalf("subscribe with handler: %v", err)
+	}
+
+	resp, ok, err := bus.Ask(ctx, "tax.rate.ask", map[string]any{})
+	if err != nil || !ok || string(resp) != string(answer) {
+		t.Fatalf("expected answer %s, got resp=%s ok=%v err=%v", answer, resp, ok, err)
+	}
+
+	decline = true
+	if resp, ok, err := bus.Ask(ctx, "tax.rate.ask", map[string]any{}); err != nil || ok || resp != nil {
+		t.Fatalf("expected no answer when handler declines, got resp=%s ok=%v err=%v", resp, ok, err)
+	}
+	decline = false
+
+	fail = true
+	if _, ok, err := bus.Ask(ctx, "tax.rate.ask", map[string]any{}); err == nil || ok {
+		t.Fatalf("expected handler error to propagate, got ok=%v err=%v", ok, err)
+	} else if !strings.Contains(err.Error(), handlerErr.Error()) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/plugins/wasm_hostfns_test.go
+++ b/internal/plugins/wasm_hostfns_test.go
@@ -79,7 +79,7 @@ func runGuest(t *testing.T, w *WasmRuntime, d *sql.DB, pluginID, url string) map
 	w.mu.Lock()
 	w.db = d
 	w.mu.Unlock()
-	if err := w.HandleEvent(context.Background(), pluginID, ev); err != nil {
+	if _, err := w.HandleEvent(context.Background(), pluginID, ev); err != nil {
 		t.Fatalf("HandleEvent: %v", err)
 	}
 	raw, err := data.NewPluginRepo(d).StorageGet(context.Background(), pluginID, "results")
@@ -176,7 +176,7 @@ func TestHostStorageDeniedWithoutPermission(t *testing.T) {
 	w.db = d
 	w.mu.Unlock()
 	payload, _ := json.Marshal(map[string]string{"url": "http://127.0.0.1:1/x"})
-	err := w.HandleEvent(context.Background(), pluginID,
+	_, err := w.HandleEvent(context.Background(), pluginID,
 		Event{ID: "e", Type: "t", Timestamp: time.Now(), Payload: payload})
 	if err == nil || !strings.Contains(err.Error(), "exit") {
 		// guest exits 1 when it cannot record results

--- a/internal/plugins/wasm_runtime.go
+++ b/internal/plugins/wasm_runtime.go
@@ -132,25 +132,28 @@ func (w *WasmRuntime) Sync(ctx context.Context, db *sql.DB) {
 			continue
 		}
 		// Authorization events run BLOCKING: the tender waits for the
-		// verdict (docs: wasm-runtime.md payment authorization).
+		// verdict (docs: wasm-runtime.md payment authorization). ".ask"
+		// events are the generic value-returning hook (EventBus.Ask) — also
+		// blocking, since the caller is waiting on the plugin's answer.
 		for _, evName := range events {
-			if strings.HasSuffix(evName, ".authorize") {
+			if strings.HasSuffix(evName, ".authorize") || strings.HasSuffix(evName, ".ask") {
 				bus.SetEventMode(evName, Blocking)
 			}
 		}
 		pluginID := row.ID
-		handle := func(hctx context.Context, ev Event) error {
+		handle := func(hctx context.Context, ev Event) (json.RawMessage, error) {
 			w.mu.Lock()
 			stale := gen != w.unsubGen
 			w.mu.Unlock()
 			if stale {
-				return nil
+				return nil, nil
 			}
-			if err := w.HandleEvent(hctx, pluginID, ev); err != nil {
+			resp, err := w.HandleEvent(hctx, pluginID, ev)
+			if err != nil {
 				logging.L().Errorf("wasm %s handling %s: %v", pluginID, ev.Type, err)
-				return err
+				return nil, err
 			}
-			return nil
+			return resp, nil
 		}
 		// The handler runs synchronously for Blocking events; for the default
 		// non-blocking mode events land on the channel, so drain it too.
@@ -161,7 +164,7 @@ func (w *WasmRuntime) Sync(ctx context.Context, db *sql.DB) {
 		}
 		go func() {
 			for ev := range ch {
-				_ = handle(context.Background(), ev)
+				_, _ = handle(context.Background(), ev)
 			}
 		}()
 		logging.L().Infof("wasm plugin %s loaded, handling %v", pluginID, events)
@@ -194,8 +197,13 @@ func (w *WasmRuntime) load(pluginID, version, path string) error {
 }
 
 // HandleEvent runs one event through the plugin's module: fresh instance,
-// event JSON on stdin, deadline-bound, stdout/stderr captured.
-func (w *WasmRuntime) HandleEvent(ctx context.Context, pluginID string, ev Event) error {
+// event JSON on stdin, deadline-bound, stdout/stderr captured. The plugin's
+// trimmed stdout is returned as-is — most handlers write nothing (or plain
+// log text, which the caller happens to have already logged too); an "ask"
+// style handler (EventBus.Ask) writes its JSON answer here instead, and
+// interpreting that JSON is entirely up to that caller, not this generic
+// runtime.
+func (w *WasmRuntime) HandleEvent(ctx context.Context, pluginID string, ev Event) (json.RawMessage, error) {
 	w.mu.Lock()
 	compiled, ok := w.modules[pluginID]
 	timeout := w.timeout
@@ -205,7 +213,7 @@ func (w *WasmRuntime) HandleEvent(ctx context.Context, pluginID string, ev Event
 	db := w.db
 	w.mu.Unlock()
 	if !ok {
-		return fmt.Errorf("module not loaded: %s", pluginID)
+		return nil, fmt.Errorf("module not loaded: %s", pluginID)
 	}
 
 	in, err := json.Marshal(map[string]any{
@@ -215,7 +223,7 @@ func (w *WasmRuntime) HandleEvent(ctx context.Context, pluginID string, ev Event
 		"payload":   json.RawMessage(ev.Payload),
 	})
 	if err != nil {
-		return fmt.Errorf("encode event: %w", err)
+		return nil, fmt.Errorf("encode event: %w", err)
 	}
 
 	cctx, cancel := context.WithTimeout(ctx, timeout)
@@ -242,10 +250,11 @@ func (w *WasmRuntime) HandleEvent(ctx context.Context, pluginID string, ev Event
 		}
 	}
 	if runErr != nil {
-		return fmt.Errorf("wasm handler: %w", runErr)
+		return nil, fmt.Errorf("wasm handler: %w", runErr)
 	}
-	if out := strings.TrimSpace(stdout.String()); out != "" {
+	out := strings.TrimSpace(stdout.String())
+	if out != "" {
 		logging.L().Infof("[wasm:%s] result: %s", pluginID, out)
 	}
-	return nil
+	return json.RawMessage(out), nil
 }

--- a/internal/pos/service.go
+++ b/internal/pos/service.go
@@ -25,63 +25,68 @@ type Service struct {
 	discountPercentBP int64       // percentage discount as basis points (a rate, not money)
 	customerID        string
 	customerName      string
-	// orderType is "" (no explicit choice — treated as dine-in/standard) or
-	// "takeaway". Deliberately NOT defaulting to "takeaway": an explicit tap
-	// is required to apply any reduced rate, so a missed/skipped choice
-	// never under-taxes a sale (§12 UStG dine-in/takeaway VAT switch).
+	// orderType is "" (no explicit choice) or OrderTypeTakeaway. What (if
+	// anything) it does to tax is entirely up to taxAsker.
 	orderType string
+	// taxAsker, when set, can override a line's tax rate per the current
+	// order type — see TaxRateAsker. nil (the default) means core just uses
+	// each line's own configured rate, unaffected by order type.
+	taxAsker TaxRateAsker
 }
 
 type Config struct {
 	TaxInclusive       bool
 	TaxRateBasisPoints int // e.g. 2000 = 20.00%
-	// ReducedTaxRateBasisPoints is the global fallback takeaway rate for
-	// lines with no per-item tax code (TaxRateBP/TakeawayRateBP both 0) —
-	// same "0 = unset" convention as TaxRateBasisPoints. 0 = no reduced
-	// rate configured for this shop's country, so order type never changes
-	// the default rate (safe no-op default).
-	ReducedTaxRateBasisPoints int
 }
 
-// OrderTypeTakeaway is the only order type value that can reduce a line's
-// tax rate; any other value (including "") is treated as dine-in/standard.
+// OrderTypeTakeaway is a value merchants may use for OrderType — dine-in vs.
+// takeaway is a genuinely common distinction (SumUp has the same concept),
+// so core keeps the label as a shared convention. What (if anything) it does
+// to a line's tax rate is entirely up to an installed TaxRateAsker: core has
+// no built-in notion of any country's tax rules.
 const OrderTypeTakeaway = "takeaway"
 
+// TaxRateAsker lets an installed plugin override a line's effective tax
+// rate — e.g. a country-specific order-type VAT switch (Germany's §12 UStG:
+// some items tax differently for takeaway than dine-in). ok=false means the
+// plugin has no opinion on this line; the line's own configured rate is
+// used, same as when no asker is set at all. Wired from internal/pages via
+// Service.SetTaxRateAsker, calling into the plugin event bus — internal/pos
+// itself never talks to the plugin subsystem, keeping this package's only
+// dependency on "what a country's tax rules are" as a pluggable interface.
+type TaxRateAsker interface {
+	AskTaxRateBP(l BasketLine, orderType string) (bp int, ok bool)
+}
+
 // effectiveTaxRateBP resolves the basis points to actually charge for one
-// line under the current order type and global config, per §12 UStG.
-// A line with its own tax code (TaxRateBP != 0) is PINNED to it unless that
-// same tax code also carries an explicit TakeawayRateBP override (e.g. a
-// cake stays at its 7% code always; a drink's code carries both 19% and a
-// 7% takeaway override). Only a line with NO tax code at all falls back to
-// the shop's global standard/reduced rates, which do switch with order
-// type — conflating the two would incorrectly drag a merchant's own
-// deliberately-pinned rate down to the unrelated global reduced rate.
-func effectiveTaxRateBP(l BasketLine, orderType string, cfg Config) int {
-	hasItemTaxCode := l.TaxRateBP != 0
+// line under the current order type: ask the installed TaxRateAsker (if
+// any) first, then fall back to the line's own configured rate — the same
+// plain default as before any tax plugin existed.
+func (s *Service) effectiveTaxRateBP(l BasketLine) int {
+	if s.taxAsker != nil {
+		if bp, ok := s.taxAsker.AskTaxRateBP(l, s.orderType); ok {
+			return bp
+		}
+	}
 	standard := l.TaxRateBP
-	if !hasItemTaxCode {
-		standard = cfg.TaxRateBasisPoints
+	if standard == 0 {
+		standard = s.cfg.TaxRateBasisPoints
 	}
 	if standard == 0 {
-		standard = 2000 // same "default to 20% if unconfigured" as NewServiceWithResolver/SetConfig
+		standard = 2000 // default to 20% if unconfigured
 	}
-	if orderType != OrderTypeTakeaway {
-		return standard
-	}
-	if hasItemTaxCode {
-		if l.TakeawayRateBP != 0 {
-			return l.TakeawayRateBP
-		}
-		return standard // pinned: this item's own tax code has no takeaway override
-	}
-	if cfg.ReducedTaxRateBasisPoints != 0 {
-		return cfg.ReducedTaxRateBasisPoints
-	}
-	return standard // no global reduced rate configured for this shop's country
+	return standard
 }
 
 func NewServiceWithResolver(cfg Config, r PriceResolver) *Service {
 	return &Service{cfg: cfg, resolver: r, scanCache: map[string]BasketLine{}}
+}
+
+// SetTaxRateAsker installs (or clears, with nil) the plugin-backed tax-rate
+// override hook and recomputes totals so the change is reflected immediately.
+func (s *Service) SetTaxRateAsker(a TaxRateAsker) {
+	s.taxAsker = a
+	s.recomputeTotals()
 }
 
 // SetConfig swaps the tax configuration IN PLACE, keeping the basket.
@@ -97,24 +102,24 @@ func (s *Service) SetConfig(cfg Config) {
 func (s *Service) Config() Config { return s.cfg }
 
 type BasketLine struct {
-	LineKey      string                  `json:"lineKey,omitempty"` // stable per-line id, assigned when a line is first appended (ADR-0020) — the only safe way to address ONE line once modifiers let several share a SKU
-	SKU          string                  `json:"sku"`
-	Name         string                  `json:"name"`
-	Qty          float64                 `json:"qty"`
-	PriceCents   money.Money             `json:"priceCents"` // effective unit price: base + sum(Modifiers deltas)
-	LineDiscount money.Money             `json:"lineDiscount,omitempty"`
-	LineTotal    money.Money             `json:"lineTotal,omitempty"`
-	ImageURL     string                  `json:"imageUrl,omitempty"`
-	ItemID       string                  `json:"-"`
-	VariantID    string                  `json:"-"`
-	TaxRateBP    int                     `json:"-"`
-	// TakeawayRateBP is the rate to use instead of TaxRateBP when the sale's
-	// OrderType is "takeaway" (0 = this line's tax rate never changes with
-	// order type — e.g. a cake pinned to one reduced rate regardless of
-	// dine-in/takeaway, which just uses a flat tax_code, no override needed).
-	TakeawayRateBP int  `json:"-"`
-	IsWeighed      bool `json:"-"`
-	Modifiers    []data.SelectedModifier `json:"modifiers,omitempty"` // ADR-0020: chosen customizations, already folded into PriceCents
+	LineKey      string      `json:"lineKey,omitempty"` // stable per-line id, assigned when a line is first appended (ADR-0020) — the only safe way to address ONE line once modifiers let several share a SKU
+	SKU          string      `json:"sku"`
+	Name         string      `json:"name"`
+	Qty          float64     `json:"qty"`
+	PriceCents   money.Money `json:"priceCents"` // effective unit price: base + sum(Modifiers deltas)
+	LineDiscount money.Money `json:"lineDiscount,omitempty"`
+	LineTotal    money.Money `json:"lineTotal,omitempty"`
+	ImageURL     string      `json:"imageUrl,omitempty"`
+	ItemID       string      `json:"-"`
+	VariantID    string      `json:"-"`
+	TaxRateBP    int         `json:"-"`
+	// TaxCodeID identifies which tax code this line's rate came from (empty
+	// if the item has none and it's using the shop's global default rate) —
+	// passed to TaxRateAsker so a tax plugin can distinguish item categories
+	// without core needing to know what any of them mean.
+	TaxCodeID string                  `json:"-"`
+	IsWeighed bool                    `json:"-"`
+	Modifiers []data.SelectedModifier `json:"modifiers,omitempty"` // ADR-0020: chosen customizations, already folded into PriceCents
 }
 
 // ModifierSignature is a stable key for two lines' modifier selections —
@@ -349,7 +354,7 @@ func (s *Service) recomputeTotals() {
 	var tax, total money.Money
 	for i := range s.lines {
 		l := &s.lines[i]
-		rateBP := effectiveTaxRateBP(*l, s.orderType, s.cfg)
+		rateBP := s.effectiveTaxRateBP(*l)
 		lineTax, lineTotal := ComputeTaxBasisPoints(l.LineTotal, rateBP, s.cfg.TaxInclusive)
 		tax = tax.Add(lineTax)
 		total = total.Add(lineTotal)
@@ -379,7 +384,7 @@ func (s *Service) OrderType() string { return s.orderType }
 // sale) must both use, so what a cashier sees pre-payment matches what gets
 // recorded/receipted.
 func (s *Service) EffectiveLineTaxRateBP(l BasketLine) int {
-	return effectiveTaxRateBP(l, s.orderType, s.cfg)
+	return s.effectiveTaxRateBP(l)
 }
 
 // SetOrderType sets the sale's order type and re-derives every current

--- a/internal/pos/service_test.go
+++ b/internal/pos/service_test.go
@@ -142,49 +142,73 @@ func TestScanCacheClearsOnRemove(t *testing.T) {
 	}
 }
 
-// TestOrderTypeTaxSwitching covers §12 UStG's dine-in/takeaway VAT switch
-// (docs/germany-pos-parity-backlog.md): a line with an explicit takeaway
-// rate switches, a line pinned to one rate (no takeaway override, e.g. a
-// cake that's always the reduced rate) never changes, and a line with no
-// per-item tax code at all falls back to the shop's global standard/reduced
-// rates — all mid-basket, matching a customer changing their mind after
-// items are already added.
+// fakeTaxAsker stands in for a real country-specific tax plugin (e.g.
+// ut-plugin-tax-de) in tests — core itself has no notion of what any
+// country's tax rules are, only this interface.
+type fakeTaxAsker struct {
+	takeawayRateByTaxCode map[string]int
+}
+
+func (f fakeTaxAsker) AskTaxRateBP(l BasketLine, orderType string) (int, bool) {
+	if orderType != OrderTypeTakeaway {
+		return 0, false
+	}
+	bp, ok := f.takeawayRateByTaxCode[l.TaxCodeID]
+	return bp, ok
+}
+
+// TestOrderTypeTaxSwitching verifies core has NO built-in tax-rate opinion
+// about order type: with no TaxRateAsker installed, switching order type
+// never changes a line's tax (today's plain default, unaffected by any
+// country's rules). Installing an asker (standing in for a real tax
+// plugin) is what makes it do anything at all — e.g. a drink's tax code
+// switching to a reduced takeaway rate while a cake's tax code, which the
+// asker declines to answer for, stays pinned to its own configured rate.
+// Switching re-derives every current line immediately, including lines
+// added before the order type was chosen or changed (a customer changing
+// their mind mid-order, docs/germany-pos-parity-backlog.md).
 func TestOrderTypeTaxSwitching(t *testing.T) {
 	resolver := mapResolver{
-		"DRINK": {SKU: "DRINK", ItemID: "item-drink", Name: "Coffee", Qty: 1, PriceCents: 1000, TaxRateBP: 1900, TakeawayRateBP: 700},
-		"CAKE":  {SKU: "CAKE", ItemID: "item-cake", Name: "Cake", Qty: 1, PriceCents: 1000, TaxRateBP: 700},
-		"MERCH": {SKU: "MERCH", ItemID: "item-merch", Name: "Mug", Qty: 1, PriceCents: 1000}, // no tax code — uses global rates
+		"DRINK": {SKU: "DRINK", ItemID: "item-drink", TaxCodeID: "tax-drink", Name: "Coffee", Qty: 1, PriceCents: 1000, TaxRateBP: 1900},
+		"CAKE":  {SKU: "CAKE", ItemID: "item-cake", TaxCodeID: "tax-cake", Name: "Cake", Qty: 1, PriceCents: 1000, TaxRateBP: 700},
 	}
-	s := NewServiceWithResolver(Config{
-		TaxRateBasisPoints:        2000, // 20% global standard
-		ReducedTaxRateBasisPoints: 500,  // 5% global reduced
-	}, resolver)
-
-	for _, sku := range []string{"DRINK", "CAKE", "MERCH"} {
+	s := NewServiceWithResolver(Config{TaxRateBasisPoints: 2000}, resolver)
+	for _, sku := range []string{"DRINK", "CAKE"} {
 		if _, err := s.ScanQty(sku, 1); err != nil {
 			t.Fatalf("ScanQty(%s) error: %v", sku, err)
 		}
 	}
 
-	b := s.Basket()
-	if b.OrderType != "" {
-		t.Fatalf("expected default order type \"\", got %q", b.OrderType)
-	}
-	if want := money.FromMinor(460); b.Tax != want { // 190 + 70 + 200
-		t.Fatalf("dine-in tax = %v, want %v", b.Tax, want)
+	dineInTax := money.FromMinor(190 + 70) // 19% of 1000 + 7% of 1000
+	if got := s.Basket().Tax; got != dineInTax {
+		t.Fatalf("dine-in tax = %v, want %v", got, dineInTax)
 	}
 
-	b = *s.SetOrderType(OrderTypeTakeaway)
+	// No asker installed: order type has zero effect.
+	s.SetOrderType(OrderTypeTakeaway)
+	if got := s.Basket().Tax; got != dineInTax {
+		t.Fatalf("takeaway with no asker changed tax: got %v, want unchanged %v", got, dineInTax)
+	}
+	s.SetOrderType("")
+
+	// Install the asker: drink switches to 7%, cake (unanswered) stays pinned.
+	s.SetTaxRateAsker(fakeTaxAsker{takeawayRateByTaxCode: map[string]int{"tax-drink": 700}})
+	if got := s.Basket().Tax; got != dineInTax {
+		t.Fatalf("dine-in with asker installed changed tax: got %v, want %v", got, dineInTax)
+	}
+
+	b := *s.SetOrderType(OrderTypeTakeaway)
 	if b.OrderType != OrderTypeTakeaway {
 		t.Fatalf("expected order type %q, got %q", OrderTypeTakeaway, b.OrderType)
 	}
-	if want := money.FromMinor(190); b.Tax != want { // 70 (switched) + 70 (pinned) + 50 (global reduced)
-		t.Fatalf("takeaway tax = %v, want %v", b.Tax, want)
+	takeawayTax := money.FromMinor(70 + 70) // drink switched to 7%, cake pinned at its own 7%
+	if b.Tax != takeawayTax {
+		t.Fatalf("takeaway with asker: tax = %v, want %v", b.Tax, takeawayTax)
 	}
 
 	// Customer changes their mind back to dine-in mid-order.
 	b = *s.SetOrderType("")
-	if want := money.FromMinor(460); b.Tax != want {
-		t.Fatalf("dine-in (reverted) tax = %v, want %v", b.Tax, want)
+	if b.Tax != dineInTax {
+		t.Fatalf("dine-in (reverted) tax = %v, want %v", b.Tax, dineInTax)
 	}
 }

--- a/internal/ui/buttons.go
+++ b/internal/ui/buttons.go
@@ -311,15 +311,15 @@ func (a PriceResolverAdapter) resolve(ctx context.Context, code string) (pos.Bas
 		return pos.BasketLine{}, false
 	}
 	line := pos.BasketLine{
-		SKU:            row.SKU,
-		Name:           row.Name,
-		Qty:            1,
-		PriceCents:     money.FromMinor(row.Price),
-		ItemID:         row.ItemID,
-		VariantID:      row.VariantID,
-		TaxRateBP:      row.TaxRateBP,
-		TakeawayRateBP: row.TakeawayRateBP,
-		IsWeighed:      row.IsWeighed,
+		SKU:        row.SKU,
+		Name:       row.Name,
+		Qty:        1,
+		PriceCents: money.FromMinor(row.Price),
+		ItemID:     row.ItemID,
+		VariantID:  row.VariantID,
+		TaxRateBP:  row.TaxRateBP,
+		TaxCodeID:  row.TaxCodeID,
+		IsWeighed:  row.IsWeighed,
 	}
 	if row.ImageURL != "" {
 		line.ImageURL = row.ImageURL

--- a/internal/ui/buttons_test.go
+++ b/internal/ui/buttons_test.go
@@ -88,15 +88,15 @@ func TestButtonStoreAdd_ValidatesActiveItem(t *testing.T) {
 	}
 }
 
-// TestPriceResolverAdapter_TakeawayRateBP verifies the resolver reads the
-// new tax_codes.takeaway_rate_basis_points column through to BasketLine —
-// the §12 UStG dine-in/takeaway VAT switch depends on it reaching the
-// basket at scan time (internal/pos.effectiveTaxRateBP consumes it later).
-func TestPriceResolverAdapter_TakeawayRateBP(t *testing.T) {
+// TestPriceResolverAdapter_TaxCodeID verifies the resolver reads an item's
+// tax_code_id through to BasketLine — a tax plugin (internal/pos.
+// TaxRateAsker) uses it to tell item categories apart without core
+// interpreting it itself.
+func TestPriceResolverAdapter_TaxCodeID(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
-	_, _ = db.Exec(`INSERT INTO tax_codes(id, rate_basis_points, takeaway_rate_basis_points) VALUES('tax-drink', 1900, 700)`)
+	_, _ = db.Exec(`INSERT INTO tax_codes(id, rate_basis_points) VALUES('tax-drink', 1900)`)
 	_, _ = db.Exec(`INSERT INTO items(id, sku, name, base_price, tax_code_id, is_active) VALUES('itm1','DRINK1','Coffee', 1000, 'tax-drink', 1)`)
 	_, _ = db.Exec(`INSERT INTO item_barcodes(barcode, item_id, is_primary) VALUES('DRINK1','itm1',1)`)
 	store := NewButtonStore(db)
@@ -109,7 +109,7 @@ func TestPriceResolverAdapter_TakeawayRateBP(t *testing.T) {
 	if line.TaxRateBP != 1900 {
 		t.Fatalf("expected TaxRateBP 1900, got %d", line.TaxRateBP)
 	}
-	if line.TakeawayRateBP != 700 {
-		t.Fatalf("expected TakeawayRateBP 700, got %d", line.TakeawayRateBP)
+	if line.TaxCodeID != "tax-drink" {
+		t.Fatalf("expected TaxCodeID tax-drink, got %q", line.TaxCodeID)
 	}
 }

--- a/web/ui/pages/setup.html
+++ b/web/ui/pages/setup.html
@@ -11,7 +11,7 @@
   </head>
   <body class="login-screen{{ if kiosk }} kiosk{{ end }}">
     <main class="setup-card" x-data="{ step: {{ if .errKey }}4{{ else }}1{{ end }}, last: 5,
-                                       country: '', currency: '', tax: '', reducedTax: '', taxinc: 'on' }">
+                                       country: '', currency: '', tax: '', taxinc: 'on' }">
       <img class="login-logo" src="/public/assets/logo/ut-logo-name.svg" alt="Universal Till" />
       <div class="setup-dots" aria-hidden="true">
         <template x-for="i in last"><span class="setup-dot" :class="{ active: i <= step }"></span></template>
@@ -40,15 +40,14 @@
           <h1>{{ T "setup.country.title" }}</h1>
           <p class="muted">{{ T "setup.country.hint" }}</p>
           <select name="country" x-model="country"
-                  @change="const o = $event.target.selectedOptions[0]; currency = o.dataset.currency || currency; tax = o.dataset.tax ?? tax; reducedTax = o.dataset.reducedTax ?? reducedTax; taxinc = o.dataset.taxinc || taxinc;">
+                  @change="const o = $event.target.selectedOptions[0]; currency = o.dataset.currency || currency; tax = o.dataset.tax ?? tax; taxinc = o.dataset.taxinc || taxinc;">
             <option value="">{{ T "setup.country.choose" }}</option>
             {{ range .countries }}
-            <option value="{{ .Code }}" data-currency="{{ .Currency }}" data-tax="{{ .TaxRatePct }}" data-reduced-tax="{{ .ReducedTaxRatePct }}" data-taxinc="{{ if .TaxInclusive }}on{{ else }}off{{ end }}">{{ T .NameKey }}</option>
+            <option value="{{ .Code }}" data-currency="{{ .Currency }}" data-tax="{{ .TaxRatePct }}" data-taxinc="{{ if .TaxInclusive }}on{{ else }}off{{ end }}">{{ T .NameKey }}</option>
             {{ end }}
           </select>
           <input type="hidden" name="currency" :value="currency">
           <input type="hidden" name="tax_rate_pct" :value="tax">
-          <input type="hidden" name="reduced_tax_rate_pct" :value="reducedTax">
           <input type="hidden" name="tax_inclusive" :value="taxinc">
           <p class="muted" x-show="currency"><span x-text="currency"></span> · <span x-text="tax"></span>% </p>
           <div class="setup-nav">


### PR DESCRIPTION
## Why
Direct feedback: the previous PR embedded Germany's §12 UStG dine-in/takeaway VAT rule in core (new DB column, global setting, DE=7% wizard seed, the switching logic itself) — exactly the "every country's tax quirk needs a core PR" pattern the plugin architecture exists to avoid. The UK has its own version of this problem that would have hit the same wall.

## What changed
- **New, generic, reusable**: `EventBus.Ask` — a blocking, value-returning plugin hook (the runtime previously only supported accept/reject). Events ending `.ask` auto-run blocking, same convention as the existing `.authorize` suffix.
- **Removed from core**: `TakeawayRateBP`, `ReducedTaxRateBasisPoints`, the pinned/global-fallback branching logic, the DE=7% wizard seed, and all the settings plumbing for it.
- **Added instead**: `pos.TaxRateAsker` interface — an installed plugin can override a line's rate; no asker (or `ok=false`) falls back to the line's own configured rate, today's plain default. `internal/pos` still never imports the plugin subsystem; `internal/pages/tax_hook.go` is the seam, same shape as the existing payment-authorization gate.
- `BasketLine.TaxCodeID` (replacing `TakeawayRateBP`) lets a plugin tell item categories apart without core interpreting what any of them mean.
- `OrderType`/`OrderTypeTakeaway` stayed in core — dine-in/takeaway is a universal POS concept (SumUp has it too), not German-specific. Only what it does to *tax* moved to the plugin.

Full writeup: `docs/code-reviews/2026-07-28-tax-rate-plugin-hook-refactor.md`.

## Not done here
`ut-plugin-tax-de` doesn't answer this hook yet — separate follow-up (different repo). Core's side is complete and testable independent of any plugin subscribing.

## Verification
`go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l`, both CI guard scripts pass. New: `TestEventBus_Ask`, rewritten `TestOrderTypeTaxSwitching` (proves core is inert with no asker), `TestPriceResolverAdapter_TaxCodeID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)