### PR TITLE
fix: Windows/Linux desktop-shell builds never embedded buildinfo.Version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,8 +106,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
       - name: Build unitill-desktop (${{ matrix.arch }})
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          CGO_ENABLED=1 go build -trimpath -tags desktop -ldflags "-s -w" \
+          CGO_ENABLED=1 go build -trimpath -tags desktop \
+            -ldflags "-s -w -X github.com/universaltill/universal-till/internal/buildinfo.Version=${VERSION}" \
             -o unitill-desktop ./cmd/unitill-desktop
           file unitill-desktop
       - uses: actions/upload-artifact@v4
@@ -403,3 +406,95 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.version }}
           TAG: ${{ needs.prepare.outputs.tag }}
         run: gh release upload "${TAG}" "unitill-pos_${VERSION}_android.apk" --clobber
+
+  # Regression gate for a real bug found 2026-07-28: the Windows and Linux
+  # desktop-shell (WebView) builds had no buildinfo.Version ldflag at all
+  # (linux-shells / .goreleaser.yaml's desktop-windows build both copied the
+  # CGO/-tags=desktop build command but dropped the -X version injection the
+  # plain server build next to them already had) — so unitill-desktop
+  # silently shipped as "Universal Till vdev" on those two platforms, every
+  # release, unnoticed because the status bar still renders *something*
+  # rather than erroring. Traced from a real user report that looked
+  # identical to this bug (turned out to be an unrelated stray local
+  # process that session, not this) — this job makes sure that if it ever
+  # IS the real bug, the release fails loudly instead of shipping quietly.
+  verify-versions:
+    needs: [prepare, goreleaser, macos-app]
+    if: ${{ !cancelled() && needs.prepare.result == 'success' }}
+    runs-on: macos-14 # hdiutil for the .dmg, plus tar/unzip for the rest — one runner covers every format
+    permissions:
+      contents: read
+    steps:
+      - name: Wait for the GitHub release to exist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            gh release view "$TAG" --json tagName >/dev/null 2>&1 && exit 0
+            echo "release $TAG not visible yet (attempt $i/30)"; sleep 20
+          done
+          echo "::error::release $TAG does not exist"
+          exit 1
+      - name: Download the artifacts that embed buildinfo.Version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir dist-check && cd dist-check
+          gh release download "$TAG" -R universaltill/universal-till \
+            --pattern "unitill-pos_*_linux_amd64.tar.gz" \
+            --pattern "unitill-pos_*_windows_amd64.zip" \
+            --pattern "unitill-pos_*_darwin_arm64.tar.gz" \
+            --pattern "unitill-pos-*-macOS-arm64.dmg"
+      - name: Every binary must report the real version, never "dev"
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          fail=0
+          check() {
+            local file="$1" label="$2"
+            if [ ! -f "$file" ]; then
+              echo "::error::missing $label ($file)"
+              fail=1
+              return
+            fi
+            if strings -a "$file" | grep -qx "dev"; then
+              echo "::error::$label embeds buildinfo.Version=dev — the ldflags -X version injection is broken for this build"
+              fail=1
+              return
+            fi
+            if strings -a "$file" | grep -qxE "v?${VERSION//./\\.}"; then
+              echo "ok: $label carries version $VERSION"
+            else
+              echo "::error::$label does not contain the expected version string $VERSION anywhere"
+              fail=1
+            fi
+          }
+
+          cd dist-check
+          mkdir extracted
+
+          tar xzf "unitill-pos_${VERSION}_linux_amd64.tar.gz" -C extracted
+          check extracted/unitill-pos "linux unitill-pos"
+          check extracted/unitill-desktop "linux unitill-desktop (the omission that caused the real bug)"
+          rm -rf extracted && mkdir extracted
+
+          unzip -q "unitill-pos_${VERSION}_windows_amd64.zip" -d extracted
+          check extracted/unitill-pos.exe "windows unitill-pos.exe"
+          check extracted/unitill-desktop.exe "windows unitill-desktop.exe (the omission that caused the real bug)"
+          rm -rf extracted && mkdir extracted
+
+          tar xzf "unitill-pos_${VERSION}_darwin_arm64.tar.gz" -C extracted
+          check extracted/unitill-pos "macOS portable unitill-pos"
+          rm -rf extracted && mkdir extracted
+
+          hdiutil attach -nobrowse -quiet -mountpoint extracted "unitill-pos-${VERSION}-macOS-arm64.dmg"
+          check "extracted/Universal Till.app/Contents/MacOS/unitill-pos" "macOS .app unitill-pos"
+          check "extracted/Universal Till.app/Contents/MacOS/unitill-desktop" "macOS .app unitill-desktop"
+          hdiutil detach -quiet -force extracted || true
+
+          exit $fail

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,7 +35,7 @@ builds:
       - CC=x86_64-w64-mingw32-gcc
       - CXX=x86_64-w64-mingw32-g++
     flags: [-trimpath, -tags=desktop]
-    ldflags: ["-s -w -H windowsgui"]
+    ldflags: ["-s -w -H windowsgui -X github.com/universaltill/universal-till/internal/buildinfo.Version={{.Version}}"]
     goos: [windows]
     goarch: [amd64]
   - id: darwin

--- a/docs/code-reviews/2026-07-28-verify-release-versions.md
+++ b/docs/code-reviews/2026-07-28-verify-release-versions.md
@@ -1,0 +1,70 @@
+# 2026-07-28 — Release version-injection regression gate
+
+## Context
+A user reported the Mac app's status bar showing "Universal Till vdev"
+after downloading and installing a real release. Investigation found the
+actual installed app was fine (`v0.2.44`, confirmed via `Info.plist` and
+`strings` on the binary) — the "vdev" was a stray local dev-mode test
+process I'd left running on port 8080 from earlier debugging in the same
+session, which the user's browser happened to hit.
+
+That was resolved by killing the stray process. But the user's follow-up
+was pointed and correct: "add some test that dont let you do kind of
+mistake." A code-level test can't stop an agent from forgetting to kill a
+background process — that's session hygiene, not something the codebase
+can enforce. But looking at *why* "vdev" is even a plausible thing to see
+turned up a real, currently-shipping bug worth a real regression test.
+
+## Real bug found while investigating
+`buildinfo.Version` is injected via `-ldflags "-X .../buildinfo.Version=…"`
+at build time; without it, the variable defaults to `"dev"` — exactly the
+string that confused the user. Checking every build target that produces
+it:
+
+| Target | ldflags has `-X buildinfo.Version=` ? |
+|---|---|
+| goreleaser `linux` (unitill-pos) | yes |
+| goreleaser `windows` (unitill-pos.exe) | yes |
+| goreleaser `darwin` (unitill-pos) | yes |
+| **goreleaser `desktop-windows` (unitill-desktop.exe)** | **no** — `ldflags: ["-s -w -H windowsgui"]` |
+| **release.yml `linux-shells` (unitill-desktop)** | **no** — `-ldflags "-s -w"` |
+| `packaging/macos/build-app.sh` (both binaries) | yes |
+
+Both desktop-shell (WebView) builds for Windows and Linux — the two
+platforms whose custom build commands were written separately from their
+sibling plain-server build, evidently copy-pasted without carrying the
+version flag over — have been shipping `buildinfo.Version == "dev"` in
+every release. Any Windows or Linux user opening the native app window
+(not the browser-based server) would see exactly "Universal Till vdev" in
+the status bar, indistinguishable from the confusion today. macOS was
+unaffected only because `build-app.sh` is a from-scratch script, not a
+copy of the plain build command.
+
+## Fix
+- `.goreleaser.yaml`: `desktop-windows` build now includes the same
+  `-X .../buildinfo.Version={{.Version}}` its sibling `windows` build has.
+- `.github/workflows/release.yml`: `linux-shells` job's build command now
+  takes `VERSION` from `needs.prepare.outputs.version` and injects it the
+  same way.
+
+## The actual regression test
+New `verify-versions` job in `release.yml`, running after `goreleaser` and
+`macos-app`: downloads every release artifact that's supposed to embed
+`buildinfo.Version` (linux tar.gz, windows zip, darwin tar.gz, the macOS
+`.dmg`), extracts each, and asserts via `strings` that none of the
+binaries inside — `unitill-pos` *and* `unitill-desktop` on every platform
+that ships both — contains a bare `"dev"` string or fails to contain the
+real release version. Runs on `macos-14` so one runner has `hdiutil` (for
+the `.dmg`) plus `tar`/`unzip` for everything else. A future regression of
+this exact kind (someone adds a new build target, or edits an existing
+one's ldflags, and drops the version injection) now fails the release
+loudly instead of shipping silently.
+
+## Verification
+`goreleaser check --config .goreleaser.yaml` passes. `actionlint
+.github/workflows/release.yml` reports only one warning, pre-existing and
+unrelated to this change (verified via `git diff` hunk ranges). `go build
+./...` unaffected (no Go source touched). The check logic itself can't be
+unit-tested outside a real GitHub Actions run — it will get its first real
+exercise on the next release, at which point it should also silently
+confirm the fix (both previously-broken binaries now pass).


### PR DESCRIPTION
## What happened
A user reported the Mac status bar showing "Universal Till vdev" after installing a real release. The actual cause that time was a stray local test process of mine — but checking *why* "vdev" is even a plausible thing to see turned up a real, currently-shipping bug.

## The real bug
`unitill-desktop` (the native WebView app) for **Windows** (`.goreleaser.yaml`'s `desktop-windows` build) and **Linux** (`release.yml`'s `linux-shells` job) both had their `-ldflags` copy-pasted from their sibling plain-server build, but dropped the `-X buildinfo.Version=...` injection. Every release has shipped both with the version defaulting to `"dev"` — a real Windows or Linux user opening the native app window sees exactly "Universal Till vdev". macOS was unaffected (`build-app.sh` is a from-scratch script, not a copy).

## Fix
- `.goreleaser.yaml`: `desktop-windows` build gets the same version ldflag its sibling `windows` build already has.
- `release.yml`: `linux-shells` job now injects `VERSION` the same way.

## The regression gate
New `verify-versions` CI job: downloads every release artifact that should embed `buildinfo.Version`, extracts each, and fails the release if any binary reports `"dev"` or the wrong version. Runs on `macos-14` (one runner covers `.dmg`/`hdiutil` plus tar/zip for everything else).

Full writeup: `docs/code-reviews/2026-07-28-verify-release-versions.md`.

## Verification
`goreleaser check` passes. `actionlint` reports only one pre-existing, unrelated warning. `go build ./...` unaffected (no Go source touched). The new job itself can only be exercised by a real release — next one should confirm both the fix and the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)