### PR TITLE
fix: verify-versions job had no checkout step, gh lost repo context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -425,6 +425,17 @@ jobs:
     permissions:
       contents: read
     steps:
+      # Every sibling job with this same "wait" step has this first — gh
+      # infers which repo to talk to from the checked-out git remote; without
+      # it, `gh release view` fails for an unrelated reason (no repo
+      # context) that the `>/dev/null 2>&1` redirect below silently
+      # swallows, looking exactly like "release not visible yet" for the
+      # full 30-attempt/10-minute timeout. Found by this job failing that
+      # way on its first real run — see docs/code-reviews/2026-07-28-verify-
+      # release-versions.md's follow-up note.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
       - name: Wait for the GitHub release to exist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/code-reviews/2026-07-28-verify-release-versions.md
+++ b/docs/code-reviews/2026-07-28-verify-release-versions.md
@@ -68,3 +68,26 @@ unrelated to this change (verified via `git diff` hunk ranges). `go build
 unit-tested outside a real GitHub Actions run — it will get its first real
 exercise on the next release, at which point it should also silently
 confirm the fix (both previously-broken binaries now pass).
+
+## Follow-up: the gate itself had a bug on its first real run
+Cut v0.2.45 to actually exercise this end to end. `linux-shells`,
+`goreleaser`, `macos-app`, `windows-installer`, `android-app` all passed —
+the real fix works. `verify-versions` itself failed: its "Wait for the
+GitHub release to exist" step looped for the full 10-minute timeout
+insisting the release didn't exist, even though `gh release list` showed
+v0.2.45 published a minute *before* the job even started.
+
+Root cause: every sibling job with this same wait-loop pattern
+(`windows-installer`, `macos-app`, `android-app`) runs `actions/checkout@v4`
+first — `gh` infers which repo to talk to from the checked-out git remote.
+This job had no checkout step at all, so `gh release view "$TAG"` failed
+for an unrelated reason (no repo context), and the `>/dev/null 2>&1`
+redirect on that line silently swallowed the real error, making a
+config mistake look exactly like "release not visible yet." Copied the
+wait-loop text from a sibling job without copying the step it depends on.
+Fixed by adding the same `actions/checkout@v4` step. Worth noting plainly:
+even a change added specifically *to* catch mistakes needs its own real
+end-to-end run before trusting it — it had a bug that would have made the
+regression gate itself silently useless (timing out and failing the whole
+release without ever checking a single binary) if the timeout hadn't been
+loud enough to notice.


### PR DESCRIPTION
Follow-up to #76. Cut v0.2.45 to actually exercise the new `verify-versions` gate end to end — every real fix passed (`linux-shells`, `goreleaser`, `macos-app`, `windows-installer`, `android-app`), but `verify-versions` itself failed: its "wait for release" loop ran the full 10-minute timeout insisting v0.2.45 didn't exist, even though it was published a minute before the job started.

Root cause: every sibling job with this wait-loop pattern runs `actions/checkout@v4` first so `gh` has repo context to infer from. This job didn't — `gh release view` failed for an unrelated reason, silently swallowed by `>/dev/null 2>&1`, indistinguishable from "not visible yet." Fixed by adding the same checkout step.

Full note in `docs/code-reviews/2026-07-28-verify-release-versions.md`'s follow-up section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)