### PR TITLE
fix: verify-versions job's pipe interacted badly with macOS strings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -473,12 +473,20 @@ jobs:
               fail=1
               return
             fi
-            if strings -a "$file" | grep -qx "dev"; then
+            # Capture first, then grep the captured text — NOT `strings | grep
+            # -q`: macOS's strings errors ("failed to flush output") when grep
+            # -q closes the pipe early on its first match, and set -o pipefail
+            # then reports that as the WHOLE pipeline failing even though grep
+            # found what it was looking for — every check failed this way on
+            # this job's first real run despite the versions being correct.
+            local out
+            out="$(strings -a "$file" 2>/dev/null || true)"
+            if grep -qx "dev" <<< "$out"; then
               echo "::error::$label embeds buildinfo.Version=dev — the ldflags -X version injection is broken for this build"
               fail=1
               return
             fi
-            if strings -a "$file" | grep -qxE "v?${VERSION//./\\.}"; then
+            if grep -qxE "v?${VERSION//./\\.}" <<< "$out"; then
               echo "ok: $label carries version $VERSION"
             else
               echo "::error::$label does not contain the expected version string $VERSION anywhere"

--- a/docs/code-reviews/2026-07-28-verify-release-versions.md
+++ b/docs/code-reviews/2026-07-28-verify-release-versions.md
@@ -91,3 +91,19 @@ end-to-end run before trusting it — it had a bug that would have made the
 regression gate itself silently useless (timing out and failing the whole
 release without ever checking a single binary) if the timeout hadn't been
 loud enough to notice.
+
+## Follow-up #2: the check itself had a pipe bug (v0.2.46)
+With the checkout fix in, the job ran the real check — and every single
+binary failed with "does not contain the expected version string," even
+though (verified separately, by hand, against the actual downloaded
+artifacts) the version really was there and correct. Cause: `strings -a
+"$file" | grep -qx "..."` — macOS's `strings` (Xcode's, not GNU's) errors
+("failed to flush output") when `grep -q` closes its read end early after
+finding the first match, and `set -o pipefail` then reports that broken-pipe
+error as the whole pipeline failing, even though `grep` itself found what it
+was looking for and would have reported success. Fixed by capturing
+`strings`' output into a variable first (`out="$(strings -a "$file" ||
+true)"`) and grepping the captured text instead of a live pipe — no process
+left running to receive a SIGPIPE, so no interaction with `pipefail` at all.
+Verified locally against the real v0.2.46 artifacts (downloaded by hand)
+before pushing again, rather than spending a third CI cycle to find out.


### PR DESCRIPTION
Follow-up to #76/#77. With the checkout fix in (#77), v0.2.46's release run got the \`verify-versions\` job actually executing — and every single check failed with "does not contain the expected version string," despite the versions genuinely being correct (confirmed by hand against the real downloaded artifacts).

Cause: \`strings -a "\$file" | grep -qx "..."\` — macOS's \`strings\` (Xcode's) errors ("failed to flush output") when \`grep -q\` closes its read end early right after finding a match, and \`set -o pipefail\` turns that broken-pipe error into a false pipeline failure even though \`grep\` succeeded. Fixed by capturing \`strings\`' output into a variable first, then grepping the captured text — no live pipe, no SIGPIPE, no interaction with pipefail.

Verified locally against the real v0.2.46 artifacts (downloaded by hand, ran the exact check logic) before pushing again rather than burning a third CI cycle to find out. This also independently confirms the original ldflags fix genuinely works — the real \`unitill-desktop\`/\`unitill-desktop.exe\` from v0.2.46 both carry the correct version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)