### PR TITLE
fix: dine-in/takeaway toggle buttons showed no visible selected state

### DIFF
--- a/web/public/app.css
+++ b/web/public/app.css
@@ -414,6 +414,9 @@ a.btn, a.btn:hover { text-decoration: none; }
 .disc-input { width: 3.6rem; padding: .3rem .35rem; font-size: .8rem; margin-top: .2rem; }
 .btn-x { padding: .3rem .55rem; font-size: .8rem; min-height: 0; }
 
+.order-type-toggle { display: flex; gap: .4rem; margin-bottom: .6rem; }
+.order-type-toggle .btn { flex: 1; }
+
 .basket table { width: 100%; border-collapse: collapse; background: var(--surface);
                 border-radius: var(--radius); overflow: hidden; }
 .basket th { font-size: .75rem; text-transform: uppercase; letter-spacing: .04em;

--- a/web/ui/partials/basket.html
+++ b/web/ui/partials/basket.html
@@ -5,12 +5,14 @@
   {{ end }}
   <h2>{{ T "basket.title" }}</h2>
   <div class="order-type-toggle" role="group" aria-label="{{ T "basket.order_type.label" }}">
-    <button type="button" class="btn{{ if ne .OrderType "takeaway" }} primary{{ end }}"
+    <button type="button" class="btn{{ if eq .OrderType "takeaway" }} secondary{{ end }}"
+            aria-pressed="{{ if ne .OrderType "takeaway" }}true{{ else }}false{{ end }}"
             hx-post="/api/pos/order-type" hx-vals='{"order_type":""}' hx-target="#basket" hx-swap="outerHTML">
-      {{ T "basket.order_type.dine_in" }}</button>
-    <button type="button" class="btn{{ if eq .OrderType "takeaway" }} primary{{ end }}"
+      {{ if ne .OrderType "takeaway" }}✓ {{ end }}{{ T "basket.order_type.dine_in" }}</button>
+    <button type="button" class="btn{{ if ne .OrderType "takeaway" }} secondary{{ end }}"
+            aria-pressed="{{ if eq .OrderType "takeaway" }}true{{ else }}false{{ end }}"
             hx-post="/api/pos/order-type" hx-vals='{"order_type":"takeaway"}' hx-target="#basket" hx-swap="outerHTML">
-      {{ T "basket.order_type.takeaway" }}</button>
+      {{ if eq .OrderType "takeaway" }}✓ {{ end }}{{ T "basket.order_type.takeaway" }}</button>
   </div>
   <div class="basket-scroll">
     <table>


### PR DESCRIPTION
\`.btn\` and \`.btn.primary\` render identically in this design system (both \`background: var(--accent)\`) — toggling the "primary" class produced zero visible difference, so clicking the button appeared to do nothing even though the state change was working correctly server-side.

Swapped to \`.secondary\` (a real, visually distinct style already in the design system) for the *unselected* button, added a checkmark prefix + \`aria-pressed\` on the selected one, and gave the toggle group its own layout (it had none before).

Verified by hand against a local running instance: default state shows dine-in selected, POSTing \`order_type=takeaway\` flips both buttons' classes/aria-pressed/checkmark correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)