### PR TITLE
fix: new catalog items missing from Inventory; catalog images missing from sale-screen tiles

### DIFF
--- a/docs/code-reviews/2026-07-29-catalog-item-visibility-fixes.md
+++ b/docs/code-reviews/2026-07-29-catalog-item-visibility-fixes.md
@@ -1,0 +1,69 @@
+# 2026-07-29 — Two catalog-item visibility bugs, found live
+
+## Context
+While setting up sample café items (Latte, Ham Sandwich, etc.) to test the
+new dine-in/takeaway tax-switching feature, real bugs surfaced from actual
+use of the catalog admin UI — not from code review.
+
+## Bug 1: a new item never showed up on the Inventory page
+`CatalogRepo.CreateItem` (and `CreateVariant`) only ever inserted into
+`items`/`item_variants` — never `inventory`. `ListStockLevels` (the
+Inventory page's query) starts from `FROM inventory inv JOIN items i ON
+i.id = inv.item_id` — an INNER JOIN, so an item with zero inventory rows is
+invisible there, even though it shows up fine in the catalog list (a
+different query, no such join). `RecordStockMovement`'s own `UPDATE
+inventory SET quantity = quantity + ?` can't create a missing row either —
+it's a plain UPDATE, a no-op against zero matching rows. Nothing in the
+codebase created that first row for a brand-new item.
+
+**Fix**: both `CreateItem` and `CreateVariant` now call a new
+`ensureInventoryRow` helper — finds or creates the default "Main" location
+(same logic as `POSRepo.EnsureStockLocation`, kept local to avoid a
+cross-repo dependency for five lines of SQL) and inserts a zero-quantity
+`inventory` row, `INSERT OR IGNORE` against the existing unique index so a
+re-run is a no-op.
+
+**Judgment call, and the one that actually broke tests on the first pass**:
+this must be genuinely best-effort, not just labeled that way. My first
+version returned the inventory-row error from `CreateItem`/`CreateVariant`,
+which immediately broke `TestCatalogCreateAndDeactivate` and
+`TestCreateVariantAndBarcode` — both use a minimal hand-rolled test schema
+with no `stock_locations` table, and turning that into a 400 on every item
+creation is exactly wrong: an item is fully usable for sale without a
+stock row (stock tracking is opt-in), so a failure here must only be
+logged (`logging.L().Warnf`), never surfaced as item-creation failure.
+Added `TestCreateItem_SucceedsWithoutStockLocationsTable` specifically to
+lock this in — regression-tests the mistake, not just the feature.
+
+## Bug 2: a catalog-uploaded item image never showed on the sale-screen tile
+Two parallel, never-synced image sources: `item_images` (role='thumbnail')
+— what the catalog list and the barcode/scan resolvers
+(`internal/data/pos_repo.go`'s `resolve*` functions) already read — and
+`shortcut_buttons.image_path`, a separate column only the sale-screen
+product-tile grid (`ShortcutsRepo.LoadButtons`) reads. Uploading a photo
+via the catalog form writes to `item_images`; nothing ever populates
+`shortcut_buttons.image_path` from that upload. Confirmed live: an item's
+photo appeared in the catalog list, never on its own tile.
+
+**Fix**: `LoadButtons`' query now does `COALESCE(sb.image_path, (SELECT
+path FROM item_images img WHERE img.item_id = sb.item_id AND img.role =
+'thumbnail' LIMIT 1))` — falls back to the catalog image when the button
+has no image of its own, same subquery pattern already used elsewhere. An
+explicit button-specific image (set via the Designer) still wins when both
+exist — the more specific choice should override the general fallback, not
+the other way round.
+
+## Not a bug: per-variant images
+Reported alongside the above ("different variant can have different
+images but there is no place to add it") — checked, and the UI already
+exists: `catalog_variants.html`'s variant grid has a small 📷 icon
+(`.vg-img-upload`) next to each variant's thumbnail, wired to the existing
+`POST /api/catalog/variant/image` endpoint. Easy to miss (small, `opacity:
+.6` until hover) but functional — no code change made here.
+
+## Verification
+`go build ./...`, `go vet ./...`, `go test ./...`, both CI guard scripts,
+`gofmt -l` all pass. New tests: `TestCreateItem_CreatesInventoryRow`,
+`TestCreateVariant_CreatesInventoryRow`,
+`TestCreateItem_SucceedsWithoutStockLocationsTable`,
+`TestLoadButtons_FallsBackToCatalogImage`.

--- a/internal/data/catalog_repo.go
+++ b/internal/data/catalog_repo.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/universaltill/universal-till/internal/catalogtypes"
+	"github.com/universaltill/universal-till/internal/logging"
 )
 
 type CatalogRepo struct {
@@ -447,7 +448,44 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	if err != nil {
 		return "", fmt.Errorf("insert item: %w", err)
 	}
+	// Without this, a newly created item has NO row in inventory at all
+	// (RecordStockMovement's UPDATE can't create one, only adjust an
+	// existing one) — invisible on the Inventory page until some other
+	// stock action happened to touch it first. Confirmed live: an item
+	// added through this form showed up in the catalog list but nowhere in
+	// Inventory. Genuinely best-effort, not just in name: the item is
+	// already committed and perfectly usable for sale without a stock
+	// row (stock tracking is opt-in), so a failure here — e.g. no
+	// stock_locations table at all, a legitimately stockless deployment —
+	// must never fail item creation itself, only get logged.
+	if err := r.ensureInventoryRow(ctx, in.ID, ""); err != nil {
+		logging.L().Warnf("catalog: create item %s: inventory row not created: %v", in.ID, err)
+	}
 	return in.ID, nil
+}
+
+// ensureInventoryRow creates a zero-quantity inventory row for a new item or
+// variant (exactly one of itemID/variantID set) at the default stock
+// location, if one doesn't already exist. See CreateItem/CreateVariant.
+func (r *CatalogRepo) ensureInventoryRow(ctx context.Context, itemID, variantID string) error {
+	var locationID string
+	err := r.db.QueryRowContext(ctx, `SELECT id FROM stock_locations WHERE name = 'Main' OR id = 'loc_main' ORDER BY id LIMIT 1`).Scan(&locationID)
+	if errors.Is(err, sql.ErrNoRows) {
+		locationID = "loc_main"
+		if _, err := r.db.ExecContext(ctx, `INSERT INTO stock_locations (id, name) VALUES (?, ?)`, locationID, "Main"); err != nil {
+			return fmt.Errorf("create default location: %w", err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("find default location: %w", err)
+	}
+	_, err = r.db.ExecContext(ctx, `
+INSERT OR IGNORE INTO inventory (id, item_id, variant_id, location_id, quantity)
+VALUES (?, ?, ?, ?, 0)
+`, uuid.NewString(), nullIfEmpty(itemID), nullIfEmpty(variantID), locationID)
+	if err != nil {
+		return fmt.Errorf("insert inventory row: %w", err)
+	}
+	return nil
 }
 
 // ItemCostPrice returns the item's cost price in minor units (0 = unset).
@@ -588,6 +626,12 @@ VALUES (?, ?, ?, ?, ?, ?, ?)
 `, in.ID, in.ItemID, nullableString(in.SKU), in.Name, in.Price, nullableInt64(in.CostPrice), active)
 	if err != nil {
 		return "", fmt.Errorf("insert variant: %w", err)
+	}
+	// Same reasoning as CreateItem: without this a new variant has no
+	// inventory row and is invisible on the Inventory page. Best-effort,
+	// same as CreateItem — never fails variant creation itself.
+	if err := r.ensureInventoryRow(ctx, "", in.ID); err != nil {
+		logging.L().Warnf("catalog: create variant %s: inventory row not created: %v", in.ID, err)
 	}
 	return in.ID, nil
 }

--- a/internal/data/catalog_repo_inventory_test.go
+++ b/internal/data/catalog_repo_inventory_test.go
@@ -1,0 +1,124 @@
+package data_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/catalogtypes"
+	"github.com/universaltill/universal-till/internal/data"
+	"github.com/universaltill/universal-till/internal/db"
+	"github.com/universaltill/universal-till/internal/testsupport"
+)
+
+// The inventory-row creation added to CreateItem must be genuinely
+// best-effort: several existing test suites (and, in principle, a real
+// stockless deployment) use a schema with no stock_locations table at all.
+// Item creation itself must still succeed. This is a real regression test —
+// the first version of this fix returned the inventory error from
+// CreateItem, which broke TestCatalogCreateAndDeactivate and others by
+// turning every item creation into a 400 wherever stock_locations didn't
+// exist.
+func TestCreateItem_SucceedsWithoutStockLocationsTable(t *testing.T) {
+	db := testsupport.NewCatalogTestDB(t)
+	defer db.Close()
+
+	repo := data.NewCatalogRepo(db)
+	id, err := repo.CreateItem(context.Background(), catalogtypes.ItemInput{
+		Name: "Latte", BasePrice: 320, IsActive: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem must succeed even when inventory tracking is unavailable: %v", err)
+	}
+	if id == "" {
+		t.Fatal("expected a non-empty item id")
+	}
+}
+
+// A newly created item/variant had NO row in inventory at all until some
+// other stock action happened to touch it — invisible on the Inventory page
+// (ListStockLevels starts from an INNER JOIN on inventory) despite showing
+// up fine in the catalog list. Confirmed live 2026-07-29: an item added
+// through the catalog form was "only in catalog," missing from Inventory.
+func TestCreateItem_CreatesInventoryRow(t *testing.T) {
+	d, err := db.Open(filepath.Join(t.TempDir(), "cat.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	ctx := context.Background()
+	repo := data.NewCatalogRepo(d.DB)
+
+	id, err := repo.CreateItem(ctx, catalogtypes.ItemInput{
+		Name: "Latte", BasePrice: 320, IsActive: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	var qty float64
+	var locationID string
+	err = d.DB.QueryRowContext(ctx,
+		`SELECT quantity, location_id FROM inventory WHERE item_id = ?`, id,
+	).Scan(&qty, &locationID)
+	if err != nil {
+		t.Fatalf("expected an inventory row for the new item, got: %v", err)
+	}
+	if qty != 0 {
+		t.Fatalf("expected initial quantity 0, got %v", qty)
+	}
+	if locationID == "" {
+		t.Fatal("expected a default location to be assigned")
+	}
+
+	// A second item must land at the SAME default location, not create a
+	// duplicate "Main" location each time.
+	id2, err := repo.CreateItem(ctx, catalogtypes.ItemInput{
+		Name: "Cappuccino", BasePrice: 320, IsActive: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem #2: %v", err)
+	}
+	var locationID2 string
+	if err := d.DB.QueryRowContext(ctx,
+		`SELECT location_id FROM inventory WHERE item_id = ?`, id2,
+	).Scan(&locationID2); err != nil {
+		t.Fatalf("expected an inventory row for the second item: %v", err)
+	}
+	if locationID2 != locationID {
+		t.Fatalf("expected the same default location, got %q then %q", locationID, locationID2)
+	}
+}
+
+func TestCreateVariant_CreatesInventoryRow(t *testing.T) {
+	d, err := db.Open(filepath.Join(t.TempDir(), "cat.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	ctx := context.Background()
+	repo := data.NewCatalogRepo(d.DB)
+
+	itemID, err := repo.CreateItem(ctx, catalogtypes.ItemInput{
+		Name: "Coffee", BasePrice: 300, IsActive: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	variantID, err := repo.CreateVariant(ctx, catalogtypes.VariantInput{
+		ItemID: itemID, Name: "Large", Price: 350, IsActive: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateVariant: %v", err)
+	}
+
+	var qty float64
+	if err := d.DB.QueryRowContext(ctx,
+		`SELECT quantity FROM inventory WHERE variant_id = ?`, variantID,
+	).Scan(&qty); err != nil {
+		t.Fatalf("expected an inventory row for the new variant, got: %v", err)
+	}
+	if qty != 0 {
+		t.Fatalf("expected initial quantity 0, got %v", qty)
+	}
+}

--- a/internal/data/shortcuts_repo.go
+++ b/internal/data/shortcuts_repo.go
@@ -29,8 +29,17 @@ func (r *ShortcutsRepo) LoadButtons(ctx context.Context) ([]ShortcutButton, erro
 	var err error
 	done := shortcutsObs.trace("load_buttons")
 	defer func() { done(err) }()
+	// image_path falls back to the item's own catalog image (item_images,
+	// role='thumbnail' — same source the catalog list and barcode/scan
+	// resolvers already use) when the button has no image of its own set
+	// explicitly. Without this, a shop's catalog-uploaded item photo showed
+	// up in the catalog list but never on the actual sale-screen tile,
+	// since shortcut_buttons.image_path is a separate column nothing ever
+	// populates from a plain catalog image upload — confirmed live 2026-07-29.
 	rows, err := r.db.QueryContext(ctx, `
-SELECT sb.label, sb.barcode, sb.item_id, sb.image_path, COALESCE(i.base_price, 0)
+SELECT sb.label, sb.barcode, sb.item_id,
+       COALESCE(sb.image_path, (SELECT path FROM item_images img WHERE img.item_id = sb.item_id AND img.role = 'thumbnail' LIMIT 1)),
+       COALESCE(i.base_price, 0)
 FROM shortcut_buttons sb
 LEFT JOIN items i ON i.id = sb.item_id
 ORDER BY sb.sort_order, sb.label`)

--- a/internal/data/shortcuts_repo_test.go
+++ b/internal/data/shortcuts_repo_test.go
@@ -1,0 +1,70 @@
+package data_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/data"
+	"github.com/universaltill/universal-till/internal/db"
+)
+
+// A shortcut button (sale-screen product tile) has its own, separate
+// image_path column from item_images (the catalog's own image storage,
+// also used by the barcode/scan resolvers) — nothing ever populated it from
+// a plain catalog image upload, so an item's catalog photo showed up in the
+// catalog list but never on its actual sale-screen tile. Confirmed live
+// 2026-07-29.
+func TestLoadButtons_FallsBackToCatalogImage(t *testing.T) {
+	d, err := db.Open(filepath.Join(t.TempDir(), "shortcuts.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	ctx := context.Background()
+	ex := func(q string, args ...any) {
+		if _, err := d.DB.ExecContext(ctx, q, args...); err != nil {
+			t.Fatalf("seed %q: %v", q, err)
+		}
+	}
+
+	// item-a: catalog image only, no button-specific image — must fall back.
+	ex(`INSERT INTO items (id, sku, name, base_price, is_active, is_weighed, unit) VALUES ('item-a','SKU-A','Latte',320,1,0,'each')`)
+	ex(`INSERT INTO item_images (id, item_id, path, role) VALUES ('img-a','item-a','/public/assets/items/item-a/thumb.png','thumbnail')`)
+	ex(`INSERT INTO shortcut_buttons (barcode, item_id, label, sort_order) VALUES ('BTN-A','item-a','Latte',1)`)
+
+	// item-b: an explicit button image set — must win over the catalog image.
+	ex(`INSERT INTO items (id, sku, name, base_price, is_active, is_weighed, unit) VALUES ('item-b','SKU-B','Cappuccino',320,1,0,'each')`)
+	ex(`INSERT INTO item_images (id, item_id, path, role) VALUES ('img-b','item-b','/public/assets/items/item-b/thumb.png','thumbnail')`)
+	ex(`INSERT INTO shortcut_buttons (barcode, item_id, label, image_path, sort_order) VALUES ('BTN-B','item-b','Cappuccino','/public/images/custom-cappuccino.png',2)`)
+
+	// item-c: neither — must stay empty, not error.
+	ex(`INSERT INTO items (id, sku, name, base_price, is_active, is_weighed, unit) VALUES ('item-c','SKU-C','Croissant',195,1,0,'each')`)
+	ex(`INSERT INTO shortcut_buttons (barcode, item_id, label, sort_order) VALUES ('BTN-C','item-c','Croissant',3)`)
+
+	repo := data.NewShortcutsRepo(d.DB)
+	btns, err := repo.LoadButtons(ctx)
+	if err != nil {
+		t.Fatalf("LoadButtons: %v", err)
+	}
+
+	byLabel := map[string]data.ShortcutButton{}
+	for _, b := range btns {
+		byLabel[b.Label] = b
+	}
+	for _, want := range []string{"Latte", "Cappuccino", "Croissant"} {
+		if _, ok := byLabel[want]; !ok {
+			t.Fatalf("expected a button labeled %q among the loaded buttons", want)
+		}
+	}
+
+	if got := byLabel["Latte"].ImageURL; got != "/public/assets/items/item-a/thumb.png" {
+		t.Fatalf("expected catalog-image fallback for Latte, got %q", got)
+	}
+	if got := byLabel["Cappuccino"].ImageURL; got != "/public/images/custom-cappuccino.png" {
+		t.Fatalf("expected the explicit button image to win for Cappuccino, got %q", got)
+	}
+	if got := byLabel["Croissant"].ImageURL; got != "" {
+		t.Fatalf("expected no image for Croissant, got %q", got)
+	}
+}


### PR DESCRIPTION
Two real bugs found live while setting up sample data to test the dine-in/takeaway tax feature.

**Bug 1**: \`CreateItem\`/\`CreateVariant\` never created an \`inventory\` row, so a brand-new item was invisible on the Inventory page (its query is an INNER JOIN starting from \`inventory\`) despite showing up fine in the catalog list. Fixed with a best-effort \`ensureInventoryRow\` — genuinely non-fatal (logs on failure, first version wrongly returned the error and broke two existing tests that use a schema without \`stock_locations\`; added a regression test for exactly that).

**Bug 2**: \`shortcut_buttons.image_path\` (sale-screen tile grid) and \`item_images\` (catalog list + scan resolvers) never synced — a catalog-uploaded photo never appeared on its own tile. \`LoadButtons\` now falls back to the catalog image when no button-specific image is set.

**Checked, not a bug**: per-variant images already have a UI (small 📷 icon per variant row) — easy to miss, works fine, no change needed.

Full writeup: \`docs/code-reviews/2026-07-29-catalog-item-visibility-fixes.md\`.

## Verification
\`go build\`, \`go vet\`, \`go test ./...\`, both CI guards, \`gofmt -l\` all pass. 4 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)