### PR TITLE
fix: uploaded images lost on every update; stock table never refreshed

### DIFF
--- a/docs/code-reviews/2026-07-29-uploaded-assets-lost-on-update-and-stock-table-refresh.md
+++ b/docs/code-reviews/2026-07-29-uploaded-assets-lost-on-update-and-stock-table-refresh.md
@@ -1,0 +1,104 @@
+# 2026-07-29 — Uploaded images lost on every update; stock table never refreshed
+
+## Context
+Follow-up to yesterday's catalog visibility fixes. Farshid reported three
+more things live: "still no image upload, this was working previously,"
+variant images "still" not working, and "inventory count is not updating."
+Testing each hands-on (not just reading code) surfaced two real, separate
+bugs — one of them a genuine data-loss bug, not a display glitch.
+
+## Bug 1 (serious): uploaded images live inside the app bundle/release tree
+`POST /api/catalog/item/image`, `/variant/image`, the barcode-autofill
+image fetch, and the receipt logo upload all wrote to
+`filepath.Join("web", "public", "assets", ...)` — a path relative to the
+process's **current working directory**. For the packaged macOS `.app`,
+that's `Contents/Resources/`, i.e. **inside the versioned app bundle
+itself**. `applyMacApp` (self-update) replaces that whole bundle on every
+update (`ditto "$NEW" "$APP"` over the old one); the archive self-update
+path (`internal/selfupdate.Apply`) does the same to `web/` specifically
+(`os.Rename(curWeb, webBak)` then moves the new archive's `web/` into
+place). Either way, anything written under `web/public/...` is discarded
+on the very next update — confirmed live: an item's uploaded photo,
+present in the catalog list right after upload, was gone after installing
+the release that was supposed to *fix* an unrelated display bug for it.
+
+Root cause of "still no image upload, this was working previously": it
+wasn't the upload that broke — it's that the update the user had just
+installed (to get yesterday's fixes) silently deleted the previous
+upload, and any new upload would meet the identical fate at the next
+update.
+
+**Fix**: `internal/paths` already exists specifically for "mutable data
+that must survive version upgrades" (its own doc comment). All four write
+sites now write to `paths.Data("public", "assets", ...)` instead. The
+static file server (`internal/pages/static_page.go`'s `fallbackFS`) gains
+a new, highest-priority tier for that stable directory, ahead of the
+existing release-tree/embedded-default tiers — same fallback chain
+`/public/` and theme resolution already shared, just with the missing
+persistent tier added. `receiptLogoPath` changed from a `const` to a
+`func()`: `paths.DataDir()` only resolves correctly after `paths.Init` has
+run (during config load), which happens after Go package-level consts
+would already have been evaluated.
+
+**Migration, not just a fix going forward**: added
+`paths.migrateLegacyUploadedAssets`, called from the existing
+`MigrateLegacyData` (the same one-time migration hook that already moves
+the DB and plugin bundles into the stable dir on first run after an
+update). Copies `web/public/assets/items/**` and specifically
+`web/public/assets/logo/receipt-logo.png` — **not** a blanket copy of
+`web/public/assets`, which also holds built-in default icons/logo that
+must stay resolvable from the embedded/release tiers so a future release
+can still update them; copying those into the stable tier would freeze
+them at whatever version happened to exist during this one migration.
+Without this, fixing the write path would still have left every shop
+needing to re-upload everything right after finally getting the fix.
+
+## Bug 2: the stock-levels table never refreshed after a stock change
+Checked the actual data first: a receive/adjust genuinely updated
+`inventory.quantity` correctly (verified 10 + 15 = 25 in the real
+database) — this was never a database bug. The `/inventory` page's
+stock-levels table is server-rendered once, on page load, with no HTMX
+trigger to look again; the receive/adjust/override/return forms all
+target a small `#result` status div, never the table. A successful
+submission was — correctly — invisible on screen until a full manual page
+reload, reading as "inventory count is not updating."
+
+**Fix**: extracted the table into its own partial (`stock_table.html`) and
+a new `GET /ui/inventory/stock-table` endpoint (sharing the same
+`stockLevelsForDisplay` helper the full page uses, so they can't drift).
+The table's wrapping card gets `hx-trigger="stock-updated from:body"
+hx-get="/ui/inventory/stock-table" hx-swap="innerHTML"` — same idiom the
+adjacent low-stock list already used for its own `hx-trigger="load"`. The
+three mutation endpoints' success responses now set `HX-Trigger:
+stock-updated` (a new `writeHTMLStockChanged` wrapper around the existing
+`writeHTML`), which htmx turns into a DOM event on `<body>` that both the
+stock table and the low-stock list (also updated to listen) react to.
+
+## Not a bug
+Rechecked per-variant images (reported again as "no place to add it") —
+the control exists (`catalog_variants.html`'s 📷 icon per row, wired to
+`POST /api/catalog/variant/image`) and, once Bug 1's write-path fix
+lands, writes to the correct persistent location. No separate issue found
+beyond Bug 1 affecting it the same way item images were affected.
+
+## Verification
+`go build ./...`, `go vet ./...`, `go test ./...`, both CI guard scripts,
+`gofmt -l` all pass (one pre-existing, unrelated gofmt hit in
+`internal/plugins/marketplace/client.go`, untouched by this change).
+
+New tests:
+- `TestMigrateLegacyUploadedAssets` (`internal/paths`) — migrates item/
+  variant photos and the receipt logo, leaves built-in default assets
+  alone, is idempotent.
+- `TestInventoryReceiptTriggersStockTableRefresh` (`internal/pages`) —
+  asserts the `HX-Trigger: stock-updated` header on a successful receipt,
+  and that the new partial endpoint reflects the updated quantity.
+
+`TestInventoryFormRender` failing when run in isolation (`-run
+TestInventoryFormRender` alone) is a **pre-existing** test-isolation
+artifact, not a regression from this change — confirmed by running it
+both before and after this change, both times passing only as part of the
+full package suite (an earlier test in the same binary happens to
+initialize i18n as a side effect; run alone, template keys render as
+literal `key.name` text instead of the English string the assertion
+expects). Not fixed here — out of scope, and pre-dates this change.

--- a/internal/pages/catalog/handlers.go
+++ b/internal/pages/catalog/handlers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/universaltill/universal-till/internal/httpx"
 	productlookup "github.com/universaltill/universal-till/internal/lookup"
 	"github.com/universaltill/universal-till/internal/pages/common"
+	"github.com/universaltill/universal-till/internal/paths"
 	"github.com/universaltill/universal-till/internal/pos"
 )
 
@@ -507,7 +508,7 @@ func Register(mux *http.ServeMux, d *common.Deps) {
 			http.Error(w, "not a valid PNG/JPEG image", http.StatusBadRequest)
 			return
 		}
-		dir := filepath.Join("web", "public", "assets", "items", itemID)
+		dir := paths.Data("public", "assets", "items", itemID)
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -560,7 +561,7 @@ func Register(mux *http.ServeMux, d *common.Deps) {
 			http.Error(w, "not a valid PNG/JPEG image", http.StatusBadRequest)
 			return
 		}
-		dir := filepath.Join("web", "public", "assets", "items", itemID, "variants", variantID)
+		dir := paths.Data("public", "assets", "items", itemID, "variants", variantID)
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -645,7 +646,7 @@ func saveLookupImage(ctx context.Context, c *productlookup.Client, itemID, imgUR
 	if err != nil {
 		return err
 	}
-	dir := filepath.Join("web", "public", "assets", "items", itemID)
+	dir := paths.Data("public", "assets", "items", itemID)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}

--- a/internal/pages/inventory_api.go
+++ b/internal/pages/inventory_api.go
@@ -147,6 +147,19 @@ func writeHTML(w http.ResponseWriter, status int, html string) {
 	fmt.Fprint(w, html)
 }
 
+// writeHTMLStockChanged is writeHTML plus HX-Trigger: stock-updated — htmx
+// fires that as a DOM event on <body> once the response lands, and the
+// /inventory page's stock-levels table listens for it (hx-trigger="load,
+// stock-updated from:body") to refetch itself. Without this, a successful
+// receive/adjust/override/return updated the database correctly but the
+// on-screen quantity table just sat there showing the old number until a
+// full page reload — confirmed live 2026-07-29 as "inventory count is not
+// updating" (it was; nothing told the table to look again).
+func writeHTMLStockChanged(w http.ResponseWriter, status int, html string) {
+	w.Header().Set("HX-Trigger", "stock-updated")
+	writeHTML(w, status, html)
+}
+
 // respondError writes error response (JSON or HTML based on request)
 func respondError(w http.ResponseWriter, r *http.Request, status int, message string) {
 	if strings.Contains(r.Header.Get("Accept"), "application/json") {
@@ -161,7 +174,7 @@ func respondSuccess(w http.ResponseWriter, r *http.Request, data StockReceiptRes
 	if strings.Contains(r.Header.Get("Accept"), "application/json") {
 		writeJSON(w, http.StatusOK, data)
 	} else {
-		writeHTML(w, http.StatusOK, fmt.Sprintf("<div class='success'>Stock movement created: %s</div>", data.MovementID))
+		writeHTMLStockChanged(w, http.StatusOK, fmt.Sprintf("<div class='success'>Stock movement created: %s</div>", data.MovementID))
 	}
 }
 
@@ -305,7 +318,7 @@ func respondOverrideSuccess(w http.ResponseWriter, r *http.Request, data Overrid
 	if strings.Contains(r.Header.Get("Accept"), "application/json") {
 		writeJSON(w, http.StatusOK, data)
 	} else {
-		writeHTML(w, http.StatusOK, fmt.Sprintf("<div class='success'>Override recorded: %s</div>", data.OverrideID))
+		writeHTMLStockChanged(w, http.StatusOK, fmt.Sprintf("<div class='success'>Override recorded: %s</div>", data.OverrideID))
 	}
 }
 
@@ -492,7 +505,7 @@ func respondReturnSuccess(w http.ResponseWriter, r *http.Request, data ReturnRes
 	if strings.Contains(r.Header.Get("Accept"), "application/json") {
 		writeJSON(w, http.StatusOK, data)
 	} else {
-		writeHTML(w, http.StatusOK, fmt.Sprintf("<div class='success'>Return created: %s (Receipt: %s)</div>", data.ReturnSaleID, data.ReceiptNo))
+		writeHTMLStockChanged(w, http.StatusOK, fmt.Sprintf("<div class='success'>Return created: %s (Receipt: %s)</div>", data.ReturnSaleID, data.ReceiptNo))
 	}
 }
 

--- a/internal/pages/inventory_page.go
+++ b/internal/pages/inventory_page.go
@@ -1,6 +1,7 @@
 package pages
 
 import (
+	"context"
 	"encoding/json"
 	"html/template"
 	"math"
@@ -11,56 +12,67 @@ import (
 	"github.com/universaltill/universal-till/internal/pages/common"
 )
 
+// stockRow is one rendered row of the /inventory stock-levels table.
+type stockRow struct {
+	data.LowStockItem
+	Low      bool
+	DaysLeft int  // predicted days of stock left; -1 = no sell rate
+	RunsOut  bool // predicted stockout within the warning window
+	OrderQty int  // suggested order to reach coverDays of stock; 0 = none
+}
+
+// stockLevelsForDisplay computes the /inventory table's rows and the
+// running-out count — shared by the full page render and the
+// stock-updated-triggered partial refresh (registerInventoryPage's
+// /ui/inventory/stock-table), so both use identical logic.
+func stockLevelsForDisplay(ctx context.Context, d *common.Deps) ([]stockRow, int) {
+	posRepo := data.NewPOSRepo(d.Db)
+	rawLevels, _ := posRepo.ListStockLevels(ctx)
+	// Sell-rate prediction (28-day average): "this item runs out in ~N
+	// days at the current rate". Best-effort — no history, no column.
+	rates, _ := posRepo.ItemDailySellRates(ctx, 28)
+
+	const warnDays = 7
+	// coverDays is the stock target the suggestion refills to: two weeks
+	// of sales at the current rate (a sensible default until per-item
+	// lead times exist).
+	const coverDays = 14
+	runningOut := 0
+	levels := make([]stockRow, 0, len(rawLevels))
+	for _, l := range rawLevels {
+		row := stockRow{
+			LowStockItem: l,
+			Low:          l.ReorderLevel > 0 && l.CurrentQty < float64(l.ReorderLevel),
+			DaysLeft:     -1,
+		}
+		if rate := rates[l.ItemID]; rate > 0 && l.CurrentQty > 0 {
+			row.DaysLeft = int(l.CurrentQty / rate)
+			row.RunsOut = row.DaysLeft <= warnDays
+		} else if rate > 0 && l.CurrentQty <= 0 {
+			row.DaysLeft = 0
+			row.RunsOut = true
+		}
+		if rate := rates[l.ItemID]; row.RunsOut && rate > 0 {
+			if need := rate*coverDays - l.CurrentQty; need > 0 {
+				row.OrderQty = int(math.Ceil(need))
+			}
+		}
+		if row.RunsOut {
+			runningOut++
+		}
+		levels = append(levels, row)
+	}
+	return levels, runningOut
+}
+
 func registerInventoryPage(mux *http.ServeMux, d *common.Deps) {
 	mux.HandleFunc("/inventory", func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		posRepo := data.NewPOSRepo(d.Db)
 		catRepo := data.NewCatalogRepo(d.Db)
 
-		rawLevels, _ := posRepo.ListStockLevels(ctx)
-		locations, _ := posRepo.ListStockLocations(ctx)
+		levels, runningOut := stockLevelsForDisplay(ctx, d)
+		locations, _ := data.NewPOSRepo(d.Db).ListStockLocations(ctx)
 		items, _ := catRepo.ListItems(ctx)
-		// Sell-rate prediction (28-day average): "this item runs out in ~N
-		// days at the current rate". Best-effort — no history, no column.
-		rates, _ := posRepo.ItemDailySellRates(ctx, 28)
-
-		type stockRow struct {
-			data.LowStockItem
-			Low      bool
-			DaysLeft int  // predicted days of stock left; -1 = no sell rate
-			RunsOut  bool // predicted stockout within the warning window
-			OrderQty int  // suggested order to reach coverDays of stock; 0 = none
-		}
-		const warnDays = 7
-		// coverDays is the stock target the suggestion refills to: two weeks
-		// of sales at the current rate (a sensible default until per-item
-		// lead times exist).
-		const coverDays = 14
-		runningOut := 0
-		levels := make([]stockRow, 0, len(rawLevels))
-		for _, l := range rawLevels {
-			row := stockRow{
-				LowStockItem: l,
-				Low:          l.ReorderLevel > 0 && l.CurrentQty < float64(l.ReorderLevel),
-				DaysLeft:     -1,
-			}
-			if rate := rates[l.ItemID]; rate > 0 && l.CurrentQty > 0 {
-				row.DaysLeft = int(l.CurrentQty / rate)
-				row.RunsOut = row.DaysLeft <= warnDays
-			} else if rate > 0 && l.CurrentQty <= 0 {
-				row.DaysLeft = 0
-				row.RunsOut = true
-			}
-			if rate := rates[l.ItemID]; row.RunsOut && rate > 0 {
-				if need := rate*coverDays - l.CurrentQty; need > 0 {
-					row.OrderQty = int(math.Ceil(need))
-				}
-			}
-			if row.RunsOut {
-				runningOut++
-			}
-			levels = append(levels, row)
-		}
 
 		// Compact id/name/sku list for the item picker.
 		type pickerItem struct {
@@ -85,5 +97,17 @@ func registerInventoryPage(mux *http.ServeMux, d *common.Deps) {
 			"SyncPrimary": d.SyncPrimaryURL(r.Context()),
 		}
 		httpx.Render("ui/pages/inventory.html", data)(w, r)
+	})
+
+	// Stock-levels table, on its own so it can be refreshed in place after a
+	// receive/adjust/override/return (see writeHTMLStockChanged's
+	// HX-Trigger: stock-updated, which the table in inventory.html listens
+	// for) without a full page reload.
+	mux.HandleFunc("/ui/inventory/stock-table", func(w http.ResponseWriter, r *http.Request) {
+		levels, runningOut := stockLevelsForDisplay(r.Context(), d)
+		httpx.RenderPartial("ui/partials/stock_table.html", map[string]any{
+			"StockLevels": levels,
+			"RunningOut":  runningOut,
+		})(w, r)
 	})
 }

--- a/internal/pages/print_api.go
+++ b/internal/pages/print_api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/universaltill/universal-till/internal/data"
 	"github.com/universaltill/universal-till/internal/httpx"
 	"github.com/universaltill/universal-till/internal/pages/common"
+	"github.com/universaltill/universal-till/internal/paths"
 	"github.com/universaltill/universal-till/internal/print"
 )
 
@@ -62,10 +63,16 @@ const (
 	keyReceiptShowTax     = "receipt.show_tax"
 	keyReceiptShowBarcode = "receipt.show_barcode"
 	keyReceiptShowLogo    = "receipt.show_logo"
-
-	// receiptLogoPath is where the designer stores the uploaded logo.
-	receiptLogoPath = "web/public/assets/logo/receipt-logo.png"
 )
+
+// receiptLogoPath is where the designer stores the uploaded logo — the
+// stable per-user data directory, NOT the release tree: a self-update
+// replaces the release tree wholesale (see internal/pages/static_page.go's
+// fallbackFS doc comment), which silently deleted a shop's uploaded logo
+// when this was "web/public/assets/logo/receipt-logo.png". A function, not
+// a const: paths.DataDir() resolves at runtime (paths.Init runs during
+// config load, after this package's consts would already be evaluated).
+func receiptLogoPath() string { return paths.Data("public", "assets", "logo", "receipt-logo.png") }
 
 // receiptLogoRaster loads and encodes the uploaded logo when the design
 // wants it; nil (no logo) on any failure — never block a receipt.
@@ -73,7 +80,7 @@ func receiptLogoRaster(rd receiptDesign) []byte {
 	if !rd.ShowLogo {
 		return nil
 	}
-	raw, err := os.ReadFile(receiptLogoPath)
+	raw, err := os.ReadFile(receiptLogoPath())
 	if err != nil {
 		return nil
 	}

--- a/internal/pages/receipt_designer.go
+++ b/internal/pages/receipt_designer.go
@@ -78,7 +78,7 @@ func registerReceiptDesigner(mux *http.ServeMux, d *common.Deps) {
 		rd := receiptDesignFromSettings(r.Context(), d)
 		header := make([]string, 3)
 		copy(header, rd.Header)
-		logoStat, logoErr := os.Stat(receiptLogoPath)
+		logoStat, logoErr := os.Stat(receiptLogoPath())
 		logoV := int64(0)
 		if logoErr == nil {
 			logoV = logoStat.ModTime().Unix()
@@ -142,7 +142,7 @@ func registerReceiptDesigner(mux *http.ServeMux, d *common.Deps) {
 			return
 		}
 		if r.FormValue("remove") == "1" {
-			_ = os.Remove(receiptLogoPath)
+			_ = os.Remove(receiptLogoPath())
 			_ = posRepo.InsertAudit(r.Context(), nil, getSessionUserID(r), "settings", "receipt", "receipt_logo_removed",
 				nil, time.Now().UTC().Format(time.RFC3339), "")
 			fmt.Fprintf(w, `<span>✓ %s</span>`, httpx.T(locale, "designer.receipt.logo_removed"))
@@ -160,7 +160,7 @@ func registerReceiptDesigner(mux *http.ServeMux, d *common.Deps) {
 			fmt.Fprintf(w, `<span class="muted">✗ %s</span>`, httpx.T(locale, "designer.receipt.logo_invalid"))
 			return
 		}
-		if err := os.WriteFile(receiptLogoPath, raw, 0o644); err != nil {
+		if err := os.WriteFile(receiptLogoPath(), raw, 0o644); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/internal/pages/static_page.go
+++ b/internal/pages/static_page.go
@@ -6,18 +6,26 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
+	"github.com/universaltill/universal-till/internal/paths"
 	uiassets "github.com/universaltill/universal-till/web"
 )
 
-// fallbackFS serves from disk when present (a shop's uploaded item images,
-// receipt logo, or theme overrides — internal/pages/catalog/handlers.go and
-// friends still write to web/public/... on disk), falling back to the
-// binary's embedded default assets otherwise. This is what lets the app run
-// with zero loose files alongside it: a packaged install with no web/public
-// directory at all still serves CSS/JS/logos/themes correctly, while a shop
-// that HAS customized/uploaded assets still gets those instead of the
-// bundled defaults.
+// fallbackFS serves, in order: the stable per-user data directory (a shop's
+// uploaded item images, receipt logo, or theme overrides — see
+// internal/pages/catalog/handlers.go and internal/pages/print_api.go, which
+// write there, NOT to the release tree), then the release's own on-disk
+// web/public (bundled defaults + anything a plugin drops there at runtime),
+// then the binary's embedded defaults.
+//
+// The stable tier exists specifically because the release tree is NOT safe
+// for user data: a self-update replaces it wholesale (internal/selfupdate's
+// archive path renames the whole web/ dir aside; the macOS .app path
+// replaces the entire bundle, whose Contents/Resources/web IS the "disk"
+// tier). Writing uploads there means a routine update — the same one that
+// fixed this — silently deletes a shop's item photos and receipt logo.
+// Confirmed live 2026-07-29: an item's photo vanished after updating.
 //
 // disk.Open is attempted on every call, not gated by an existence check
 // cached at construction time: os.DirFS is lazy (it doesn't require the
@@ -27,11 +35,17 @@ import (
 // self-healing behavior of the old http.FileServer(http.Dir(...)) exactly,
 // just with a working fallback for the common case where it's missing.
 type fallbackFS struct {
-	disk  fs.FS
-	embed fs.FS
+	stable fs.FS
+	disk   fs.FS
+	embed  fs.FS
 }
 
 func (f fallbackFS) Open(name string) (fs.File, error) {
+	if f.stable != nil {
+		if file, err := f.stable.Open(name); err == nil {
+			return file, nil
+		}
+	}
 	if f.disk != nil {
 		if file, err := f.disk.Open(name); err == nil {
 			return file, nil
@@ -40,33 +54,30 @@ func (f fallbackFS) Open(name string) (fs.File, error) {
 	return f.embed.Open(name)
 }
 
-// ReadDir merges both sides by name (disk wins on conflict) rather than
-// preferring one side wholesale like Open does — otherwise an existing but
-// empty/partial on-disk directory (e.g. web/public/themes created by some
-// other action but not yet holding every built-in theme) would hide
-// embedded defaults from a directory listing even though Open(a specific
-// file) still correctly falls through to them.
+// ReadDir merges all three sides by name (stable wins, then disk, then
+// embed) rather than preferring one side wholesale like Open does —
+// otherwise an existing but empty/partial on-disk directory (e.g.
+// web/public/themes created by some other action but not yet holding every
+// built-in theme) would hide embedded defaults from a directory listing
+// even though Open(a specific file) still correctly falls through to them.
 func (f fallbackFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	byName := map[string]fs.DirEntry{}
 	var anyOK bool
-	if f.disk != nil {
-		if entries, err := fs.ReadDir(f.disk, name); err == nil {
+	for _, side := range []fs.FS{f.stable, f.disk, f.embed} {
+		if side == nil {
+			continue
+		}
+		if entries, err := fs.ReadDir(side, name); err == nil {
 			anyOK = true
 			for _, e := range entries {
-				byName[e.Name()] = e
-			}
-		}
-	}
-	if entries, err := fs.ReadDir(f.embed, name); err == nil {
-		anyOK = true
-		for _, e := range entries {
-			if _, exists := byName[e.Name()]; !exists {
-				byName[e.Name()] = e
+				if _, exists := byName[e.Name()]; !exists {
+					byName[e.Name()] = e
+				}
 			}
 		}
 	}
 	if !anyOK {
-		// Neither side has it — surface the embed side's error, the
+		// None of the sides have it — surface the embed side's error, the
 		// canonical "this doesn't exist" answer.
 		_, err := fs.ReadDir(f.embed, name)
 		return nil, err
@@ -79,10 +90,12 @@ func (f fallbackFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	return merged, nil
 }
 
-// newPublicFallbackFS builds the disk-then-embedded-default fs.FS backing
-// both the /public/ static file server and built-in theme resolution
-// (internal/pages/themes.go), rooted at embedRoot inside web.FS (e.g.
-// "public" or "public/themes") and the matching on-disk path.
+// newPublicFallbackFS builds the stable-data-then-disk-then-embedded-default
+// fs.FS backing both the /public/ static file server and built-in theme
+// resolution (internal/pages/themes.go). diskDir/embedRoot are the existing
+// release-tree/embedded roots (e.g. "web/public" + "public", or
+// "web/public/themes" + "public/themes"); the stable root mirrors embedRoot
+// under the resolved per-user data directory (paths.DataDir()).
 func newPublicFallbackFS(diskDir, embedRoot string) fs.FS {
 	embedded, err := fs.Sub(uiassets.FS, embedRoot)
 	if err != nil {
@@ -91,7 +104,8 @@ func newPublicFallbackFS(diskDir, embedRoot string) fs.FS {
 		// serving nothing if it ever isn't.
 		panic("web.FS has no " + embedRoot + " subtree: " + err.Error())
 	}
-	return fallbackFS{disk: os.DirFS(diskDir), embed: embedded}
+	stableDir := paths.Data(strings.Split(embedRoot, "/")...)
+	return fallbackFS{stable: os.DirFS(stableDir), disk: os.DirFS(diskDir), embed: embedded}
 }
 
 func registerStatic(mux *http.ServeMux) {

--- a/internal/pages/ui_smoke_test.go
+++ b/internal/pages/ui_smoke_test.go
@@ -415,6 +415,73 @@ func TestInventoryFormRender(t *testing.T) {
 	}
 }
 
+// TestInventoryReceiptTriggersStockTableRefresh covers a real bug: the
+// stock-levels table only ever rendered once, at page load — a successful
+// receive/adjust/override/return updated the database correctly (confirmed
+// live, quantity matched exactly) but nothing told the on-screen table to
+// look again, so it just sat there showing the old number. Confirmed live
+// 2026-07-29 as "inventory count is not updating." Fixed with an
+// HX-Trigger: stock-updated response header the table listens for
+// (hx-trigger="stock-updated from:body") to refetch itself from the new
+// /ui/inventory/stock-table endpoint.
+func TestInventoryReceiptTriggersStockTableRefresh(t *testing.T) {
+	chdirRoot(t)
+	db := openPagesTestDB(t)
+	defer db.Close()
+	seedForPages(t, db)
+
+	cfg := &config.Config{
+		Theme:   "default",
+		Locales: config.Locales{Currency: "GBP", TaxRate: 20},
+		Marketplace: config.MarketplaceConfig{
+			EndpointURL: "http://localhost:8081",
+		},
+	}
+	pm, err := plugins.Init(t.Context(), cfg, db)
+	if err != nil {
+		t.Fatalf("init plugins: %v", err)
+	}
+	state := common.LoadState(t.Context(), settings.NewStore(db), cfg)
+	dp := &common.Deps{
+		Cfg:      cfg,
+		Db:       db,
+		State:    state,
+		Menu:     []common.MenuItem{{Href: "/", Label: "Home"}},
+		Pm:       pm,
+		Settings: settings.NewStore(db),
+	}
+
+	mux := http.NewServeMux()
+	registerInventoryPage(mux, dp)
+	registerInventoryAPI(mux, dp)
+
+	formData := "type=receive&item_id=itm1&location_id=loc_main&quantity=10&reason=test"
+	req := httptest.NewRequest(http.MethodPost, "/api/inventory/receipt", strings.NewReader(formData))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /api/inventory/receipt failed: code %d body %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("HX-Trigger"); got != "stock-updated" {
+		t.Fatalf("expected HX-Trigger: stock-updated on a successful receipt, got %q", got)
+	}
+
+	// The endpoint the table's hx-trigger fetches must reflect the update
+	// (itm1 started at 50, +10 receive = 60) — same repo call the full page
+	// uses, so this also guards against the partial and the full page ever
+	// drifting to different data sources.
+	req = httptest.NewRequest(http.MethodGet, "/ui/inventory/stock-table", nil)
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /ui/inventory/stock-table failed: code %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), ">60<") {
+		t.Fatalf("expected updated quantity 60 in stock-table partial, got: %s", rec.Body.String())
+	}
+}
+
 func TestManagerOverrideForm(t *testing.T) {
 	chdirRoot(t)
 	db := openPagesTestDB(t)

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -57,6 +57,70 @@ func Plugins(parts ...string) string {
 func MigrateLegacyData(dbPath string) {
 	migrateLegacyDB(dbPath)
 	migrateLegacyPlugins()
+	migrateLegacyUploadedAssets()
+}
+
+// migrateLegacyUploadedAssets copies a shop's already-uploaded item/variant
+// photos and receipt logo out of the release tree (web/public/assets) into
+// the stable data directory, the FIRST time this runs after the fix that
+// made new uploads go to the stable location instead. Without this, a shop
+// that uploaded images under the old (broken) behavior would still lose
+// them on the very next update, having to re-upload everything right after
+// finally getting the fix — confirmed live 2026-07-29, this exact scenario.
+//
+// Deliberately narrow, not a blanket copy of web/public/assets: that tree
+// also holds BUILT-IN default assets (the stock logo/icons) which must
+// stay resolvable from the embedded/release tiers so a future release can
+// still update them — copying them into the stable tier would freeze them
+// at whatever version happened to exist during this one migration.
+func migrateLegacyUploadedAssets() {
+	legacyItems := filepath.Join("web", "public", "assets", "items")
+	targetItems := Data("public", "assets", "items")
+	if entries, err := os.ReadDir(legacyItems); err == nil {
+		for _, e := range entries {
+			dst := filepath.Join(targetItems, e.Name())
+			if _, err := os.Stat(dst); err == nil {
+				continue // already present in the stable location
+			}
+			src := filepath.Join(legacyItems, e.Name())
+			if e.IsDir() {
+				if err := os.MkdirAll(dst, 0o755); err != nil {
+					continue
+				}
+				if err := os.CopyFS(dst, os.DirFS(src)); err != nil {
+					_ = os.RemoveAll(dst) // don't leave a half-copied item's images
+				}
+			} else {
+				_ = os.MkdirAll(targetItems, 0o755)
+				copyFileBestEffort(src, dst)
+			}
+		}
+	}
+
+	legacyLogo := filepath.Join("web", "public", "assets", "logo", "receipt-logo.png")
+	targetLogo := Data("public", "assets", "logo", "receipt-logo.png")
+	if _, err := os.Stat(targetLogo); err != nil {
+		if _, err := os.Stat(legacyLogo); err == nil {
+			_ = os.MkdirAll(filepath.Dir(targetLogo), 0o755)
+			copyFileBestEffort(legacyLogo, targetLogo)
+		}
+	}
+}
+
+func copyFileBestEffort(src, dst string) {
+	in, err := os.Open(src)
+	if err != nil {
+		return
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		_ = os.Remove(dst) // don't leave a truncated file behind
+	}
 }
 
 // migrateLegacyDB copies an old cwd-relative database into the resolved data

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -93,3 +93,59 @@ func TestMigrateLegacyPlugins(t *testing.T) {
 		t.Fatalf("migration clobbered existing bundle: %q", b)
 	}
 }
+
+// TestMigrateLegacyUploadedAssets guards the fix for a real bug: item/
+// variant photos and the receipt logo used to be written into the release
+// tree (web/public/assets), which a self-update replaces wholesale — a
+// shop's uploads vanished on the very next update. This migrates anything
+// already sitting in the old location into the stable data dir, once, so
+// fixing the write path doesn't ALSO require every shop to re-upload
+// everything right after finally getting the fix.
+func TestMigrateLegacyUploadedAssets(t *testing.T) {
+	wd := t.TempDir()
+	old, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(old); Init("") })
+	_ = os.Chdir(wd)
+
+	mustWrite := func(path, content string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// An item photo, a variant photo nested under it, and the receipt logo —
+	// all in the legacy, cwd-relative release-tree location.
+	mustWrite(filepath.Join("web", "public", "assets", "items", "itm1", "thumb.png"), "item-photo")
+	mustWrite(filepath.Join("web", "public", "assets", "items", "itm1", "variants", "v1", "thumb.png"), "variant-photo")
+	mustWrite(filepath.Join("web", "public", "assets", "logo", "receipt-logo.png"), "logo-bytes")
+	// A BUILT-IN default asset that must NOT be swept into the stable dir —
+	// only items/ and the specific receipt-logo.png file are user content.
+	mustWrite(filepath.Join("web", "public", "assets", "logo", "ut-logo.ico"), "built-in-icon")
+
+	stable := filepath.Join(wd, "stable")
+	Init(stable)
+	MigrateLegacyData(filepath.Join(stable, "unitill-pos.db"))
+
+	if b, err := os.ReadFile(filepath.Join(stable, "public", "assets", "items", "itm1", "thumb.png")); err != nil || string(b) != "item-photo" {
+		t.Fatalf("item photo not migrated: err=%v content=%q", err, b)
+	}
+	if b, err := os.ReadFile(filepath.Join(stable, "public", "assets", "items", "itm1", "variants", "v1", "thumb.png")); err != nil || string(b) != "variant-photo" {
+		t.Fatalf("variant photo not migrated: err=%v content=%q", err, b)
+	}
+	if b, err := os.ReadFile(filepath.Join(stable, "public", "assets", "logo", "receipt-logo.png")); err != nil || string(b) != "logo-bytes" {
+		t.Fatalf("receipt logo not migrated: err=%v content=%q", err, b)
+	}
+	if _, err := os.Stat(filepath.Join(stable, "public", "assets", "logo", "ut-logo.ico")); err == nil {
+		t.Fatal("built-in default asset must NOT be migrated into the stable dir — it would shadow future releases' updates to it")
+	}
+
+	// Idempotent: an existing file in the stable dir is never overwritten.
+	mustWrite(filepath.Join(stable, "public", "assets", "items", "itm1", "thumb.png"), "current")
+	MigrateLegacyData(filepath.Join(stable, "unitill-pos.db"))
+	if b, _ := os.ReadFile(filepath.Join(stable, "public", "assets", "items", "itm1", "thumb.png")); string(b) != "current" {
+		t.Fatalf("migration clobbered an existing uploaded photo: %q", b)
+	}
+}

--- a/web/ui/pages/inventory.html
+++ b/web/ui/pages/inventory.html
@@ -11,7 +11,7 @@
 
 <div class="catalog-layout">
   <div class="catalog-list">
-    <div class="card">
+    <div class="card" id="stock-levels-card" hx-trigger="stock-updated from:body" hx-get="/ui/inventory/stock-table" hx-swap="innerHTML">
       <h2>{{ T "inventory.stock_levels" }}
         {{ if .RunningOut }}<span class="chip chip-warn">⚠ {{ .RunningOut }} {{ T "inventory.running_out" }}</span>{{ end }}</h2>
       <table class="table" id="stock-table">
@@ -40,7 +40,7 @@
 
     <div class="card" style="margin-top:1rem">
       <h2>{{ T "inventory.low_stock" }} <span id="low-stock-badge" class="tag" style="background:rgba(220,38,38,.12); color:var(--danger)">0</span></h2>
-      <div id="low-stock-list" hx-get="/api/inventory/low-stock" hx-trigger="load" hx-swap="innerHTML">
+      <div id="low-stock-list" hx-get="/api/inventory/low-stock" hx-trigger="load, stock-updated from:body" hx-swap="innerHTML">
         {{ T "common.loading" }}
       </div>
     </div>

--- a/web/ui/partials/stock_table.html
+++ b/web/ui/partials/stock_table.html
@@ -1,0 +1,24 @@
+<h2>{{ T "inventory.stock_levels" }}
+  {{ if .RunningOut }}<span class="chip chip-warn">⚠ {{ .RunningOut }} {{ T "inventory.running_out" }}</span>{{ end }}</h2>
+<table class="table" id="stock-table">
+  <thead><tr><th>{{ T "basket.col.item" }}</th><th>{{ T "catalog.col.sku" }}</th><th>{{ T "inventory.location" }}</th><th>{{ T "basket.col.qty" }}</th><th>{{ T "inventory.reorder_at" }}</th><th>{{ T "inventory.days_left" }}</th></tr></thead>
+  <tbody>
+    {{ if .StockLevels }}
+      {{ range .StockLevels }}
+        <tr class="stock-row" data-item="{{ .ItemID }}" data-name="{{ .Name }}" data-sku="{{ .SKU }}" data-location="{{ .LocationID }}">
+          <td class="catalog-name">{{ .Name }}</td>
+          <td class="muted">{{ .SKU }}</td>
+          <td>{{ .LocationName }}</td>
+          <td class="{{ if .Low }}stock-low{{ end }}">{{ .CurrentQty }}</td>
+          <td class="muted">{{ if .ReorderLevel }}{{ .ReorderLevel }}{{ else }}—{{ end }}</td>
+          <td>{{ if lt .DaysLeft 0 }}<span class="muted">—</span>
+              {{ else if .RunsOut }}<span class="days-left days-warn" title="{{ T "inventory.days_left_hint" }}">⚠ {{ .DaysLeft }}</span>
+              {{ if .OrderQty }}<span class="order-hint" title="{{ T "inventory.order_hint_title" }}">{{ T "inventory.order_hint" }} {{ .OrderQty }}</span>{{ end }}
+              {{ else }}<span class="days-left" title="{{ T "inventory.days_left_hint" }}">{{ .DaysLeft }}</span>{{ end }}</td>
+        </tr>
+      {{ end }}
+    {{ else }}
+      <tr><td colspan="6" class="empty">{{ T "inventory.empty" }}</td></tr>
+    {{ end }}
+  </tbody>
+</table>


### PR DESCRIPTION
Two real bugs found live, one of them genuine data loss.

## Bug 1 (serious): uploaded images live inside the app bundle/release tree
Item/variant photos and the receipt logo were written to \`web/public/assets/...\` — relative to cwd, which for the packaged macOS \`.app\` is *inside the versioned bundle itself*. Self-update (both the .app bundle-replace and the archive's \`web/\` swap) discards that whole tree on every update. Confirmed live: an uploaded photo was gone after installing the very release meant to fix an unrelated display bug for it — that's the "still no image upload, this was working previously" report.

**Fix**: all four write sites now use \`paths.Data(...)\` (the stable per-user directory already used for the DB/plugins). The static file server gets a new highest-priority tier serving from there. Added a one-time migration so shops that already uploaded under the old behavior don't lose everything right after getting the fix — deliberately narrow (items/ + receipt-logo.png only, not a blanket copy that would freeze built-in default assets out of future updates).

## Bug 2: stock-levels table never refreshed after a change
Verified the data itself was correct (10 + 15 receive movements = 25 in the real DB) — the \`/inventory\` page's table just never had an HTMX trigger to look again after a receive/adjust/override/return, unlike the low-stock list right next to it. Extracted the table into its own partial + endpoint, wired an \`HX-Trigger: stock-updated\` header the table (and the low-stock list) now listen for.

Also rechecked "no place to add a variant image" — the control already exists, just affected by Bug 1 the same way.

Full writeup: \`docs/code-reviews/2026-07-29-uploaded-assets-lost-on-update-and-stock-table-refresh.md\`.

## Verification
\`go build\`, \`go vet\`, \`go test ./...\`, both CI guards, \`gofmt -l\` all pass. New tests: \`TestMigrateLegacyUploadedAssets\`, \`TestInventoryReceiptTriggersStockTableRefresh\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)