### PR TITLE
fix: Linux desktop app silently fell back to browser (missing GTK/WebKit deps)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -126,9 +126,21 @@ nfpms:
     homepage: https://universaltill.com
     license: MIT
     bindir: /opt/unitill/bin
-    # The desktop shell links GTK3/WebKitGTK — present on any Linux desktop,
-    # deliberately NOT a hard dependency so headless/kiosk installs stay lean.
-    suggests:
+    # The desktop shell cgo-links directly against GTK3/WebKitGTK
+    # (webview_go's #cgo pkg-config: gtk+-3.0 webkit2gtk-4.0). `recommends`
+    # (not `suggests`, and not `depends`): plain `apt install` pulls these
+    # in by default so the double-click app actually works out of the box
+    # on any Linux desktop -- `suggests` is NEVER auto-installed by apt, so
+    # on a fresh install that didn't already have these libs, the dynamic
+    # linker refuses to even exec unitill-desktop at all (no window, no
+    # visible error to a user just double-clicking an icon) -- it never
+    # reaches Go code, so this isn't the same as webview.New returning nil
+    # (that's the separate no-display-available case, which DOES fall back
+    # to opening a browser -- see cmd/unitill-desktop/webview_fallback.go).
+    # Still skippable with `--no-install-recommends` for headless/kiosk-only
+    # Pi installs that don't want the desktop stack at all (see
+    # packaging/linux/unitill-kiosk-setup.sh, updated to use this flag).
+    recommends:
       - libwebkit2gtk-4.0-37
       - libgtk-3-0
     contents:

--- a/packaging/linux/unitill-kiosk-setup.sh
+++ b/packaging/linux/unitill-kiosk-setup.sh
@@ -5,7 +5,10 @@
 # power on → till service starts → the screen goes straight to the POS,
 # fullscreen. No desktop, no browser chrome, nothing else visible.
 #
-#   1. Install the till:   sudo apt install ./unitill-pos_*_arm64.deb
+#   1. Install the till:   sudo apt install --no-install-recommends ./unitill-pos_*_arm64.deb
+#                          (skips the desktop-app GTK/WebKit libs -- this
+#                          script installs cage+Chromium instead, so a
+#                          headless Lite box doesn't need both stacks)
 #   2. Run this once:      sudo bash unitill-kiosk-setup.sh
 #   3. Reboot:             sudo reboot
 #


### PR DESCRIPTION
## Summary

Farshid reported live on a real Raspberry Pi: "I dont like browser base app... just double-click and run." Investigated: the Linux/Windows desktop shell (`cmd/unitill-desktop`, `webview_go`) cgo-links directly against GTK3+WebKitGTK. `.goreleaser.yaml`'s `.deb` packaging listed these libs under `suggests`, which plain `apt install` never auto-installs. On a fresh install without them, the dynamic linker refuses to even exec `unitill-desktop` -- no window, no visible error -- so manually opening a browser to localhost:8080 was the only path anyone would find.

**Fix**: `suggests` -> `recommends` (installed by default, still skippable via `--no-install-recommends`). Updated `unitill-kiosk-setup.sh`'s own documented install command to use that flag, since headless Pi OS Lite kiosk installs don't need the desktop GTK/WebKit stack at all.

Companion fix in `ut-website` corrects the download page's own instructions, which had inverted macOS's app-window vs. browser-launcher framing (caught by independent review).

## Test plan
- [x] `goreleaser check` -- config validates
- [x] Independently reviewed (different model): confirmed the nfpm field/package names are correct, confirmed the causal reasoning (missing libs crash the dynamic linker before Go code runs, not the same as `webview.New()` returning nil), caught and fixed an inverted-instructions bug in the companion website copy
- [ ] Not yet verified end-to-end on a real fresh Pi install (needs a new release build to test against) -- Farshid has SSH access to a live device now, worth confirming after the next release

🤖 Generated as part of Universal Till's autonomous SDLC pipeline (`unitill/.claude/skills/`)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>