### PR TITLE
fix: kiosk setup never actually launched (lightdm grabbed the console first)

### DIFF
--- a/packaging/linux/unitill-kiosk-setup.sh
+++ b/packaging/linux/unitill-kiosk-setup.sh
@@ -32,6 +32,19 @@ for grp in video render input seat; do
   getent group "$grp" >/dev/null && usermod -aG "$grp" "$KIOSK_USER" || true
 done
 
+# Raspberry Pi OS "with Desktop" images (unlike Lite, which this script's
+# header assumes) ship a display manager (lightdm by default) enabled on
+# graphical.target -- the same target this script points at. Left running,
+# it grabs the console/seat first and cage silently never gets a display
+# (confirmed live, 2026-07-29: cage process ran with zero children, no
+# error logged anywhere -- lightdm had already won the seat). `display-manager`
+# is the systemd alias every DM (lightdm/gdm3/sddm) registers itself under,
+# so this doesn't need to special-case which one is installed.
+if systemctl is-enabled display-manager.service >/dev/null 2>&1 || systemctl is-active display-manager.service >/dev/null 2>&1; then
+  echo "==> Disabling the desktop display manager (conflicts with the kiosk console)…"
+  systemctl disable --now display-manager.service
+fi
+
 echo "==> Installing the kiosk launcher…"
 install -D -m 0755 "$(dirname "$0")/unitill-kiosk-launch.sh" /opt/unitill/bin/unitill-kiosk-launch
 


### PR DESCRIPTION
## Summary

Live-tested on a real Raspberry Pi tonight (Debian 13 trixie, Pi OS "with Desktop", not Lite): `unitill-kiosk-setup.sh` installed cleanly but `cage` never actually launched Chromium -- `pstree` showed zero children, nothing logged anywhere. Root-caused live: `lightdm.service` was also enabled on `graphical.target` and had already grabbed the console/seat before cage could get it. The script's header assumed Pi OS Lite (no desktop = no competing display manager); this Pi has the full Desktop image.

**Fix**: disable `display-manager.service` (the DM-agnostic systemd alias) before installing the kiosk launcher.

## Test plan
- [x] Applied the equivalent fix live on the actual device, rebooted it, confirmed via `pstree` that `cage` now has a real `chromium` process tree with `--kiosk --ozone-platform=wayland http://127.0.0.1:8080`, GPU-accelerated over Wayland
- [x] `curl localhost:8080/healthz` returns 200 from inside the kiosk session
- [x] Independently reviewed (different model): confirmed `set -e` safety on Pi OS Lite (no display-manager.service to begin with), confirmed the alias resolves correctly across lightdm/gdm3/sddm, confirmed idempotency on re-run

🤖 Generated as part of Universal Till's autonomous SDLC pipeline (`unitill/.claude/skills/`)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>