### PR TITLE
fix: ui_scale ceiling too low + basket rows could vanish at high scale

### DIFF
--- a/docs/code-reviews/2026-07-29-ui-scale-high-density-touchscreen.md
+++ b/docs/code-reviews/2026-07-29-ui-scale-high-density-touchscreen.md
@@ -1,0 +1,101 @@
+# 2026-07-29 — UI scale ceiling + basket flex-collapse on high-density touchscreens
+
+## What shipped
+
+Farshid reported live, testing the till on a real Pi with a 10.1"
+1920×1200 touchscreen (~224 PPI):
+
+1. **"the scale on 150% it still small to read"** — the settings page's
+   `ui_scale` dropdown maxed out at 150%, but the backend
+   (`internal/pages/settings_page.go`) already validates and accepts
+   0.5–2.0. At 150% on this panel, computed text cap-height was still
+   only ~1.9mm — under any reasonable legibility floor. Fixed: added
+   `175%`/`200%` options to `settings.html` (no backend change needed —
+   the range was already there, just never exposed).
+
+2. **"it even can't show an item in the basket"** — a separate, more
+   serious bug found while investigating #1: at high `ui_scale` on a
+   ~1200px-tall viewport, a scanned item was correctly added to the sale
+   (the total updated) but its row was **completely invisible** — not
+   clipped, genuinely zero rendered height (confirmed via Playwright
+   `boundingBox()`). Root cause: `.pos-container`'s grid column width
+   (`330px`/`420px`) and `.line-item`'s `max-width: 158px` were raw
+   pixels, never scaling with the rem-based root font-size `ui_scale`
+   drives — so container width stayed fixed while content inside grew.
+   Combined with `.basket-scroll { min-height: 0 }` inside a flex column
+   whose siblings (toggle row + pinned totals) also grew, the item
+   list's flex-basis got squeezed to true zero once those siblings
+   outgrew the grid row's allotted height. Fixed: `330px`/`420px` →
+   `20.625rem`/`26.25rem`, `158px` → `9.875rem`, `.basket-scroll` given a
+   `min-height: 6rem` floor, and `.pos-container > .basket`'s
+   `overflow: hidden` → `overflow-y: auto` so if the floor still can't
+   fit, the panel becomes genuinely scrollable rather than silently
+   hiding sale contents.
+
+Real root cause for #1 was independently confirmed against hard evidence,
+not assumption: `wlr-randr` identified the live panel as a Waveshare
+10.1" 1920×1200 (confirmed via Waveshare's own product page), giving
+~224 PPI — about 2.3× a typical 96 PPI assumption.
+
+Also corrected `ut-docs/hardware/diy-pos.md`'s existing scale guidance,
+which recommends this exact panel style and gave backwards advice
+("smaller panel → lower scale") — the real determinant is pixel density,
+not physical size, and a small high-resolution panel needs *more* scale,
+not less.
+
+## Independent review (different model, opus)
+
+**Verdict: PASS**, no blocking findings. Everything re-verified from
+scratch:
+
+- Full `go build`/`go vet`/`go test` clean; all three CI guards pass
+  (data-access, i18n, webkit-version).
+- Playwright `default`+`auth` projects (19 specs) run twice, both green,
+  no flakiness.
+- **Independently re-verified both TDD claims** by reverting each fix in
+  isolation and re-running: reverting `app.css` → the new Playwright spec
+  fails on the exact `.basket-scroll` zero-height assertion; reverting
+  `settings.html` → the new Go test fails; both restored and passing
+  again, diffs confirmed byte-identical to the working versions after.
+- Confirmed the 200% option's value (`2`) is within the backend's
+  already-inclusive `f > 2.0` rejection bound (2.0 itself is accepted).
+- Confirmed neither new test is tautological (both proven red against
+  `main` before green).
+- Confirmed no scale=1 regression: `overflow-y: auto` only shows a
+  scrollbar on genuine overflow, no double-scrollbar nesting at normal
+  scale.
+- Confirmed no `os.MkdirAll`/cwd-path bug class applies (no Go
+  file-writing code in this diff) and no secrets/real client names.
+
+Two non-blocking nitpicks: the `.receipt-view` variant rule now
+redundantly repeats `overflow-y: auto` (harmless, `display: block` still
+does the meaningful override); three unrelated pre-existing untracked
+files in the working tree must not be swept into this commit (they
+weren't).
+
+## Verified beyond automated tests
+
+- Real screenshots at 100%/150%/200% scale on both the actual live Pi
+  (via `grim` over the real Wayland kiosk session) and a headless
+  Playwright run at the identical 1920×1200 viewport — the exact same
+  clipping/collapse bug reproduced in a plain browser, confirming it's a
+  general CSS bug, not a Pi/kiosk-specific rendering quirk.
+- Visually confirmed the fix: full basket row (name, barcode, qty, price,
+  total, remove button) readable and untruncated at 150%; at 200%, the
+  row renders correctly and the panel becomes scrollable to reach the
+  totals, rather than losing the row entirely.
+
+## Explicitly deferred / accepted gaps
+
+- Auto-detecting physical screen density to pick a smarter default scale
+  — real potential improvement, no reliable browser-side signal for
+  physical panel size without extra setup-wizard input; not attempted
+  here, logged as a possible follow-up if it recurs.
+- Backend's scale ceiling stays at 2.0 (not raised) — computed to be
+  sufficient for the reported panel (~112 effective PPI at 2.0, close to
+  a normal comfortable range); no evidence yet of a denser panel needing
+  more.
+
+## Safe to merge
+
+Yes. Feature branch `fix/ui-scale-high-density-touchscreen`.

--- a/e2e/tests/ui-scale-basket.spec.ts
+++ b/e2e/tests/ui-scale-basket.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+import { watchConsole } from './helpers';
+
+// Farshid's field report, 2026-07-29: on a real high-density small
+// touchscreen (10.1" 1920x1200, ~224 PPI), even the then-max 150% scale
+// still rendered text too small to read, and separately -- a distinct,
+// worse bug -- a scanned item was added to the sale (the total updated)
+// but its row was completely invisible in the basket, not merely clipped:
+// the basket-scroll flex child's computed height collapsed to literal 0
+// once the toggle row + pinned totals outgrew the grid row's allotted
+// space at high scale. Guards both: the settings page must offer scale
+// options up to the backend's already-validated 2.0 ceiling, and the
+// basket item list must never fully disappear at that ceiling.
+test.use({ viewport: { width: 1920, height: 1200 } });
+
+test('basket stays visible at the maximum ui_scale on a short viewport', async ({ page }) => {
+  const assertClean = watchConsole(page);
+  await page.goto('/settings');
+  const scaleSelect = page.locator('form[hx-post="/api/settings/ui-scale"] select');
+  await expect(scaleSelect.locator('option[value="2"]')).toHaveCount(1);
+  await scaleSelect.selectOption('2');
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/settings/ui-scale')),
+    scaleSelect.locator('..').locator('button[type=submit]').click(),
+  ]);
+  await page.waitForEvent('load');
+
+  await page.goto('/');
+  await page.getByRole('textbox').first().fill('5000000000011');
+  // #basket is a full hx-swap="outerHTML" -- wait for that exact response
+  // before inspecting layout, or a race between the swap and boundingBox()
+  // can read a stale/mid-swap node.
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/pos/scan')),
+    page.locator('.scan-row button[type=submit]').click(),
+  ]);
+  await expect(page.locator('.basket table tbody tr')).toHaveCount(1);
+
+  // Not just "present in the DOM" -- genuinely rendered with non-zero size,
+  // which is exactly what the flex-collapse bug violated.
+  const row = page.locator('.basket table tbody tr').first();
+  await expect(row).toBeVisible();
+  await expect.poll(async () => (await row.boundingBox())?.height ?? 0).toBeGreaterThan(0);
+  await expect.poll(async () => (await page.locator('.basket-scroll').boundingBox())?.height ?? 0).toBeGreaterThan(0);
+
+  // Restore default so later specs sharing this server aren't affected.
+  await page.goto('/settings');
+  const scaleSelect2 = page.locator('form[hx-post="/api/settings/ui-scale"] select');
+  await scaleSelect2.selectOption('1');
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/settings/ui-scale')),
+    scaleSelect2.locator('..').locator('button[type=submit]').click(),
+  ]);
+  await page.waitForEvent('load');
+  assertClean();
+});

--- a/internal/pages/settings_page_test.go
+++ b/internal/pages/settings_page_test.go
@@ -183,6 +183,31 @@ func TestDisplayAndStoreSettings(t *testing.T) {
 
 // The claim-code / register-now / fleet enrol endpoints all refuse a non-manager
 // operator before ever touching the marketplace (offline-first, no network in
+// A high-density small touchscreen (e.g. a 10.1" 1920x1200 panel, ~224 PPI)
+// needs more than the old 150% ceiling to render legibly -- the backend
+// already validates up to 2.0 (see the bounds check above), but the
+// settings page itself never offered an option past 150%, so a shop on
+// that hardware had no way to reach a usable scale through the UI at all.
+func TestSettingsPageOffersHighDensityScaleOption(t *testing.T) {
+	mux, _, _ := newFullAuthDeps(t)
+	req := httptest.NewRequest(http.MethodGet, "/settings", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /settings = %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `value="2"`) {
+		t.Fatalf("settings page offers no 200%% scale option for high-density small panels:\n%s", body)
+	}
+	// The value the backend actually applies for a "200%" pick must itself
+	// be within the already-validated 0.5..2.0 range -- posting it should
+	// succeed, not 400.
+	if rec := postForm(mux, "/api/settings/ui-scale", url.Values{"scale": {"2"}}, nil); rec.Code != http.StatusNoContent {
+		t.Fatalf("scale=2 (the new option's value) = %d, want 204", rec.Code)
+	}
+}
+
 // the forbidden path). Each answers 200 (HTMX swap target) with an error/muted
 // notice rather than a hard status.
 func TestEnrolEndpointsRefuseNonManager(t *testing.T) {

--- a/web/public/app.css
+++ b/web/public/app.css
@@ -271,7 +271,7 @@ body.osk-padded { padding-block-end: 15.5rem; }
    by overriding grid-template-areas/-columns. */
 .pos-container {
   display: grid;
-  grid-template-columns: minmax(330px, 420px) 1fr;
+  grid-template-columns: minmax(20.625rem, 26.25rem) 1fr;
   grid-template-rows: minmax(0, 1fr) minmax(0, 1.15fr);
   grid-template-areas:
     "basket products"
@@ -303,14 +303,22 @@ body.osk-padded { padding-block-end: 15.5rem; }
   overflow-y: auto;
 }
 
-/* Basket: lines scroll, totals pinned at the bottom of the panel. */
-.pos-container > .basket { display: flex; flex-direction: column; overflow: hidden; }
+/* Basket: lines scroll, totals pinned at the bottom of the panel. At a high
+   ui_scale on a short viewport, the toggle row + pinned totals can outgrow
+   the grid row's allotted height entirely, squeezing basket-scroll's flex
+   basis to 0 -- invisible, not just clipped (confirmed live 2026-07-29: a
+   scanned item existed in the DOM and the total updated, but the row
+   itself had zero rendered height, nothing to scroll to). overflow-y: auto
+   here is the fallback once basket-scroll's own min-height (below) can't
+   be satisfied -- the panel becomes genuinely scrollable instead of
+   silently hiding sale contents. */
+.pos-container > .basket { display: flex; flex-direction: column; overflow-y: auto; }
 /* Tender: the panel itself never scrolls — only the active tab body does. */
 .pos-container > .tender { overflow: hidden; }
 /* After a sale the receipt swaps into the basket slot; it keeps the grid area
    and scrolls internally instead of bleeding over other panels. */
 .pos-container > .basket.receipt-view { display: block; overflow-y: auto; }
-.basket-scroll { flex: 1; min-height: 0; overflow-y: auto; }
+.basket-scroll { flex: 1; min-height: 6rem; overflow-y: auto; }
 .basket .totals { flex-shrink: 0; }
 
 @media (max-width: 900px) {
@@ -383,7 +391,7 @@ a.btn, a.btn:hover { text-decoration: none; }
                vertical-align: middle; }
 
 /* ---------- Basket ---------- */
-.line-item { max-width: 158px; display: flex; align-items: center; gap: .4rem; }
+.line-item { max-width: 9.875rem; display: flex; align-items: center; gap: .4rem; }
 .line-thumb {
   flex: 0 0 auto; width: 2rem; height: 2rem; object-fit: cover;
   border-radius: 6px; border: 1px solid var(--border);

--- a/web/ui/pages/settings.html
+++ b/web/ui/pages/settings.html
@@ -71,6 +71,8 @@
       <option value="1.15" {{ if eq $scale "1.15" }}selected{{ end }}>115%</option>
       <option value="1.3"  {{ if eq $scale "1.3" }}selected{{ end }}>130% — {{ T "settings.display.large" }}</option>
       <option value="1.5"  {{ if eq $scale "1.5" }}selected{{ end }}>150%</option>
+      <option value="1.75" {{ if eq $scale "1.75" }}selected{{ end }}>175%</option>
+      <option value="2"    {{ if eq $scale "2" }}selected{{ end }}>200%</option>
     </select>
     <button class="btn" type="submit">{{ T "settings.display.apply" }}</button>
   </form>


### PR DESCRIPTION
## Summary
- Settings page's `ui_scale` dropdown maxed at 150%, still unreadable on a real 10.1" 1920x1200 (~224 PPI) touchscreen — backend already validated up to 2.0, just never exposed. Added 175%/200% options.
- Separate, worse bug found while investigating: at high scale, a scanned basket row could render with **genuinely zero height** (not clipped — item was in the DOM and the total updated, but nothing was visible). Root cause: raw-px container widths never scaling with the rem-based `ui_scale` root font-size. Fixed with rem equivalents + a min-height floor + a scrollable fallback.
- Corrected backwards touchscreen-scale guidance in `ut-docs/hardware/diy-pos.md` (recommends this exact panel style).

## Test plan
- [x] Both regressions proven red (Go test + Playwright) against `main`, green after the fix
- [x] `go build`/`go vet`/`go test` clean; all 3 CI guards pass
- [x] Playwright `default`+`auth` (19 specs) run twice, clean, no flakiness
- [x] Reproduced identically in headless Playwright at the real device's exact viewport (1920x1200) — confirms general CSS bug, not kiosk-specific
- [x] Independent review (different model, opus): PASS — see `docs/code-reviews/2026-07-29-ui-scale-high-density-touchscreen.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yS4U3wicRKdqvKVvKQHpt