### PR TITLE
fix: kiosk Chromium could get stuck behind an undismissable keyring prompt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         run: bash scripts/ci/guard-i18n.sh
       - name: Linux desktop webkit2gtk version guard
         run: bash scripts/ci/guard-webkit-version.sh
+      - name: Kiosk launch flags guard
+        run: bash scripts/ci/guard-kiosk-launch-flags.sh
       - name: Build
         env:
           GOMODCACHE: ${{ runner.temp }}/gomodcache

--- a/docs/code-reviews/2026-07-29-kiosk-keyring-prompt.md
+++ b/docs/code-reviews/2026-07-29-kiosk-keyring-prompt.md
@@ -1,0 +1,45 @@
+# 2026-07-29 — Kiosk Chromium stuck behind an undismissable keyring prompt
+
+## What shipped
+
+Confirmed live while deploying an unrelated fix to Farshid's Pi: restarting
+the kiosk (`cage` + Chromium `--kiosk`) session made Chromium's first
+touch of its password manager pop a native "Authentication required —
+keyring is locked" GTK dialog over the one surface `cage` renders. With no
+keyboard/mouse on a bare touchscreen till, there is no way to dismiss a
+GTK dialog like this — the till would be stuck showing only the prompt,
+never reaching the POS UI, on any restart or reboot that triggers it.
+
+Fixed with `--password-store=basic` in
+`packaging/linux/unitill-kiosk-launch.sh` — this kiosk is a single-purpose
+browser pointed at one hardcoded local URL, not a general browsing
+profile; POS auth is server-side (sessions/PINs), so the OS keyring
+wasn't protecting anything meaningful here. New CI guard
+(`scripts/ci/guard-kiosk-launch-flags.sh`) fails if this flag ever
+regresses out of the launch script.
+
+## Independent review (different model, opus)
+
+**PASS.** Re-ran the guard both ways personally: reverted the launch
+script to `main`'s version, confirmed the guard fails with the exact
+expected message, restored the fix, confirmed green again. Confirmed
+`go build` and the three pre-existing unrelated guards (data-access,
+i18n, webkit-version) are unaffected. Confirmed `--password-store=basic`
+is a real, standard Chromium flag (not a hallucination), consistent with
+common kiosk/embedded Chromium deployment practice. Flagged (and this
+session then confirmed) that a plain `git checkout --` cannot restore
+*uncommitted* working-tree changes — a process note for this pipeline,
+not a defect in the change itself. Confirmed no security downgrade of
+substance (device access already implies physical access; nothing
+credential-worthy lived in this profile) and no secrets/client names in
+the diff.
+
+## Verified beyond automated tests
+
+Live on the actual device: applied the flag, restarted the kiosk
+service, took a real screenshot — the dialog did not reappear, the POS
+screen rendered normally, footer showed the hotfix build version.
+
+## Safe to merge
+
+Yes. Feature branch `fix/kiosk-chromium-keyring-prompt`.

--- a/packaging/linux/unitill-kiosk-launch.sh
+++ b/packaging/linux/unitill-kiosk-launch.sh
@@ -10,9 +10,13 @@ for _ in $(seq 1 60); do
 done
 
 BROWSER="$(command -v chromium-browser || command -v chromium)"
+# --password-store=basic: without it, Chromium's first touch of its password
+# manager pops a blocking "keyring is locked" GTK dialog over the kiosk with
+# no way to dismiss it from the touchscreen (confirmed live, 2026-07-29).
 exec "$BROWSER" \
   --kiosk --noerrdialogs --disable-infobars --no-first-run \
   --disable-session-crashed-bubble --disable-features=TranslateUI \
   --check-for-update-interval=31536000 \
+  --password-store=basic \
   --ozone-platform=wayland \
   "$URL"

--- a/scripts/ci/guard-kiosk-launch-flags.sh
+++ b/scripts/ci/guard-kiosk-launch-flags.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# The kiosk launch script must never regress on flags that avoid blocking,
+# undismissable GTK dialogs on a touchscreen-only kiosk with no keyboard/mouse
+# to interact with them. --password-store=basic avoids a real, confirmed-live
+# "keyring is locked" prompt on Chromium's first password-manager touch
+# (2026-07-29) -- there is no way to dismiss it from a bare touchscreen.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT_DIR}/packaging/linux/unitill-kiosk-launch.sh"
+
+if ! grep -q -- '--password-store=basic' "$SCRIPT"; then
+  echo "❌ kiosk-launch guard: ${SCRIPT} is missing --password-store=basic" >&2
+  echo "   (without it, Chromium can block the kiosk behind an undismissable keyring prompt)" >&2
+  exit 1
+fi
+
+echo "✓ kiosk-launch guard: --password-store=basic present"


### PR DESCRIPTION
## Summary
- Confirmed live: restarting the kiosk session could make Chromium pop a native "keyring is locked" GTK dialog over the kiosk's one rendered surface — with no keyboard/mouse on a bare touchscreen till, there's no way to dismiss it.
- Fixed with `--password-store=basic` (this kiosk is a single-purpose browser with no general profile — nothing credential-worthy for the OS keyring to protect anyway).
- New CI guard prevents this flag from regressing.

## Test plan
- [x] Guard proven red against the unfixed script, green after
- [x] `go build` + all 4 CI guards pass
- [x] Independent review (opus): PASS
- [x] Verified live on the actual device — dialog no longer appears after applying the fix + kiosk restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yS4U3wicRKdqvKVvKQHpt