### PR TITLE
fix: menu icons invisible on Pi — no color-emoji font on base Raspberry Pi OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
         run: bash scripts/ci/guard-webkit-version.sh
       - name: Kiosk launch flags guard
         run: bash scripts/ci/guard-kiosk-launch-flags.sh
+      - name: Emoji font guard
+        run: bash scripts/ci/guard-emoji-font.sh
       - name: Build
         env:
           GOMODCACHE: ${{ runner.temp }}/gomodcache

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -146,9 +146,19 @@ nfpms:
     # Still skippable with `--no-install-recommends` for headless/kiosk-only
     # Pi installs that don't want the desktop stack at all (see
     # packaging/linux/unitill-kiosk-setup.sh, updated to use this flag).
+    # fonts-noto-color-emoji: the POS UI's icons (menu tiles, status
+    # glyphs, plugin buttons) are plain Unicode emoji text, and a base
+    # Raspberry Pi OS image ships NO color-emoji font at all -- confirmed
+    # on a real field device (2026-07-29): every menu icon rendered as a
+    # blank/tofu box until the font was installed. Arch: all; same package
+    # name on every currently-built target (bookworm, jammy, trixie).
+    # NOTE: the kiosk flow documents `--no-install-recommends`, so
+    # packaging/linux/unitill-kiosk-setup.sh ALSO installs this explicitly
+    # (both spots CI-guarded by scripts/ci/guard-emoji-font.sh).
     recommends:
       - libwebkit2gtk-4.1-0
       - libgtk-3-0
+      - fonts-noto-color-emoji
     contents:
       - src: web
         dst: /opt/unitill/web

--- a/deploy/raspberry-pi/install.sh
+++ b/deploy/raspberry-pi/install.sh
@@ -34,6 +34,19 @@ systemctl daemon-reload
 systemctl enable --now unitill-pos.service
 systemctl enable unitill-kiosk.service
 
+echo "==> Installing emoji font (menu icons, plugin/status glyphs)"
+# Base Raspberry Pi OS images ship no color-emoji font, so the app's
+# emoji-glyph icons (e.g. the /menu page) render as blank boxes without
+# this -- confirmed on a real field device, 2026-07-29. Deliberately
+# best-effort and AFTER the core install: this script never needed the
+# network before (offline re-runs must keep working), so a mirror/network
+# failure here must not abort an otherwise-complete POS install.
+if ! (apt-get update -qq && apt-get install -y fonts-noto-color-emoji); then
+  echo "WARN: could not install fonts-noto-color-emoji (offline?); menu icons" >&2
+  echo "      may render as blank boxes until it is installed manually:" >&2
+  echo "      sudo apt-get install fonts-noto-color-emoji" >&2
+fi
+
 echo ""
 echo "Done. The POS starts on boot; the kiosk browser starts with the desktop"
 echo "session. Reboot to see the full flow, or: systemctl start unitill-kiosk"

--- a/docs/code-reviews/2026-07-29-menu-icons-emoji-font.md
+++ b/docs/code-reviews/2026-07-29-menu-icons-emoji-font.md
@@ -1,0 +1,118 @@
+# Code review — menu icons invisible on Raspberry Pi (missing color-emoji font)
+
+- **Date**: 2026-07-29
+- **Branch**: `fix/menu-icons-emoji-font-fallback`
+- **Field report**: Farshid, 2026-07-29 — "icons on the menu page are not
+  appearing" on his live Pi till (`Pi4-1`, kiosk mode).
+- **Reviewer**: independent different-model subagent (opus); pipeline
+  (fable) implemented, triaged, and re-verified.
+
+## Root cause (verified on the real device, not assumed)
+
+The POS UI renders icons — the `/menu` launcher tiles, status glyphs,
+plugin buttons — as **plain Unicode emoji text** (see `iconFor` in
+`internal/pages/menu_page.go`), not image/SVG assets. A base Raspberry Pi
+OS image ships **no color-emoji font at all**, and the app's CSS
+font-family stack had no emoji-capable fallback entry either. Result:
+most glyphs rendered as nothing/blank.
+
+Evidence:
+
+- `/var/log/apt/history.log` on the live Pi shows `fonts-noto-color-emoji`
+  was first installed 2026-07-29 22:43 (by the interrupted first half of
+  this session, as the live hotfix) — before that the device had zero
+  emoji fonts (`fc-list | grep -i emoji` empty).
+- **Counterfactual reproduced on the device**: a headless Chromium render
+  of the exact 14 `iconFor` glyphs with Noto Color Emoji masked via a
+  fontconfig `rejectfont` rule shows **9 of the 14 glyphs render as
+  literally nothing** (🧾 🎨 📦 📒 📊 🧩 🏷️ 👤 🖥️), matching the field
+  report precisely; only the few glyphs with legacy text-presentation
+  coverage in other system fonts (🕒 ⚙️ ❓ 🌐 ▪️) survive as monochrome
+  outlines. Same render with the font present: all 14 visible.
+
+## The fix (5 files)
+
+1. `web/public/app.css` — body font stack gains
+   `"Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", "Segoe UI
+   Symbol"` after `sans-serif`. Effective because font fallback is
+   per-grapheme (`sans-serif` does not terminate the search), and
+   deliberately placed *last* so color-emoji fonts never hijack ASCII
+   digits/`#`/`©` (reviewer confirmed this ordering is the idiomatic
+   pattern, e.g. Bootstrap/GitHub). Buttons/inputs inherit via the
+   existing `font: inherit` rules — verified.
+2. `deploy/raspberry-pi/install.sh` — installs `fonts-noto-color-emoji`,
+   **best-effort and after the core install** (see review finding 3).
+3. `.goreleaser.yaml` — `.deb` `recommends` gains the font package (the
+   actual install path of the field device; arch:all, same package name
+   on bookworm/jammy/trixie).
+4. `packaging/linux/unitill-kiosk-setup.sh` — installs it explicitly,
+   because the kiosk flow's own documented install command is
+   `apt install --no-install-recommends ./unitill-pos_*.deb`, which
+   bypasses `recommends` entirely — i.e. the exact field-reported
+   configuration would have stayed broken with only fix (3).
+5. `scripts/ci/guard-emoji-font.sh` (new, wired into `ci.yml`) — four
+   checks (CSS fallback + all three Linux install paths), each proven
+   red against its reverted half before green.
+
+The interrupted first half of this session had shipped (1), (2), and a
+first version of (5); this cycle's BA pass found that it missed the two
+install paths the real device actually uses — (3) and (4) — and extended
+the guard to cover them.
+
+## Independent review findings (opus, different model)
+
+Verdict: **PASS-with-nitpicks**. All four guard halves independently
+re-verified red/green by the reviewer (reverted each, confirmed the
+specific failure message, restored). Findings, all fixed before commit:
+
+1. **(non-blocking, demonstrated live) Guard false-pass on the
+   `.goreleaser.yaml` check** — the recommends block's explanatory
+   comment also contains the package name, and the reviewer deleted the
+   real `- fonts-noto-color-emoji` entry, kept the comment, and the guard
+   still passed. Fixed: anchored to the YAML list-item form
+   (`^\s*-\s*fonts-noto-color-emoji\s*$`), mutation-tested.
+2. **(nitpick) Same substring-match weakness in the other checks** —
+   fixed by anchoring the apt checks to a real (uncommented, unquoted)
+   `apt-get install` line. While hardening this, the pipeline found a
+   *second* false-pass the reviewer's regex suggestion wouldn't have
+   caught: the install script's own failure-hint echo (`sudo apt-get
+   install fonts-noto-color-emoji`) satisfied a comment-only exclusion.
+   The final regex also excludes quoted contexts; all three script
+   checks now mutation-tested (commented-out line, disabled line,
+   deleted entry — guard fails on each).
+3. **(non-blocking) `install.sh` regression risk** — the first version
+   ran `apt-get update && apt-get install` *first* under
+   `set -euo pipefail`, so a mirror/network failure would abort the whole
+   POS install, which previously needed no network at all (offline
+   re-runs are a real use of this script). Fixed: font install moved
+   after the core install and made non-fatal with a clear WARN + manual
+   remedy hint.
+
+Reviewer explicitly cleared: CSS fallback ordering/semantics, nfpms
+`recommends` validity, `--no-install-recommends` interplay, apt
+idempotency, i18n precedent for root-run script echo lines, no real
+shop names, no secrets.
+
+## Verified beyond automated tests
+
+- **Live device, red/green at the runtime layer**: headless Chromium on
+  the actual field Pi rendering the exact menu glyph set — font masked →
+  9/14 glyphs invisible (the reported bug); font present → all 14 render.
+- Live kiosk screenshot (grim) shows the running till with nav emoji
+  (👤, ☰-adjacent glyphs) rendering, v0.2.49 session intact.
+- The live device itself is already fixed (font installed 22:43 during
+  the interrupted session); this change makes every future install —
+  all three Linux paths — get the font without manual intervention.
+- Full gate: `go build`, `go vet`, full `go test ./...`, all five CI
+  guard scripts, `goreleaser check`, and the full Playwright e2e suite
+  (19/19) — all green.
+
+## Explicitly deferred / out of scope
+
+- Replacing emoji-glyph icons with bundled SVG assets (would make icon
+  rendering fully deterministic across platforms, but is a design change
+  touching ~25 templates — not warranted by this bug once the font is
+  guaranteed present on every install path).
+- Windows/macOS need nothing (ship system emoji fonts).
+
+**Safe to merge**: yes.

--- a/packaging/linux/unitill-kiosk-setup.sh
+++ b/packaging/linux/unitill-kiosk-setup.sh
@@ -27,6 +27,15 @@ apt-get install -y --no-install-recommends cage seatd curl
 apt-get install -y --no-install-recommends chromium-browser 2>/dev/null ||
   apt-get install -y --no-install-recommends chromium
 
+echo "==> Installing emoji font (menu icons, plugin/status glyphs)…"
+# The till UI's icons are plain Unicode emoji text, and a base Raspberry Pi
+# OS image ships no color-emoji font at all -- without this every menu icon
+# renders as a blank box (confirmed on a real field device, 2026-07-29).
+# Installed explicitly here because this flow's documented install command
+# (`apt install --no-install-recommends ./unitill-pos_*.deb`, see header)
+# deliberately bypasses the .deb's `recommends` list, which also carries it.
+apt-get install -y --no-install-recommends fonts-noto-color-emoji
+
 echo "==> Kiosk user permissions (video/input)…"
 for grp in video render input seat; do
   getent group "$grp" >/dev/null && usermod -aG "$grp" "$KIOSK_USER" || true

--- a/scripts/ci/guard-emoji-font.sh
+++ b/scripts/ci/guard-emoji-font.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# The POS UI renders icons (menu tiles, status glyphs, plugin buttons) as
+# plain Unicode emoji text across ~25 templates, not image/SVG assets. A
+# field report (2026-07-29) found menu icons invisible on a real Raspberry
+# Pi kiosk: the base Pi OS image ships no color-emoji font, and the app's
+# CSS font stack had no emoji-capable fallback, so the glyphs rendered as
+# blank/tofu boxes. Guards against silently regressing any of the four
+# halves of the fix: the CSS fallback (helps any platform that already has
+# one of these fonts, e.g. Windows/most desktop Linux) and a color-emoji
+# font package deterministically installed by EVERY Linux install path --
+# the curl-pipe Pi install script, the .deb's own dependency list, and the
+# kiosk setup script. The kiosk one matters most: its documented install
+# flow is `apt install --no-install-recommends ./unitill-pos_*.deb`
+# (see packaging/linux/unitill-kiosk-setup.sh header), which deliberately
+# bypasses the .deb's `recommends` -- so the font must ALSO be installed
+# explicitly there, or the exact field-reported configuration (Pi kiosk)
+# stays broken while every other path is fixed.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+CSS="web/public/app.css"
+INSTALL_SH="deploy/raspberry-pi/install.sh"
+GORELEASER=".goreleaser.yaml"
+KIOSK_SETUP="packaging/linux/unitill-kiosk-setup.sh"
+
+if ! grep -qE 'Noto Color Emoji|Segoe UI Emoji|Apple Color Emoji' "${CSS}"; then
+  echo "❌ emoji-font guard: ${CSS} has no emoji-capable font fallback" >&2
+  echo "   (menu/status icons are plain emoji glyphs -- without a fallback font name" >&2
+  echo "   in the font-family stack, they render as blank boxes on platforms with no" >&2
+  echo "   system color-emoji font, e.g. a base Raspberry Pi OS image)" >&2
+  exit 1
+fi
+
+# Anchored to a real apt install line: not commented out (#) and not inside
+# a quoted string (the script's own failure-hint echo says "sudo apt-get
+# install fonts-noto-color-emoji", which a looser match would count). A bare
+# substring match false-passing on a mere mention is exactly what the
+# independent review demonstrated against the goreleaser check.
+if ! grep -qE '^[^#"'"'"']*apt-get install[^#"'"'"']*fonts-noto-color-emoji' "${INSTALL_SH}"; then
+  echo "❌ emoji-font guard: ${INSTALL_SH} no longer installs fonts-noto-color-emoji" >&2
+  echo "   (the real field-reported device needs this installed explicitly --" >&2
+  echo "   a base Raspberry Pi OS image doesn't ship a color-emoji font by default)" >&2
+  exit 1
+fi
+
+# Anchored to the actual YAML list-item form: the recommends block also has
+# an explanatory comment containing the package name, and a bare substring
+# grep passed with the real entry deleted (found by the independent review).
+if ! grep -qE '^[[:space:]]*-[[:space:]]*fonts-noto-color-emoji[[:space:]]*$' "${GORELEASER}"; then
+  echo "❌ emoji-font guard: ${GORELEASER} no longer lists fonts-noto-color-emoji in the .deb's recommends" >&2
+  echo "   (a plain \`apt install ./unitill-pos_*.deb\` on a base Raspberry Pi OS image would" >&2
+  echo "   leave the system with no color-emoji font -- menu/status icons render as blank boxes)" >&2
+  exit 1
+fi
+
+if ! grep -qE '^[^#"'"'"']*apt-get install[^#"'"'"']*fonts-noto-color-emoji' "${KIOSK_SETUP}"; then
+  echo "❌ emoji-font guard: ${KIOSK_SETUP} no longer installs fonts-noto-color-emoji" >&2
+  echo "   (the kiosk flow's documented install command uses --no-install-recommends, which" >&2
+  echo "   bypasses the .deb's recommends list entirely -- the kiosk setup script must install" >&2
+  echo "   the font explicitly, or the exact field-reported Pi-kiosk configuration stays broken)" >&2
+  exit 1
+fi
+
+echo "✓ emoji-font guard: CSS fallback present; all three Linux install paths provide fonts-noto-color-emoji"

--- a/web/public/app.css
+++ b/web/public/app.css
@@ -27,7 +27,8 @@
 html { font-size: 16px; }
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", "Segoe UI Symbol";
   background: var(--bg);
   color: var(--text);
   line-height: 1.45;


### PR DESCRIPTION
## Field report
Farshid, 2026-07-29: "icons on the menu page are not appearing" (live Pi till, kiosk mode).

## Root cause (verified on the real device)
The UI's icons are plain Unicode emoji text (`iconFor` in `internal/pages/menu_page.go`), and a base Raspberry Pi OS image ships **no color-emoji font at all**. Counterfactually reproduced on the actual field Pi: with Noto Color Emoji masked via fontconfig, 9 of the 14 menu glyphs render as literally nothing.

## Fix — every Linux install path
- `web/public/app.css`: emoji fallback fonts appended to the body stack (per-grapheme fallback; placed after `sans-serif` so color-emoji fonts never hijack ASCII digits/symbols)
- `.goreleaser.yaml`: `fonts-noto-color-emoji` in the `.deb` `recommends` (the field device's actual install path)
- `packaging/linux/unitill-kiosk-setup.sh`: explicit install — the kiosk flow's documented command uses `--no-install-recommends`, bypassing recommends
- `deploy/raspberry-pi/install.sh`: best-effort install after the core steps (offline re-runs must keep working)
- `scripts/ci/guard-emoji-font.sh` + ci.yml wiring: 4 checks, each proven red, then hardened + mutation-tested after the independent review demonstrated a comment-only false-pass

## Verification
- Live Pi red/green headless render of the exact glyph set (font masked vs present)
- Full gate: build, vet, full `go test`, all 5 guards, `goreleaser check`, Playwright e2e 19/19
- Independent different-model review (opus): PASS-with-nitpicks, all findings fixed — `docs/code-reviews/2026-07-29-menu-icons-emoji-font.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkpbKKWW8MMDFKtJCP1Xtj