### PR TITLE
test: cover the four internal/pages stragglers; fix legacy manifest synthesis

### DIFF
--- a/docs/code-reviews/2026-07-30-coverage-pages-stragglers.md
+++ b/docs/code-reviews/2026-07-30-coverage-pages-stragglers.md
@@ -1,0 +1,99 @@
+# Code review — internal/pages coverage batch: the four stragglers (2026-07-30)
+
+**Branch:** `test/pages-stragglers-batch`
+**Scope:** the QUEUE.md "Test-coverage push, remainder" item's first batch —
+the four named `internal/pages` stragglers left at the end of PR #82.
+**Reviewer:** independent different-model subagent (opus), adversarial brief,
+told to run everything itself. Pipeline model: fable.
+
+## What shipped
+
+Four new test files driving real HTTP requests through the real mux:
+
+| File | Covers | Function coverage |
+|---|---|---|
+| `buttons_api_test.go` | `/ui/buttons`, `/api/buttons/add\|remove\|search`, reorder edges | `registerButtonsAPI` 24.2% → **87.1%** |
+| `journal_page_test.go` | `/journal`, `/journal/{receipt}` (found/return-links/404/500), `/ui/journal` limit=5 vs full | `registerJournal` 34.3% → **94.3%** |
+| `plugin_api_legacy_test.go` | the six legacy inline handlers: upload, catalog proxy, marketplace/install, permissions grant/revoke, trust | `registerPluginAPI` 22.9% → **80.2%** |
+| `plugins_store_api_test.go` | store lifecycle API: 400s, installer-unconfigured 500s, download-fail 502, delete-download, full staged-signed-bundle install success | `registerPluginStoreAPI` 29.2% → **93.8%** |
+
+Package: `internal/pages` **71.2% → 75.7%**.
+
+Plus ONE production fix, found TDD-first (failing test before fix):
+
+- **`plugin_api.go` — synthesized-manifest JSON injection/breakage + temp-file
+  race (severity: medium).** Both legacy install endpoints built the plugin
+  manifest via `fmt.Sprintf` into a JSON string literal: any legitimate
+  name/version containing `"` produced invalid JSON (install 500), and a
+  crafted catalog value could inject arbitrary manifest fields. The
+  marketplace/install path additionally wrote to a FIXED `plugin.json` path in
+  the shared `os.TempDir()` — concurrent installs raced on it. Fixed with a
+  shared `writeSynthesizedManifest` helper: `json.Marshal` + `os.CreateTemp`.
+  Red first: `parse manifest json: invalid character 'Q' after object
+  key:value pair` (upload) / `invalid character 'x' ...` (install), green
+  after. (The race itself isn't deterministically testable; the unique-file
+  fix rides along with the injection fix and was reviewed as correct.)
+
+## Independent review (different model): SAFE TO MERGE, no blocking findings
+
+The reviewer ran build/vet/tests/guards itself (all green, plus `-race` on the
+new tests — clean), and:
+
+- **Re-proved the TDD claim from scratch**: stashed only `plugin_api.go`,
+  confirmed both regression tests fail against the old code with the exact
+  JSON parse errors, restored, confirmed green.
+- **Mutation-checked 3 fresh tests** (different from the tester's own 3):
+  broke the buttons image normalization, the journal 404 branch, and the
+  store install status save — each named test failed; no false-passes found
+  among 6 total probed mutations (tester's: reorder comma-split, journal
+  limit=full, Sprintf revert on both endpoints).
+- **Checked the two recurring bug classes explicitly**: neither applies — the
+  synthesized manifest is a transient same-request temp file (deleted at both
+  call sites), so `paths.Data()`/`MkdirAll` would be wrong here, not missing.
+- **Checked the "blessing danger" question**: the fix does not add capability
+  to the legacy ghost-install endpoints (DB row only, artifact deleted,
+  nothing extracted or executed, manager-gated, same synthesized
+  `runtime:"go"` as before) — pre-existing behavior pinned, remove-vs-finish
+  logged as backlog.
+- 2 NITPICKs, both accepted as established package precedent with verified
+  isolation: legacy endpoints use the real `os.TempDir()` during tests (all
+  paths `defer os.Remove`d, serial tests, unique names); `chdirRoot(t)` never
+  restores cwd (pre-existing pattern; the `isolatePluginsDir` tests don't
+  depend on cwd).
+
+## Verified beyond automated tests
+
+- Full gate: `go build`, `go vet`, full `go test ./...` (whole repo, not just
+  the package), all 5 CI guards, Playwright e2e **19/19** against a really
+  running till.
+- The store-install success test exercises the REAL verification path: a
+  fresh Ed25519 keypair, a genuinely signed asset-only bundle staged exactly
+  where `DownloadToStore` puts one, installed through
+  `/api/plugins/store/install` — asserting the DB row, manager visibility
+  after reload, the `active` install-status record, and consumption of the
+  staged bundle.
+- No leftover test servers/processes (checked ports 8080/8081/4173).
+
+## Honestly-untestable remainder (documented, not faked — no coverage theater)
+
+- `writeSynthesizedManifest` 50%: the uncovered half is `os.CreateTemp`/
+  `Write`/`Close` failure branches on the system temp dir — faking requires
+  invasive FS mocking disproportionate to risk.
+- `registerPluginAPI` remaining ~20%: same class — local IO error branches
+  (`os.Create`, `io.Copy`, checksum-read failures on just-written temp
+  files) plus `ParseForm` errors.
+- Store download success over the real network protocol is covered at the
+  installer layer (`internal/plugins/installer_marketplace_test.go`); the
+  pages handler's parse/gate/error-mapping and the staged-bundle install ARE
+  covered here.
+
+## Follow-ups logged to ut-docs/QUEUE.md (not this batch's scope)
+
+- Legacy `plugin_api.go` endpoints are half-implemented ghost-installs
+  (manifest row persisted, artifact deleted, nothing extracted, no Ed25519
+  verify) and unreferenced by any UI template — decide remove vs finish.
+
+## Verdict
+
+Merged after review. Next coverage batches (same queue item): `internal/server`,
+`selfupdate`, `updates`, `plugins/storage`, `ui`.

--- a/internal/pages/buttons_api_test.go
+++ b/internal/pages/buttons_api_test.go
@@ -1,0 +1,198 @@
+package pages
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/pages/common"
+	"github.com/universaltill/universal-till/internal/ui"
+)
+
+// newButtonsMux wires registerButtonsAPI over a DB seeded with the pages
+// fixture plus the shortcut_buttons table (created by migrations in prod;
+// the shared fixture doesn't include it).
+func newButtonsMux(t *testing.T) (*http.ServeMux, *common.Deps) {
+	t.Helper()
+	chdirRoot(t)
+	initPagesI18n(t)
+	db := openPagesTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	seedForPages(t, db)
+	if _, err := db.Exec(`CREATE TABLE shortcut_buttons (barcode TEXT PRIMARY KEY, label TEXT, item_id TEXT, image_path TEXT, sort_order INTEGER NOT NULL DEFAULT 0)`); err != nil {
+		t.Fatalf("create shortcut_buttons: %v", err)
+	}
+	// LoadButtons/SearchItemsForShortcuts join item_images for tile thumbnails.
+	if _, err := db.Exec(`CREATE TABLE item_images (id TEXT PRIMARY KEY, item_id TEXT NOT NULL, path TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'thumbnail')`); err != nil {
+		t.Fatalf("create item_images: %v", err)
+	}
+	d := &common.Deps{Db: db, BtnStore: ui.NewButtonStore(db)}
+	mux := http.NewServeMux()
+	registerButtonsAPI(mux, d)
+	return mux, d
+}
+
+func TestButtonsUIFragmentRendersSeededButtons(t *testing.T) {
+	mux, d := newButtonsMux(t)
+	if _, err := d.Db.Exec(`INSERT INTO shortcut_buttons(barcode,label,item_id) VALUES ('ABC','Apple Tile','itm1')`); err != nil {
+		t.Fatalf("seed button: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ui/buttons", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/ui/buttons = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Apple Tile") {
+		t.Fatalf("buttons fragment missing seeded label: %s", rec.Body.String())
+	}
+}
+
+func TestButtonsAddValidatesPersistsAndNormalizesImage(t *testing.T) {
+	mux, d := newButtonsMux(t)
+
+	// Missing required fields -> 400 from the store's validation.
+	if rec := postForm(mux, "/api/buttons/add", url.Values{"label": {"No Code"}}, nil); rec.Code != http.StatusBadRequest {
+		t.Fatalf("add without code/itemId = %d, want 400", rec.Code)
+	}
+
+	// A bare image filename is normalized into /public/images/.
+	rec := postForm(mux, "/api/buttons/add", url.Values{
+		"label":    {"Apple"},
+		"code":     {"ABC"},
+		"itemId":   {"itm1"},
+		"imageUrl": {"apple.png"},
+	}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("add = %d (%s)", rec.Code, rec.Body.String())
+	}
+	var image string
+	if err := d.Db.QueryRow(`SELECT image_path FROM shortcut_buttons WHERE barcode='ABC'`).Scan(&image); err != nil {
+		t.Fatalf("added button missing: %v", err)
+	}
+	if image != "/public/images/apple.png" {
+		t.Fatalf("image_path = %q, want /public/images/apple.png", image)
+	}
+	// The response is the re-rendered admin grid containing the new tile.
+	if !strings.Contains(rec.Body.String(), "Apple") {
+		t.Fatalf("admin grid response missing added button: %s", rec.Body.String())
+	}
+
+	// An absolute URL is stored untouched.
+	rec = postForm(mux, "/api/buttons/add", url.Values{
+		"label":    {"Pear"},
+		"code":     {"DEF"},
+		"itemId":   {"itm1"},
+		"imageUrl": {"https://cdn.example.com/pear.png"},
+	}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("add absolute-url = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if err := d.Db.QueryRow(`SELECT image_path FROM shortcut_buttons WHERE barcode='DEF'`).Scan(&image); err != nil {
+		t.Fatalf("added button missing: %v", err)
+	}
+	if image != "https://cdn.example.com/pear.png" {
+		t.Fatalf("image_path = %q, want the absolute URL untouched", image)
+	}
+}
+
+func TestButtonsRemoveDeletesRow(t *testing.T) {
+	mux, d := newButtonsMux(t)
+	if _, err := d.Db.Exec(`INSERT INTO shortcut_buttons(barcode,label,item_id) VALUES ('ABC','Apple','itm1')`); err != nil {
+		t.Fatalf("seed button: %v", err)
+	}
+
+	rec := postForm(mux, "/api/buttons/remove", url.Values{"code": {"ABC"}}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("remove = %d (%s)", rec.Code, rec.Body.String())
+	}
+	var n int
+	if err := d.Db.QueryRow(`SELECT COUNT(*) FROM shortcut_buttons WHERE barcode='ABC'`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("button still present after remove")
+	}
+}
+
+func TestButtonsSearchShortQueryHintAndResults(t *testing.T) {
+	mux, _ := newButtonsMux(t)
+
+	// Under 3 characters: a hint, not a query.
+	rec := postForm(mux, "/api/buttons/search", url.Values{"q": {"Ap"}}, nil)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "Type 3+ characters") {
+		t.Fatalf("short query: code=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	// A real query finds the seeded item (name "Apple", barcode ABC) via
+	// either the q or the legacy search field name.
+	for _, field := range []string{"q", "search"} {
+		rec = postForm(mux, "/api/buttons/search", url.Values{field: {"Appl"}}, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("search via %s = %d (%s)", field, rec.Code, rec.Body.String())
+		}
+		if !strings.Contains(rec.Body.String(), "Apple") {
+			t.Fatalf("search via %s missing seeded item: %s", field, rec.Body.String())
+		}
+	}
+
+	// A large offset pages past the single result.
+	rec = postForm(mux, "/api/buttons/search?offset=50", url.Values{"q": {"Appl"}}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("offset search = %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "Apple") {
+		t.Fatalf("offset=50 should page past the only result: %s", rec.Body.String())
+	}
+
+	// A non-numeric offset is ignored, not an error.
+	rec = postForm(mux, "/api/buttons/search?offset=bogus", url.Values{"q": {"Appl"}}, nil)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "Apple") {
+		t.Fatalf("bogus offset: code=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestButtonsReorderEdgeCases(t *testing.T) {
+	mux, d := newButtonsMux(t)
+	if _, err := d.Db.Exec(`INSERT INTO shortcut_buttons(barcode,label) VALUES ('b1','A'),('b2','B'),('b3','C')`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// No codes at all -> 400.
+	if rec := postForm(mux, "/api/buttons/reorder", url.Values{}, nil); rec.Code != http.StatusBadRequest {
+		t.Fatalf("empty reorder = %d, want 400", rec.Code)
+	}
+
+	// A single comma-joined field is split and applied (urlencoded path).
+	rec := postForm(mux, "/api/buttons/reorder", url.Values{"codes": {"b2, b3, b1"}}, nil)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("comma-joined reorder = %d (%s)", rec.Code, rec.Body.String())
+	}
+	var first string
+	if err := d.Db.QueryRow(`SELECT barcode FROM shortcut_buttons ORDER BY sort_order LIMIT 1`).Scan(&first); err != nil {
+		t.Fatalf("read order: %v", err)
+	}
+	if first != "b2" {
+		t.Fatalf("first after reorder = %q, want b2 (comma-joined codes must split + trim)", first)
+	}
+}
+
+func TestButtonsStoreErrorsSurfaceAs500(t *testing.T) {
+	mux, d := newButtonsMux(t)
+	// Break the storage underneath the handlers.
+	if _, err := d.Db.Exec(`DROP TABLE shortcut_buttons`); err != nil {
+		t.Fatalf("drop: %v", err)
+	}
+	if _, err := d.Db.Exec(`DROP TABLE items`); err != nil {
+		t.Fatalf("drop items: %v", err)
+	}
+
+	if rec := postForm(mux, "/api/buttons/reorder", url.Values{"codes": {"b1"}}, nil); rec.Code != http.StatusInternalServerError {
+		t.Fatalf("reorder with broken store = %d, want 500", rec.Code)
+	}
+	if rec := postForm(mux, "/api/buttons/search", url.Values{"q": {"Appl"}}, nil); rec.Code != http.StatusInternalServerError {
+		t.Fatalf("search with broken store = %d, want 500", rec.Code)
+	}
+}

--- a/internal/pages/journal_page_test.go
+++ b/internal/pages/journal_page_test.go
@@ -1,0 +1,186 @@
+package pages
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/auth"
+	"github.com/universaltill/universal-till/internal/config"
+	"github.com/universaltill/universal-till/internal/pages/common"
+	"github.com/universaltill/universal-till/internal/settings"
+)
+
+// newJournalMux wires registerJournal over the seeded pages fixture.
+func newJournalMux(t *testing.T) (*http.ServeMux, *common.Deps) {
+	t.Helper()
+	chdirRoot(t)
+	initPagesI18n(t)
+	db := openPagesTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	seedForPages(t, db)
+
+	cfg := &config.Config{Theme: "default", Locales: config.Locales{Currency: "GBP", TaxRate: 20}}
+	setStore := settings.NewStore(db)
+	d := &common.Deps{
+		Cfg:      cfg,
+		Db:       db,
+		State:    common.LoadState(t.Context(), setStore, cfg),
+		Menu:     []common.MenuItem{{Href: "/", Label: "Home"}},
+		Settings: setStore,
+	}
+	mux := http.NewServeMux()
+	registerJournal(mux, d)
+	return mux, d
+}
+
+// seedJournalPageSale inserts a completed sale with one line and one payment.
+func seedJournalPageSale(t *testing.T, d *common.Deps, id, receipt, saleType string) {
+	t.Helper()
+	if _, err := d.Db.Exec(`INSERT INTO sales(id, receipt_no, status, sale_type, tender_type, offline, sync_status, currency, subtotal, discount_total, tax_total, total, created_at)
+		VALUES (?, ?, 'completed', ?, 'cash', 1, 'queued', 'GBP', 250, 0, 50, 300, datetime('now'))`, id, receipt, saleType); err != nil {
+		t.Fatalf("seed sale: %v", err)
+	}
+	if _, err := d.Db.Exec(`INSERT INTO sale_lines(id, sale_id, line_no, item_id, name_snapshot, quantity, unit_price, tax_rate_bp, tax_amount, total_before_tax, total_after_tax)
+		VALUES (?, ?, 1, 'itm1', 'Journal Apple', 1, 250, 2000, 50, 250, 300)`, id+"-l1", id); err != nil {
+		t.Fatalf("seed sale line: %v", err)
+	}
+	if _, err := d.Db.Exec(`INSERT INTO payments(id, sale_id, method_id, amount, currency, paid_at)
+		VALUES (?, ?, 'cash', 300, 'GBP', datetime('now'))`, id+"-p1", id); err != nil {
+		t.Fatalf("seed payment: %v", err)
+	}
+}
+
+func TestJournalPageRendersAndGatesInvoiceLink(t *testing.T) {
+	mux, d := newJournalMux(t)
+
+	// Seller identity unset: no invoice list link, regardless of role.
+	rec := httptest.NewRecorder()
+	req := auth.WithUser(httptest.NewRequest(http.MethodGet, "/journal", nil), auth.User{ID: "m1", Role: "manager"})
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/journal = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), `href="/invoices"`) {
+		t.Fatalf("invoice link shown with no seller configured")
+	}
+
+	// Seller configured + manager session: the invoices link appears.
+	if err := d.Settings.Set(t.Context(), "invoice.seller_name", "Task Runner Ltd"); err != nil {
+		t.Fatalf("set seller: %v", err)
+	}
+	rec = httptest.NewRecorder()
+	req = auth.WithUser(httptest.NewRequest(http.MethodGet, "/journal", nil), auth.User{ID: "m1", Role: "manager"})
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `href="/invoices"`) {
+		t.Fatalf("manager with seller configured should see invoices link (code=%d)", rec.Code)
+	}
+
+	// Cashier session (auth on, not a manager): link hidden even with seller set.
+	rec = httptest.NewRecorder()
+	req = auth.WithUser(httptest.NewRequest(http.MethodGet, "/journal", nil), auth.User{ID: "c1", Role: "cashier"})
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/journal cashier = %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), `href="/invoices"`) {
+		t.Fatalf("cashier should not see the invoices link")
+	}
+}
+
+func TestJournalDetailRendersSaleReturnsAndOriginal(t *testing.T) {
+	mux, d := newJournalMux(t)
+	seedJournalPageSale(t, d, "sale-1", "R-100", "sale")
+	seedJournalPageSale(t, d, "sale-2", "R-101", "return")
+	// sale-2 is a return of sale-1.
+	if _, err := d.Db.Exec(`INSERT INTO sale_links(id, sale_id, original_sale_id, reason) VALUES ('lnk-1','sale-2','sale-1','refund')`); err != nil {
+		t.Fatalf("seed sale link: %v", err)
+	}
+
+	// Original sale: shows its line, payment, and the return cross-link.
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/journal/R-100", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/journal/R-100 = %d (%s)", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"R-100", "Journal Apple", "R-101"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("detail missing %q: %s", want, body)
+		}
+	}
+
+	// The return: points back at its original receipt.
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/journal/R-101", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/journal/R-101 = %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "R-100") {
+		t.Fatalf("return detail missing original receipt link: %s", rec.Body.String())
+	}
+
+	// Unknown receipt -> 404.
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/journal/NOPE", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("/journal/NOPE = %d, want 404", rec.Code)
+	}
+}
+
+func TestJournalFragmentLimitsAndFullView(t *testing.T) {
+	mux, d := newJournalMux(t)
+	for i := 1; i <= 7; i++ {
+		id := fmt.Sprintf("sale-%d", i)
+		receipt := fmt.Sprintf("R-%03d", i)
+		if _, err := d.Db.Exec(`INSERT INTO sales(id, receipt_no, status, sale_type, tender_type, offline, sync_status, currency, subtotal, discount_total, tax_total, total, created_at)
+			VALUES (?, ?, 'completed', 'sale', 'cash', 0, 'synced', 'GBP', 100, 0, 20, 120, datetime('now', ?))`, id, receipt, fmt.Sprintf("-%d minutes", i)); err != nil {
+			t.Fatalf("seed sale %d: %v", i, err)
+		}
+	}
+
+	// Default view: the 5 most recent only.
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ui/journal", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/ui/journal = %d (%s)", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "R-001") || !strings.Contains(body, "R-005") {
+		t.Fatalf("default journal missing recent receipts: %s", body)
+	}
+	if strings.Contains(body, "R-006") || strings.Contains(body, "R-007") {
+		t.Fatalf("default journal should cap at 5 entries: %s", body)
+	}
+
+	// Full view: all seven.
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ui/journal?limit=full", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/ui/journal?limit=full = %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "R-007") {
+		t.Fatalf("full journal missing oldest receipt: %s", rec.Body.String())
+	}
+}
+
+func TestJournalDBErrorsSurfaceAs500(t *testing.T) {
+	mux, d := newJournalMux(t)
+	if _, err := d.Db.Exec(`DROP TABLE sales`); err != nil {
+		t.Fatalf("drop sales: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/journal/R-100", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("detail with broken db = %d, want 500", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ui/journal", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("fragment with broken db = %d, want 500", rec.Code)
+	}
+}

--- a/internal/pages/plugin_api.go
+++ b/internal/pages/plugin_api.go
@@ -144,16 +144,8 @@ func registerPluginAPI(mux *http.ServeMux, d *common.Deps) {
 
 		// Create minimal manifest for installation
 		// In production, this would be extracted from the tarball
-		manifestPath := filepath.Join(tmpDir, fmt.Sprintf("plugin-%s.json", targetPlugin.ListingID))
-		manifestJSON := fmt.Sprintf(`{
-			       "id": "%s",
-			       "name": "%s",
-			       "version": "%s",
-			       "entrypoint": "./plugin",
-			       "runtime": "go"
-		       }`, targetPlugin.ListingID, targetPlugin.Name, targetPlugin.Version)
-
-		if err := os.WriteFile(manifestPath, []byte(manifestJSON), 0644); err != nil {
+		manifestPath, err := writeSynthesizedManifest(targetPlugin.ListingID, targetPlugin.Name, targetPlugin.Version)
+		if err != nil {
 			http.Error(w, fmt.Sprintf("write manifest failed: %v", err), http.StatusInternalServerError)
 			return
 		}
@@ -309,19 +301,11 @@ func registerPluginAPI(mux *http.ServeMux, d *common.Deps) {
 
 		// For now, assume the package contains plugin.json and a binary
 		// In a real implementation, you'd extract the tarball and find these files
-		manifestPath := filepath.Join(tmpDir, "plugin.json")
 		binaryPath := packagePath // Simplified: treat package as binary
 
 		// Create a minimal manifest for testing (real implementation would extract from package)
-		manifestJSON := fmt.Sprintf(`{
-			"id": "%s",
-			"name": "%s",
-			"version": "%s",
-			"entrypoint": "./plugin",
-			"runtime": "go"
-		}`, pluginID, pluginID, version)
-
-		if err := os.WriteFile(manifestPath, []byte(manifestJSON), 0644); err != nil {
+		manifestPath, err := writeSynthesizedManifest(pluginID, pluginID, version)
+		if err != nil {
 			http.Error(w, fmt.Sprintf("write manifest failed: %v", err), http.StatusInternalServerError)
 			return
 		}
@@ -456,6 +440,40 @@ func registerPluginAPI(mux *http.ServeMux, d *common.Deps) {
 	mux.HandleFunc("GET /api/plugins/check-updates", handleCheckUpdates(d))
 	mux.HandleFunc("POST /api/plugins/import-from-file", handleImportFromFile(d))
 	mux.HandleFunc("GET /api/plugins/{id}/export", handleExportPlugin(d))
+}
+
+// writeSynthesizedManifest writes the minimal manifest the two legacy install
+// endpoints feed to InstallPlugin. Built with json.Marshal — never string
+// interpolation: a plugin name/version containing a quote used to produce
+// invalid JSON (breaking every legitimately-quoted name), and a crafted value
+// could inject arbitrary manifest fields. Written via os.CreateTemp so
+// concurrent installs can never clobber each other's manifest (the previous
+// fixed "plugin.json" path in the shared temp dir was a race).
+func writeSynthesizedManifest(id, name, version string) (string, error) {
+	manifestJSON, err := json.Marshal(map[string]string{
+		"id":         id,
+		"name":       name,
+		"version":    version,
+		"entrypoint": "./plugin",
+		"runtime":    "go",
+	})
+	if err != nil {
+		return "", err
+	}
+	f, err := os.CreateTemp("", "unitill-plugin-manifest-*.json")
+	if err != nil {
+		return "", err
+	}
+	if _, err := f.Write(manifestJSON); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
 }
 
 // handleInstallFromMarketplace handles marketplace plugin installation (T017)

--- a/internal/pages/plugin_api_legacy_test.go
+++ b/internal/pages/plugin_api_legacy_test.go
@@ -1,0 +1,494 @@
+package pages
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/config"
+	"github.com/universaltill/universal-till/internal/pages/common"
+)
+
+// --- helpers for the legacy inline handlers in registerPluginAPI ----------
+//
+// These endpoints (/api/plugins/upload, /api/plugins/marketplace,
+// /api/plugins/marketplace/install, permissions grant/revoke, trust) predate
+// the T017 lifecycle handlers and are not wired to any UI template. They
+// still ship, so their contract (gates, validation, error mapping, install
+// side effects) is pinned here. NOTE: the two install endpoints are known
+// half-implementations — they persist a manifest row but delete the artifact
+// and extract nothing, so the "installed" plugin has no runnable code. That
+// gap is a product decision (remove vs finish), tracked in ut-docs/QUEUE.md,
+// deliberately not blessed nor "fixed" here.
+
+// legacyCatalogPlugin is one entry the stub marketplace catalog serves.
+type legacyCatalogPlugin struct {
+	ListingID   string `json:"listing_id"`
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	ArtifactURL string `json:"artifact_url"`
+	SHA256      string `json:"sha256"`
+}
+
+// legacyMarketplaceStub serves /v1/catalog/plugins with the given entries and
+// /artifact/<listing_id> with the given payloads, recording catalog queries.
+func legacyMarketplaceStub(t *testing.T, plugins []legacyCatalogPlugin, artifacts map[string][]byte) (*httptest.Server, *url.Values) {
+	t.Helper()
+	var lastQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/catalog/plugins":
+			lastQuery = r.URL.Query()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"plugins": plugins})
+		case strings.HasPrefix(r.URL.Path, "/artifact/"):
+			id := strings.TrimPrefix(r.URL.Path, "/artifact/")
+			body, ok := artifacts[id]
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			_, _ = w.Write(body)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &lastQuery
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// newLegacyMux builds a mux with registerPluginAPI wired to a real-schema DB
+// and the given marketplace endpoint.
+func newLegacyMux(t *testing.T, endpointURL string) (*http.ServeMux, *common.Deps) {
+	t.Helper()
+	isolatePluginsDir(t)
+	db := openRealSchemaPagesDB(t)
+	cfg := basePluginCfg()
+	cfg.Marketplace = config.MarketplaceConfig{EndpointURL: endpointURL}
+	d := newPluginAPIDeps(t, db, cfg)
+	mux := http.NewServeMux()
+	registerPluginAPI(mux, d)
+	return mux, d
+}
+
+// --- /api/plugins/marketplace (catalog proxy) -----------------------------
+
+func TestLegacyMarketplaceList_ForwardsCatalogAndArch(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+	srv, lastQuery := legacyMarketplaceStub(t, []legacyCatalogPlugin{
+		{ListingID: "com.test.a", Name: "Plugin A", Version: "1.0.0"},
+	}, nil)
+	mux, _ := newLegacyMux(t, srv.URL)
+
+	// Default arch: the till's own GOOS/GOARCH.
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/plugins/marketplace", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET marketplace = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+	if !strings.Contains(rec.Body.String(), "Plugin A") {
+		t.Fatalf("catalog body not forwarded: %s", rec.Body.String())
+	}
+	wantArch := fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+	if got := lastQuery.Get("device_arch"); got != wantArch {
+		t.Fatalf("device_arch = %q, want %q", got, wantArch)
+	}
+	if lastQuery.Get("capability") != "" {
+		t.Fatalf("capability sent without being asked: %q", lastQuery.Get("capability"))
+	}
+
+	// Explicit os/arch/capability filters pass through.
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/plugins/marketplace?os=linux&arch=arm64&capability=payment", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("filtered GET = %d, want 200", rec.Code)
+	}
+	if got := lastQuery.Get("device_arch"); got != "linux/arm64" {
+		t.Fatalf("device_arch = %q, want linux/arm64", got)
+	}
+	if got := lastQuery.Get("capability"); got != "payment" {
+		t.Fatalf("capability = %q, want payment", got)
+	}
+}
+
+func TestLegacyMarketplaceList_MethodAndUpstreamErrors(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+
+	// Wrong method.
+	srv, _ := legacyMarketplaceStub(t, nil, nil)
+	mux, _ := newLegacyMux(t, srv.URL)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/plugins/marketplace", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST marketplace = %d, want 405", rec.Code)
+	}
+
+	// Upstream non-200 status propagates.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "catalog down", http.StatusBadGateway)
+	}))
+	t.Cleanup(upstream.Close)
+	mux2, _ := newLegacyMux(t, upstream.URL)
+	rec = httptest.NewRecorder()
+	mux2.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/plugins/marketplace", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("upstream 502 propagated as %d, want 502", rec.Code)
+	}
+
+	// Unreachable marketplace: 500 with an error message.
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	dead.Close() // now guaranteed-unreachable URL
+	mux3, _ := newLegacyMux(t, dead.URL)
+	rec = httptest.NewRecorder()
+	mux3.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/plugins/marketplace", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("unreachable marketplace = %d, want 500", rec.Code)
+	}
+}
+
+// --- /api/plugins/upload (install by listing id) --------------------------
+
+func TestLegacyUpload_Validation(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+	srv, _ := legacyMarketplaceStub(t, nil, nil)
+	mux, _ := newLegacyMux(t, srv.URL)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/plugins/upload", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET upload = %d, want 405", rec.Code)
+	}
+
+	if rec := postForm(mux, "/api/plugins/upload", url.Values{}, nil); rec.Code != http.StatusBadRequest {
+		t.Fatalf("missing id = %d, want 400", rec.Code)
+	}
+
+	// Unknown listing id -> 404 (catalog is empty).
+	if rec := postForm(mux, "/api/plugins/upload", url.Values{"id": {"com.test.ghost"}}, nil); rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown listing = %d, want 404", rec.Code)
+	}
+}
+
+func TestLegacyUpload_ChecksumMismatch_400(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+	artifact := []byte("real artifact bytes")
+	// Catalog entry advertises the WRONG hash for the artifact it serves.
+	pluginsList := []legacyCatalogPlugin{{
+		ListingID: "com.test.sum",
+		Name:      "Sum Plugin",
+		Version:   "1.0.0",
+		SHA256:    sha256Hex([]byte("different bytes")),
+	}}
+	srv, _ := legacyMarketplaceStub(t, pluginsList, map[string][]byte{"com.test.sum": artifact})
+	// The stub's URL exists only after creation; patch the shared slice.
+	pluginsList[0].ArtifactURL = srv.URL + "/artifact/com.test.sum"
+
+	mux, _ := newLegacyMux(t, srv.URL)
+	rec := postForm(mux, "/api/plugins/upload", url.Values{"id": {"com.test.sum"}}, nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("checksum mismatch = %d, want 400 (%s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "checksum mismatch") {
+		t.Fatalf("error should say checksum mismatch, got: %s", rec.Body.String())
+	}
+}
+
+func TestLegacyUpload_InstallsListedPlugin(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+	artifact := []byte("legacy artifact payload")
+	pluginsList := []legacyCatalogPlugin{{
+		ListingID: "com.test.legacyup",
+		Name:      "Legacy Upload Plugin",
+		Version:   "1.2.3",
+		SHA256:    sha256Hex(artifact),
+	}}
+	srv, _ := legacyMarketplaceStub(t, pluginsList, map[string][]byte{"com.test.legacyup": artifact})
+	pluginsList[0].ArtifactURL = srv.URL + "/artifact/com.test.legacyup"
+
+	mux, d := newLegacyMux(t, srv.URL)
+	rec := postForm(mux, "/api/plugins/upload", url.Values{"id": {"com.test.legacyup"}}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("upload install = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	var name, version string
+	if err := d.Db.QueryRow(`SELECT name, version FROM plugins WHERE id = 'com.test.legacyup'`).Scan(&name, &version); err != nil {
+		t.Fatalf("installed plugin row missing: %v", err)
+	}
+	if name != "Legacy Upload Plugin" || version != "1.2.3" {
+		t.Fatalf("stored name/version = %q/%q, want catalog values", name, version)
+	}
+	// The install must be visible to the plugin manager after Reload.
+	if _, ok := d.Pm.Installed["com.test.legacyup"]; !ok {
+		t.Fatalf("plugin manager not reloaded with new install")
+	}
+}
+
+// A legitimate plugin name containing JSON-special characters must install
+// with the exact name preserved. The legacy handler used to synthesize the
+// manifest via fmt.Sprintf into a JSON string literal — any quote in the
+// catalog name produced invalid JSON (install failed 500), and a crafted
+// name could inject arbitrary manifest fields.
+func TestLegacyUpload_PluginNameWithQuotesInstalls(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+	artifact := []byte("quoted name artifact")
+	quoted := `Legacy "Quoted" Plugin`
+	pluginsList := []legacyCatalogPlugin{{
+		ListingID: "com.test.quoted",
+		Name:      quoted,
+		Version:   "1.0.0",
+		SHA256:    sha256Hex(artifact),
+	}}
+	srv, _ := legacyMarketplaceStub(t, pluginsList, map[string][]byte{"com.test.quoted": artifact})
+	pluginsList[0].ArtifactURL = srv.URL + "/artifact/com.test.quoted"
+
+	mux, d := newLegacyMux(t, srv.URL)
+	rec := postForm(mux, "/api/plugins/upload", url.Values{"id": {"com.test.quoted"}}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("install with quoted name = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	var name string
+	if err := d.Db.QueryRow(`SELECT name FROM plugins WHERE id = 'com.test.quoted'`).Scan(&name); err != nil {
+		t.Fatalf("installed plugin row missing: %v", err)
+	}
+	if name != quoted {
+		t.Fatalf("stored name = %q, want %q", name, quoted)
+	}
+}
+
+// --- /api/plugins/marketplace/install (install by URL) --------------------
+
+func TestLegacyMarketplaceInstall_Validation(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+	srv, _ := legacyMarketplaceStub(t, nil, nil)
+	mux, _ := newLegacyMux(t, srv.URL)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/plugins/marketplace/install", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET install = %d, want 405", rec.Code)
+	}
+
+	// Each required field missing -> 400.
+	full := url.Values{
+		"id":          {"com.test.x"},
+		"version":     {"1.0.0"},
+		"package_url": {"http://example.invalid/p.tar.gz"},
+		"sha256":      {"abc"},
+	}
+	for _, missing := range []string{"id", "version", "package_url", "sha256"} {
+		form := url.Values{}
+		for k, v := range full {
+			if k != missing {
+				form[k] = v
+			}
+		}
+		if rec := postForm(mux, "/api/plugins/marketplace/install", form, nil); rec.Code != http.StatusBadRequest {
+			t.Fatalf("missing %s = %d, want 400", missing, rec.Code)
+		}
+	}
+}
+
+// A catalog entry whose artifact URL is dead (404) must fail the install
+// loudly — a real-world case whenever a release artifact is pruned.
+func TestLegacyInstalls_DeadArtifactURL_500(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+	pluginsList := []legacyCatalogPlugin{{
+		ListingID: "com.test.deadurl",
+		Name:      "Dead URL Plugin",
+		Version:   "1.0.0",
+		SHA256:    sha256Hex([]byte("whatever")),
+	}}
+	srv, _ := legacyMarketplaceStub(t, pluginsList, nil) // no artifacts served
+	pluginsList[0].ArtifactURL = srv.URL + "/artifact/com.test.deadurl"
+	mux, _ := newLegacyMux(t, srv.URL)
+
+	rec := postForm(mux, "/api/plugins/upload", url.Values{"id": {"com.test.deadurl"}}, nil)
+	if rec.Code != http.StatusInternalServerError || !strings.Contains(rec.Body.String(), "download failed") {
+		t.Fatalf("upload with dead artifact = %d (%s), want 500 download failed", rec.Code, rec.Body.String())
+	}
+
+	rec = postForm(mux, "/api/plugins/marketplace/install", url.Values{
+		"id":          {"com.test.deadurl"},
+		"version":     {"1.0.0"},
+		"package_url": {srv.URL + "/artifact/com.test.deadurl"},
+		"sha256":      {sha256Hex([]byte("whatever"))},
+	}, nil)
+	if rec.Code != http.StatusInternalServerError || !strings.Contains(rec.Body.String(), "download failed") {
+		t.Fatalf("marketplace install with dead artifact = %d (%s), want 500 download failed", rec.Code, rec.Body.String())
+	}
+}
+
+func TestLegacyMarketplaceInstall_ChecksumMismatch_400(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+	artifact := []byte("mp install artifact")
+	srv, _ := legacyMarketplaceStub(t, nil, map[string][]byte{"com.test.mpsum": artifact})
+	mux, _ := newLegacyMux(t, srv.URL)
+
+	rec := postForm(mux, "/api/plugins/marketplace/install", url.Values{
+		"id":          {"com.test.mpsum"},
+		"version":     {"1.0.0"},
+		"package_url": {srv.URL + "/artifact/com.test.mpsum"},
+		"sha256":      {sha256Hex([]byte("not the artifact"))},
+	}, nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("checksum mismatch = %d, want 400 (%s)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestLegacyMarketplaceInstall_InstallsAndDefaultsTrust(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+	artifact := []byte("mp trusted artifact")
+	srv, _ := legacyMarketplaceStub(t, nil, map[string][]byte{"com.test.mpok": artifact})
+	mux, d := newLegacyMux(t, srv.URL)
+
+	rec := postForm(mux, "/api/plugins/marketplace/install", url.Values{
+		"id":          {"com.test.mpok"},
+		"version":     {"2.0.0"},
+		"package_url": {srv.URL + "/artifact/com.test.mpok"},
+		"sha256":      {sha256Hex(artifact)},
+	}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("marketplace install = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	var trust, version string
+	if err := d.Db.QueryRow(`SELECT trust_level, version FROM plugins WHERE id = 'com.test.mpok'`).Scan(&trust, &version); err != nil {
+		t.Fatalf("installed plugin row missing: %v", err)
+	}
+	if trust != "untrusted" {
+		t.Fatalf("default trust_level = %q, want untrusted", trust)
+	}
+	if version != "2.0.0" {
+		t.Fatalf("version = %q, want 2.0.0", version)
+	}
+}
+
+// Same manifest-synthesis bug as the upload path: a version (or id) with a
+// quote used to break the fmt.Sprintf-built JSON. Must install verbatim.
+func TestLegacyMarketplaceInstall_VersionWithQuoteInstalls(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+	artifact := []byte("mp quoted artifact")
+	version := `1.0.0-beta"x`
+	srv, _ := legacyMarketplaceStub(t, nil, map[string][]byte{"com.test.mpquoted": artifact})
+	mux, d := newLegacyMux(t, srv.URL)
+
+	rec := postForm(mux, "/api/plugins/marketplace/install", url.Values{
+		"id":          {"com.test.mpquoted"},
+		"version":     {version},
+		"package_url": {srv.URL + "/artifact/com.test.mpquoted"},
+		"sha256":      {sha256Hex(artifact)},
+	}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("install with quoted version = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	var got string
+	if err := d.Db.QueryRow(`SELECT version FROM plugins WHERE id = 'com.test.mpquoted'`).Scan(&got); err != nil {
+		t.Fatalf("installed plugin row missing: %v", err)
+	}
+	if got != version {
+		t.Fatalf("stored version = %q, want %q", got, version)
+	}
+}
+
+// --- permissions grant/revoke and trust level ------------------------------
+
+func TestLegacyPermissions_GrantRevoke(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+	srv, _ := legacyMarketplaceStub(t, nil, nil)
+	mux, d := newLegacyMux(t, srv.URL)
+	seedInstalledPlugin(t, d.Db, "com.test.perms", "1.0.0")
+
+	// Method + validation gates.
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/plugins/permissions/grant", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET grant = %d, want 405", rec.Code)
+	}
+	if rec := postForm(mux, "/api/plugins/permissions/grant", url.Values{"plugin_id": {"com.test.perms"}}, nil); rec.Code != http.StatusBadRequest {
+		t.Fatalf("grant without permission = %d, want 400", rec.Code)
+	}
+	if rec := postForm(mux, "/api/plugins/permissions/revoke", url.Values{"permission": {"pos.read"}}, nil); rec.Code != http.StatusBadRequest {
+		t.Fatalf("revoke without plugin_id = %d, want 400", rec.Code)
+	}
+
+	// Granting a permission the plugin never declared must fail — the domain
+	// layer only flips pre-declared permission rows, it never invents one.
+	undeclared := url.Values{"plugin_id": {"com.test.perms"}, "permission": {"pos.read"}}
+	if rec := postForm(mux, "/api/plugins/permissions/grant", undeclared, nil); rec.Code != http.StatusInternalServerError {
+		t.Fatalf("grant of undeclared permission = %d, want 500", rec.Code)
+	}
+
+	// Declare the permission (as a manifest install would), then grant.
+	if _, err := d.Db.Exec(`INSERT INTO plugin_permissions(id, plugin_id, permission, granted) VALUES ('perm-1','com.test.perms','pos.read',0)`); err != nil {
+		t.Fatalf("seed declared permission: %v", err)
+	}
+
+	// Grant persists granted=1.
+	form := url.Values{"plugin_id": {"com.test.perms"}, "permission": {"pos.read"}}
+	if rec := postForm(mux, "/api/plugins/permissions/grant", form, nil); rec.Code != http.StatusOK {
+		t.Fatalf("grant = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	var granted int
+	if err := d.Db.QueryRow(`SELECT granted FROM plugin_permissions WHERE plugin_id='com.test.perms' AND permission='pos.read'`).Scan(&granted); err != nil {
+		t.Fatalf("granted permission row missing: %v", err)
+	}
+	if granted != 1 {
+		t.Fatalf("granted = %d, want 1", granted)
+	}
+
+	// Revoke flips it back.
+	if rec := postForm(mux, "/api/plugins/permissions/revoke", form, nil); rec.Code != http.StatusOK {
+		t.Fatalf("revoke = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	if err := d.Db.QueryRow(`SELECT granted FROM plugin_permissions WHERE plugin_id='com.test.perms' AND permission='pos.read'`).Scan(&granted); err != nil {
+		t.Fatalf("permission row missing after revoke: %v", err)
+	}
+	if granted != 0 {
+		t.Fatalf("granted after revoke = %d, want 0", granted)
+	}
+}
+
+func TestLegacyTrustLevel_UpdateAndValidation(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+	srv, _ := legacyMarketplaceStub(t, nil, nil)
+	mux, d := newLegacyMux(t, srv.URL)
+	seedInstalledPlugin(t, d.Db, "com.test.trust", "1.0.0")
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/plugins/trust", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET trust = %d, want 405", rec.Code)
+	}
+	if rec := postForm(mux, "/api/plugins/trust", url.Values{"plugin_id": {"com.test.trust"}}, nil); rec.Code != http.StatusBadRequest {
+		t.Fatalf("trust without level = %d, want 400", rec.Code)
+	}
+	// An out-of-vocabulary trust level is rejected by the domain layer.
+	if rec := postForm(mux, "/api/plugins/trust", url.Values{"plugin_id": {"com.test.trust"}, "trust_level": {"royal"}}, nil); rec.Code != http.StatusInternalServerError {
+		t.Fatalf("invalid trust level = %d, want 500", rec.Code)
+	}
+
+	if rec := postForm(mux, "/api/plugins/trust", url.Values{"plugin_id": {"com.test.trust"}, "trust_level": {"trusted"}}, nil); rec.Code != http.StatusOK {
+		t.Fatalf("trust update = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	var trust string
+	if err := d.Db.QueryRow(`SELECT trust_level FROM plugins WHERE id='com.test.trust'`).Scan(&trust); err != nil {
+		t.Fatalf("plugin row missing: %v", err)
+	}
+	if trust != "trusted" {
+		t.Fatalf("trust_level = %q, want trusted", trust)
+	}
+}

--- a/internal/pages/plugins_store_api_test.go
+++ b/internal/pages/plugins_store_api_test.go
@@ -1,0 +1,274 @@
+package pages
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/universaltill/universal-till/internal/config"
+	"github.com/universaltill/universal-till/internal/pages/common"
+	"github.com/universaltill/universal-till/internal/paths"
+	"github.com/universaltill/universal-till/internal/plugins"
+)
+
+// newStoreAPIMux wires registerPluginStoreAPI over a real-schema DB and an
+// isolated plugins dir, with the given marketplace config.
+func newStoreAPIMux(t *testing.T, mp config.MarketplaceConfig) (*http.ServeMux, *common.Deps) {
+	t.Helper()
+	isolatePluginsDir(t)
+	db := openRealSchemaPagesDB(t)
+	cfg := basePluginCfg()
+	cfg.Marketplace = mp
+	d := newPluginAPIDeps(t, db, cfg)
+	mux := http.NewServeMux()
+	registerPluginStoreAPI(mux, d)
+	return mux, d
+}
+
+// storeRespOf decodes the store API's JSON envelope.
+func storeRespOf(t *testing.T, rec *httptest.ResponseRecorder) (bool, string) {
+	t.Helper()
+	var body struct {
+		Success bool   `json:"success"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("store response is not the JSON envelope: %v (%s)", err, rec.Body.String())
+	}
+	return body.Success, body.Message
+}
+
+func TestStoreAPI_MissingListingID_400(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+	mux, _ := newStoreAPIMux(t, config.MarketplaceConfig{EndpointURL: "http://127.0.0.1:0"})
+
+	for _, path := range []string{
+		"/api/plugins/store/download",
+		"/api/plugins/store/install",
+		"/api/plugins/store/delete-download",
+	} {
+		rec := postForm(mux, path, url.Values{}, nil)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("%s without listing_id = %d, want 400", path, rec.Code)
+		}
+		if ok, msg := storeRespOf(t, rec); ok || !strings.Contains(msg, "listing_id") {
+			t.Fatalf("%s error envelope wrong: success=%v msg=%q", path, ok, msg)
+		}
+	}
+}
+
+func TestStoreAPI_InstallerNotConfigured_500(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+	// An invalid public key makes the manifest verifier (and so the
+	// installer) unconstructable — every lifecycle action must fail loudly.
+	mux, _ := newStoreAPIMux(t, config.MarketplaceConfig{
+		EndpointURL: "http://127.0.0.1:0",
+		PublicKey:   "not-hex-at-all",
+	})
+
+	form := url.Values{"listing_id": {"lst-1"}}
+	for _, path := range []string{
+		"/api/plugins/store/download",
+		"/api/plugins/store/install",
+		"/api/plugins/store/delete-download",
+	} {
+		rec := postForm(mux, path, form, nil)
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("%s with broken installer = %d, want 500", path, rec.Code)
+		}
+		if ok, msg := storeRespOf(t, rec); ok || !strings.Contains(msg, "marketplace not configured") {
+			t.Fatalf("%s envelope wrong: success=%v msg=%q", path, ok, msg)
+		}
+	}
+}
+
+func TestStoreAPI_DownloadFailureIs502(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+	// A marketplace that answers but has nothing (404 everywhere): the
+	// download must fail as a gateway error, with the envelope saying why.
+	srv := httptest.NewServer(http.HandlerFunc(http.NotFound))
+	t.Cleanup(srv.Close)
+	mux, _ := newStoreAPIMux(t, config.MarketplaceConfig{EndpointURL: srv.URL})
+
+	rec := postForm(mux, "/api/plugins/store/download", url.Values{"listing_id": {"lst-1"}}, nil)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("download from empty marketplace = %d, want 502 (%s)", rec.Code, rec.Body.String())
+	}
+	if ok, msg := storeRespOf(t, rec); ok || !strings.Contains(msg, "download failed") {
+		t.Fatalf("download envelope wrong: success=%v msg=%q", ok, msg)
+	}
+}
+
+func TestStoreAPI_InstallWithoutStagedDownload_400(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+	mux, _ := newStoreAPIMux(t, config.MarketplaceConfig{
+		EndpointURL: "http://127.0.0.1:0",
+		PublicKey:   validStorePublicKey(t),
+	})
+
+	rec := postForm(mux, "/api/plugins/store/install", url.Values{"listing_id": {"lst-none"}}, nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("install without staged bundle = %d, want 400 (%s)", rec.Code, rec.Body.String())
+	}
+	if ok, msg := storeRespOf(t, rec); ok || !strings.Contains(msg, "install failed") {
+		t.Fatalf("install envelope wrong: success=%v msg=%q", ok, msg)
+	}
+}
+
+func TestStoreAPI_DeleteDownloadRemovesStagedBundle(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+	mux, _ := newStoreAPIMux(t, config.MarketplaceConfig{EndpointURL: "http://127.0.0.1:0"})
+
+	// Stage fake download files where the installer keeps them.
+	downloads := paths.Plugins("downloads")
+	if err := os.MkdirAll(downloads, 0o755); err != nil {
+		t.Fatalf("mkdir downloads: %v", err)
+	}
+	bundle := filepath.Join(downloads, "lst-del.tar.gz")
+	meta := filepath.Join(downloads, "lst-del.json")
+	for _, p := range []string{bundle, meta} {
+		if err := os.WriteFile(p, []byte("staged"), 0o644); err != nil {
+			t.Fatalf("stage %s: %v", p, err)
+		}
+	}
+
+	rec := postForm(mux, "/api/plugins/store/delete-download", url.Values{"listing_id": {"lst-del"}}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete-download = %d (%s)", rec.Code, rec.Body.String())
+	}
+	for _, p := range []string{bundle, meta} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("staged file %s still present after delete", p)
+		}
+	}
+
+	// Deleting again (nothing staged) is idempotent, not an error.
+	rec = postForm(mux, "/api/plugins/store/delete-download", url.Values{"listing_id": {"lst-del"}}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second delete-download = %d, want 200", rec.Code)
+	}
+}
+
+// validStorePublicKey returns some syntactically valid Ed25519 public key hex.
+func validStorePublicKey(t *testing.T) string {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return hex.EncodeToString(pub)
+}
+
+// TestStoreAPI_InstallFromStagedBundleSucceeds drives the real "downloaded ->
+// installed" transition: a signed asset-only bundle staged exactly where
+// DownloadToStore would put it, then POST /api/plugins/store/install.
+func TestStoreAPI_InstallFromStagedBundleSucceeds(t *testing.T) {
+	t.Setenv("UT_AUTH", "off")
+
+	// A signed, asset-only (runtime "none") manifest — no executable needed.
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	m := plugins.Manifest{
+		ID:            "com.test.storeinstall",
+		Name:          "Store Install Plugin",
+		Version:       "1.0.0",
+		Runtime:       "none",
+		CanonicalType: "theme",
+		DeviceArch:    "any",
+	}
+	canonical, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal canonical: %v", err)
+	}
+	m.Signature = hex.EncodeToString(ed25519.Sign(priv, canonical))
+
+	mux, d := newStoreAPIMux(t, config.MarketplaceConfig{
+		EndpointURL: "http://127.0.0.1:0",
+		PublicKey:   hex.EncodeToString(pub),
+	})
+
+	// Stage the bundle + metadata exactly as DownloadToStore records them.
+	bundleSrc := writePluginBundle(t, m)
+	downloads := paths.Plugins("downloads")
+	if err := os.MkdirAll(downloads, 0o755); err != nil {
+		t.Fatalf("mkdir downloads: %v", err)
+	}
+	bundlePath := filepath.Join(downloads, "lst-store.tar.gz")
+	src, err := os.Open(bundleSrc)
+	if err != nil {
+		t.Fatalf("open bundle: %v", err)
+	}
+	dst, err := os.Create(bundlePath)
+	if err != nil {
+		t.Fatalf("create staged bundle: %v", err)
+	}
+	if _, err := io.Copy(dst, src); err != nil {
+		t.Fatalf("copy bundle: %v", err)
+	}
+	src.Close()
+	dst.Close()
+	sum, err := plugins.ComputeSHA256(bundlePath)
+	if err != nil {
+		t.Fatalf("checksum: %v", err)
+	}
+	metaRaw, err := json.Marshal(map[string]any{
+		"listing_id":      "lst-store",
+		"version":         m.Version,
+		"checksum_sha256": sum,
+		"signature":       m.Signature,
+		"source_url":      "https://marketplace.example/bundles/lst-store.tar.gz",
+		"bundle_path":     bundlePath,
+		"downloaded_at":   time.Now().UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("marshal meta: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(downloads, "lst-store.json"), metaRaw, 0o644); err != nil {
+		t.Fatalf("write meta: %v", err)
+	}
+
+	rec := postForm(mux, "/api/plugins/store/install", url.Values{"listing_id": {"lst-store"}}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("store install = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if ok, msg := storeRespOf(t, rec); !ok || !strings.Contains(msg, "Store Install Plugin") {
+		t.Fatalf("install envelope wrong: success=%v msg=%q", ok, msg)
+	}
+
+	// The plugin is persisted, visible to the manager, and status-tracked.
+	var name string
+	if err := d.Db.QueryRow(`SELECT name FROM plugins WHERE id='com.test.storeinstall'`).Scan(&name); err != nil {
+		t.Fatalf("installed plugin row missing: %v", err)
+	}
+	if name != "Store Install Plugin" {
+		t.Fatalf("stored name = %q", name)
+	}
+	if _, ok := d.Pm.Installed["com.test.storeinstall"]; !ok {
+		t.Fatalf("plugin manager not reloaded after store install")
+	}
+	statuses, err := plugins.NewInstallStatusStore(d.Db).List(t.Context())
+	if err != nil {
+		t.Fatalf("list install statuses: %v", err)
+	}
+	st, ok := statuses["lst-store"]
+	if !ok || st.State != plugins.InstallStateActive {
+		t.Fatalf("install status = %+v, want active for lst-store", st)
+	}
+
+	// The staged bundle was consumed by the successful install.
+	if _, err := os.Stat(bundlePath); !os.IsNotExist(err) {
+		t.Fatalf("staged bundle should be removed after install")
+	}
+}


### PR DESCRIPTION
First batch of the QUEUE.md "Test-coverage push, remainder" item: the four `internal/pages` register functions PR #82 left as stragglers, now driven by real httptest requests through the real mux.

| Function | Before | After |
|---|---|---|
| registerButtonsAPI | 24.2% | 87.1% |
| registerJournal | 34.3% | 94.3% |
| registerPluginAPI | 22.9% | 80.2% |
| registerPluginStoreAPI | 29.2% | 93.8% |

Package overall: 71.2% → 75.7%.

**Real bug found TDD-first**: the two legacy install endpoints synthesized the plugin manifest via `fmt.Sprintf` into a JSON literal — a name/version with a quote broke the install, crafted values could inject manifest fields, and the marketplace/install path raced on a fixed `plugin.json` temp path. Fixed with `json.Marshal` + `os.CreateTemp` (red→green proven, independently re-proven by the reviewer).

Independent different-model review (opus): **SAFE TO MERGE, no blocking findings** — 6 total mutation/revert probes across the new tests, zero false-passes. Record: `docs/code-reviews/2026-07-30-coverage-pages-stragglers.md`. Full gate green: build/vet, whole-repo `go test`, all 5 CI guards, Playwright e2e 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkpbKKWW8MMDFKtJCP1Xtj