### PR TITLE
test: cover self-update mechanics hermetically; fail closed on unverified updates

### DIFF
--- a/docs/code-reviews/2026-07-30-coverage-selfupdate-updates.md
+++ b/docs/code-reviews/2026-07-30-coverage-selfupdate-updates.md
@@ -1,0 +1,109 @@
+# Code review — coverage batch 2: internal/selfupdate + internal/updates
+
+- **Date:** 2026-07-30
+- **Branch/PR:** `test/coverage-selfupdate-updates`
+- **Author:** SDLC pipeline (fable) · **Independent reviewer:** different model (opus), subagent
+- **Scope:** hermetic test coverage for the till's self-update mechanics —
+  `internal/updates` (background release check) 29.6% → **82.5%**,
+  `internal/selfupdate` (archive-swap updater) 5.0% → **76.3%**
+  (darwin-measured; Linux CI doesn't compile the 117-line
+  `macapp_darwin.go`, so its number lands higher there). Plus two real
+  bug fixes found TDD-first, and behavior-preserving test seams.
+
+## What shipped
+
+- **Seams (production behavior unchanged; vars only ever mutated by tests
+  with `t.Cleanup` restores; no `t.Parallel` anywhere in either package):**
+  `releasesURL`/`releasesLatest` const→var (tests point them at local
+  `httptest` servers); `osExecutable`, `reexecFn`, `reexecDelay`,
+  `extractLimit` vars in `selfupdate`; `Start`'s env gate extracted to
+  `enabledFromEnv()` (logic reproduced verbatim).
+- **Tests:** full hermetic `Apply()` arcs against a fake release server on
+  a temp-dir install fixture — successful binary+`web/` swap with `.bak`
+  backups and stubbed re-exec; unsupported-install; already-latest;
+  no-archive-for-platform; download 404; checksum mismatch (binary
+  untouched, no premature `.bak`); archive-missing-binary; backup-rename
+  failure (read-only dir). Unit tests for `download`, `checksumFor`,
+  `verifySHA256`, `extractTarGz` (incl. `../` traversal rejection and
+  oversize rejection), `moveFile`/`moveDir` error paths, `fetchLatest`
+  branches. `updates`: `checkOnce` state machine (success stores
+  status with `v`-trim; 403/bad-JSON/empty-tag/unreachable leave prior
+  state), `CheckNow`, `enabledFromEnv` table, `Start` disabled/cancelled.
+  Darwin-only: `applyMacApp`'s two early hermetic branches + `Apply`'s
+  `.app`-bundle routing.
+
+## Real bugs found (TDD: proven red first, then fixed, then green)
+
+1. **Medium (security hardening): `Apply` silently skipped checksum
+   verification when the release had no `checksums.txt` asset** — a
+   fail-open on the self-update integrity gate.
+   `TestApplyRefusesReleaseWithoutChecksums` proved red (`err = <nil>`,
+   unverified archive installed) against the old code. Every real release
+   ships `checksums.txt` (`.goreleaser.yaml` `checksum:` block), so a
+   missing one only ever means a broken/tampered release; now fails
+   closed. Reviewer independently confirmed no legitimate path breaks.
+2. **Medium: `extractTarGz` silently truncated any archive entry at the
+   512MB cap** (`io.LimitReader` + `io.Copy` cannot distinguish EOF from
+   cap) — a truncated binary would then be swapped in, since the SHA-256
+   covers the `.tar.gz`, not extracted files. Proven red with a small
+   `extractLimit`: 64-byte entry extracted as 16 bytes, no error. Fixed
+   by reading `limit+1` and rejecting `n > limit`; reviewer verified the
+   boundary (an entry of exactly `extractLimit` bytes still extracts).
+
+## Hermeticity (hard requirement for this batch)
+
+- All tests pass with `HTTP_PROXY`/`HTTPS_PROXY` pointed at a dead port
+  (loopback bypasses the proxy; any real GitHub call would die) — run by
+  both tester and reviewer independently. No non-localhost URL literal in
+  any test file.
+- No test ever touches the real test binary: every path reaching the swap
+  code stubs `osExecutable` to a `t.TempDir()` fixture; `reexecFn` is
+  stubbed (the real one is `syscall.Exec` — reviewer confirmed stubbing
+  is load-bearing, a real call would replace the test process).
+- The macOS updater helper (`pkill`s real till processes, replaces
+  `/Applications` bundles) never executes: only `applyMacApp`'s
+  pre-`hdiutil` branches are tested.
+
+## Independent review (different model, opus): SAFE TO MERGE, no blocking findings
+
+- Re-proved both TDD claims itself by reverting each fix in isolation and
+  reproducing the exact claimed failure modes, then restoring.
+- Ran 2 fresh mutation probes of its own (inverted `fetchLatest`'s
+  already-latest comparison; dropped `checksumFor`'s asset-name match) —
+  both caught. On top of the tester's 3 probes (tar traversal guard
+  removal, `checkOnce` empty-tag guard removal, `enabledFromEnv` gate
+  removal) and the 2 TDD arcs: **7/7 caught, zero false-passes**.
+- Verified seam behavior-preservation, cleanup restores, absence of
+  `t.Parallel`, no real shop names, no secret-shaped literals.
+- Non-blocking, out-of-scope observations → logged to `ut-docs/QUEUE.md`:
+  the mac `.dmg` update path performs **no SHA-256 check** (relies solely
+  on `codesign --verify`, which only proves internal consistency — an
+  ad-hoc-signed tampered bundle would pass), and the `.dmg` asset name
+  hardcodes `-arm64` (amd64 Macs get "no macOS .dmg"). Both pre-existing.
+
+## Verified beyond automated tests
+
+- Race detector clean on both packages (`go test -race`).
+- Cross-compile checks: `GOOS=linux` and `GOOS=windows` build clean.
+- Full repo gate: `go build ./...`, `go vet ./...`, full `go test ./...`,
+  all 5 CI guards green.
+- Playwright e2e deliberately not run: the diff touches zero
+  UI/template/handler surface, and no e2e flow triggers (or ever should
+  trigger) a real self-update.
+
+## Honestly-untestable remainder (documented, not faked)
+
+- `reexec_unix.go` — `syscall.Exec` replaces the process image; by
+  definition cannot be exercised inside a test process.
+- `macapp_darwin.go` past the `.dmg` download — `hdiutil` mount, `ditto`,
+  `codesign`, and the detached replace-and-relaunch helper are real macOS
+  glue; the helper kills real till processes and must never run in tests.
+- `updates.Start`'s timer loop body — 30s boot wait / 24h ticker need a
+  fake clock; restructuring for one was an explicit non-goal.
+- `moveFile`/`moveDir` cross-filesystem copy success path — needs a
+  second filesystem; error fallbacks are covered.
+- Scattered local-IO error branches on just-created temp files
+  (`os.MkdirTemp`/`os.Create` failures mid-`Apply`), and the mid-swap
+  `web/` rollback branch, which requires a rename that fails only after
+  the binary swap succeeded — not arrangeable without invasive FS mocking
+  disproportionate to the risk.

--- a/internal/selfupdate/macapp_darwin_test.go
+++ b/internal/selfupdate/macapp_darwin_test.go
@@ -1,0 +1,57 @@
+//go:build darwin
+
+package selfupdate
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/buildinfo"
+)
+
+// Only applyMacApp's early, purely-local branches are unit-tested (release has
+// no .dmg; .dmg download fails). Everything past the download — hdiutil mount,
+// ditto, codesign, the detached replace-and-relaunch helper — is real macOS
+// glue that must never run in a test: the helper script pkills real
+// unitill-pos/unitill-desktop processes and replaces /Applications bundles.
+// That remainder is deliberately uncovered, not faked.
+
+// Apply routes a darwin .app-bundle executable into applyMacApp instead of the
+// archive-swap path — proven by hitting applyMacApp's distinctive error.
+func TestApplyRoutesAppBundleToMacPath(t *testing.T) {
+	oldExec, oldVer := osExecutable, buildinfo.Version
+	osExecutable = func() (string, error) {
+		return "/Applications/Universal Till.app/Contents/MacOS/unitill-pos", nil
+	}
+	buildinfo.Version = "0.1.0"
+	t.Cleanup(func() { osExecutable, buildinfo.Version = oldExec, oldVer })
+	newReleaseServer(t, "v0.2.0", map[string][]byte{})
+	err := Apply(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "no macOS .dmg") {
+		t.Fatalf("err = %v, want applyMacApp's no-dmg error", err)
+	}
+}
+
+func TestApplyMacAppNoDmgInRelease(t *testing.T) {
+	oldVer := buildinfo.Version
+	buildinfo.Version = "0.1.0"
+	t.Cleanup(func() { buildinfo.Version = oldVer })
+	newReleaseServer(t, "v0.2.0", map[string][]byte{"unitill-pos_0.2.0_linux_amd64.tar.gz": []byte("x")})
+	err := applyMacApp(context.Background(), "/Applications/Universal Till.app")
+	if err == nil || !strings.Contains(err.Error(), "no macOS .dmg") {
+		t.Fatalf("err = %v, want no-dmg-in-release", err)
+	}
+}
+
+func TestApplyMacAppDmgDownloadFails(t *testing.T) {
+	oldVer := buildinfo.Version
+	buildinfo.Version = "0.1.0"
+	t.Cleanup(func() { buildinfo.Version = oldVer })
+	// A nil asset body is listed in /latest but 404s on download.
+	newReleaseServer(t, "v0.2.0", map[string][]byte{"unitill-pos-0.2.0-macOS-arm64.dmg": nil})
+	err := applyMacApp(context.Background(), "/Applications/Universal Till.app")
+	if err == nil || !strings.Contains(err.Error(), "download .dmg") {
+		t.Fatalf("err = %v, want download failure", err)
+	}
+}

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -30,14 +30,26 @@ import (
 	"github.com/universaltill/universal-till/internal/logging"
 )
 
-const releasesLatest = "https://api.github.com/repos/universaltill/universal-till/releases/latest"
+// releasesLatest is a var (not const) purely as a test seam: tests point it at
+// a local httptest server so no test ever talks to the real GitHub API.
+var releasesLatest = "https://api.github.com/repos/universaltill/universal-till/releases/latest"
+
+// Test seams. Production code never changes these; tests do, so that the full
+// Apply flow can run hermetically against a temp-dir "install" without ever
+// touching the real running binary or re-exec'ing the test process (a real
+// syscall.Exec would replace the test binary mid-run).
+var (
+	osExecutable = os.Executable
+	reexecFn     = reexec
+	reexecDelay  = 1500 * time.Millisecond
+)
 
 // ErrUnsupported means this install type updates via a native mechanism.
 var ErrUnsupported = errors.New("in-app update is only for archive (.tar.gz) installs; use the installer (Windows) or apt (.deb)")
 
 // Supported reports whether Apply can run for this build/install.
 func Supported() bool {
-	exe, err := os.Executable()
+	exe, err := osExecutable()
 	if err != nil {
 		return false
 	}
@@ -110,7 +122,7 @@ func Apply(ctx context.Context) error {
 	if !Supported() {
 		return ErrUnsupported
 	}
-	exe, err := os.Executable()
+	exe, err := osExecutable()
 	if err != nil {
 		return fmt.Errorf("locate executable: %w", err)
 	}
@@ -155,14 +167,18 @@ func Apply(ctx context.Context) error {
 	if err := download(ctx, archiveURL, archivePath); err != nil {
 		return fmt.Errorf("download: %w", err)
 	}
-	if checksumsURL != "" {
-		want, err := checksumFor(ctx, checksumsURL, archiveName)
-		if err != nil {
-			return err
-		}
-		if err := verifySHA256(archivePath, want); err != nil {
-			return err
-		}
+	// Fail closed: every real release ships checksums.txt (.goreleaser.yaml
+	// name_template), so a release without one only ever means a broken or
+	// tampered release — never install unverified.
+	if checksumsURL == "" {
+		return fmt.Errorf("release v%s has no checksums.txt — refusing to install an unverified update", version)
+	}
+	want, err := checksumFor(ctx, checksumsURL, archiveName)
+	if err != nil {
+		return err
+	}
+	if err := verifySHA256(archivePath, want); err != nil {
+		return err
 	}
 
 	// Extract to a staging dir (contains the new binary + web/).
@@ -209,8 +225,8 @@ func Apply(ctx context.Context) error {
 	log.Infof("[selfupdate] updated to v%s — restarting", version)
 	// Re-exec the new binary shortly, so the HTTP response can flush first.
 	go func() {
-		time.Sleep(1500 * time.Millisecond)
-		if err := reexec(exe); err != nil {
+		time.Sleep(reexecDelay)
+		if err := reexecFn(exe); err != nil {
 			logging.L().Errorf("[selfupdate] re-exec failed (restart manually): %v", err)
 		}
 	}()
@@ -302,6 +318,11 @@ func verifySHA256(path, want string) error {
 	return nil
 }
 
+// extractLimit caps how many bytes a single archive entry may extract to
+// (zip-bomb guard). A var so tests can exercise the limit without writing
+// half-gigabyte fixtures.
+var extractLimit int64 = 512 << 20
+
 func extractTarGz(src, dst string) error {
 	f, err := os.Open(src)
 	if err != nil {
@@ -340,11 +361,18 @@ func extractTarGz(src, dst string) error {
 			if err != nil {
 				return err
 			}
-			if _, err := io.Copy(out, io.LimitReader(tr, 512<<20)); err != nil {
-				out.Close()
+			// Read one byte past the cap so an over-limit entry fails loudly
+			// instead of silently truncating (a truncated binary would pass
+			// the swap — the archive checksum covers the .tar.gz, not the
+			// extracted files).
+			n, err := io.Copy(out, io.LimitReader(tr, extractLimit+1))
+			out.Close()
+			if err != nil {
 				return err
 			}
-			out.Close()
+			if n > extractLimit {
+				return fmt.Errorf("archive entry %s exceeds the %d-byte extraction limit", hdr.Name, extractLimit)
+			}
 		}
 	}
 }

--- a/internal/selfupdate/selfupdate_apply_test.go
+++ b/internal/selfupdate/selfupdate_apply_test.go
@@ -1,0 +1,509 @@
+package selfupdate
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/universaltill/universal-till/internal/buildinfo"
+)
+
+// These tests mutate package-level seams (osExecutable, reexecFn, releasesLatest,
+// buildinfo.Version) — none of them may use t.Parallel. Everything is hermetic:
+// all HTTP goes to local httptest servers, the "running binary" is a fake file
+// in a t.TempDir, and re-exec is stubbed (a real one would replace the test
+// process image).
+
+// tarEntry is one file or directory for makeTarGz.
+type tarEntry struct {
+	name string
+	body string
+	dir  bool
+	mode int64
+}
+
+func makeTarGz(t *testing.T, entries []tarEntry) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, e := range entries {
+		mode := e.mode
+		if mode == 0 {
+			mode = 0o755
+		}
+		hdr := &tar.Header{Name: e.name, Mode: mode}
+		if e.dir {
+			hdr.Typeflag = tar.TypeDir
+		} else {
+			hdr.Typeflag = tar.TypeReg
+			hdr.Size = int64(len(e.body))
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if !e.dir {
+			if _, err := tw.Write([]byte(e.body)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func sha256hex(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+// releaseServer serves a fake GitHub "latest release" plus its assets.
+type releaseServer struct {
+	srv    *httptest.Server
+	tag    string
+	assets map[string][]byte // asset name -> content, served at /asset/<name>; a nil body is listed in /latest but 404s on download
+}
+
+func newReleaseServer(t *testing.T, tag string, assets map[string][]byte) *releaseServer {
+	t.Helper()
+	rs := &releaseServer{tag: tag, assets: assets}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/latest", func(w http.ResponseWriter, r *http.Request) {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf(`{"tag_name":%q,"assets":[`, rs.tag))
+		first := true
+		for name := range rs.assets {
+			if !first {
+				sb.WriteString(",")
+			}
+			first = false
+			sb.WriteString(fmt.Sprintf(`{"name":%q,"browser_download_url":%q}`, name, rs.srv.URL+"/asset/"+name))
+		}
+		sb.WriteString("]}")
+		w.Write([]byte(sb.String()))
+	})
+	mux.HandleFunc("/asset/", func(w http.ResponseWriter, r *http.Request) {
+		name := strings.TrimPrefix(r.URL.Path, "/asset/")
+		body, ok := rs.assets[name]
+		if !ok || body == nil {
+			http.NotFound(w, r)
+			return
+		}
+		w.Write(body)
+	})
+	rs.srv = httptest.NewServer(mux)
+	t.Cleanup(rs.srv.Close)
+	old := releasesLatest
+	releasesLatest = rs.srv.URL + "/latest"
+	t.Cleanup(func() { releasesLatest = old })
+	return rs
+}
+
+// installFixture is a fake portable install: a directory holding the "current"
+// binary and web/ assets, with the osExecutable seam pointing at it.
+type installFixture struct {
+	dir     string
+	exe     string
+	oldBin  string
+	reexecd chan string
+}
+
+func newInstallFixture(t *testing.T) *installFixture {
+	t.Helper()
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "unitill-pos")
+	f := &installFixture{dir: dir, exe: exe, oldBin: "OLD-BINARY-v1", reexecd: make(chan string, 1)}
+	if err := os.WriteFile(exe, []byte(f.oldBin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "web"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "web", "index.html"), []byte("OLD-WEB"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldExec, oldReexec, oldDelay, oldVer := osExecutable, reexecFn, reexecDelay, buildinfo.Version
+	osExecutable = func() (string, error) { return exe, nil }
+	reexecFn = func(path string) error { f.reexecd <- path; return nil }
+	reexecDelay = 5 * time.Millisecond
+	buildinfo.Version = "0.1.0"
+	t.Cleanup(func() {
+		osExecutable, reexecFn, reexecDelay, buildinfo.Version = oldExec, oldReexec, oldDelay, oldVer
+	})
+	return f
+}
+
+func archiveNameFor(version string) string {
+	return fmt.Sprintf("unitill-pos_%s_%s_%s.tar.gz", version, runtime.GOOS, runtime.GOARCH)
+}
+
+// The happy path: Apply downloads the release archive, verifies its checksum,
+// swaps binary + web/ keeping .bak backups, and schedules a re-exec.
+func TestApplySuccessSwapsBinaryAndWeb(t *testing.T) {
+	fix := newInstallFixture(t)
+	name := archiveNameFor("0.2.0")
+	archive := makeTarGz(t, []tarEntry{
+		{name: "unitill-pos", body: "NEW-BINARY-v2"},
+		{name: "web", dir: true},
+		{name: "web/index.html", body: "NEW-WEB"},
+	})
+	newReleaseServer(t, "v0.2.0", map[string][]byte{
+		name:            archive,
+		"checksums.txt": []byte(sha256hex(archive) + "  " + name + "\n"),
+	})
+
+	if err := Apply(context.Background()); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got, _ := os.ReadFile(fix.exe); string(got) != "NEW-BINARY-v2" {
+		t.Errorf("binary not swapped, content = %q", got)
+	}
+	if info, err := os.Stat(fix.exe); err != nil || info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("new binary not executable: %v %v", info, err)
+	}
+	if got, _ := os.ReadFile(fix.exe + ".bak"); string(got) != fix.oldBin {
+		t.Errorf("backup missing/wrong, content = %q", got)
+	}
+	if got, _ := os.ReadFile(filepath.Join(fix.dir, "web", "index.html")); string(got) != "NEW-WEB" {
+		t.Errorf("web not swapped, content = %q", got)
+	}
+	if got, _ := os.ReadFile(filepath.Join(fix.dir, "web.bak", "index.html")); string(got) != "OLD-WEB" {
+		t.Errorf("web backup missing/wrong, content = %q", got)
+	}
+	select {
+	case exe := <-fix.reexecd:
+		if exe != fix.exe {
+			t.Errorf("re-exec'd %q, want %q", exe, fix.exe)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("re-exec never scheduled")
+	}
+}
+
+func TestApplyUnsupportedInstall(t *testing.T) {
+	old := osExecutable
+	osExecutable = func() (string, error) { return "/usr/bin/unitill-pos", nil }
+	t.Cleanup(func() { osExecutable = old })
+	if err := Apply(context.Background()); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("Apply on a .deb install = %v, want ErrUnsupported", err)
+	}
+}
+
+func TestSupportedFalseWhenExecutableUnknown(t *testing.T) {
+	old := osExecutable
+	osExecutable = func() (string, error) { return "", errors.New("boom") }
+	t.Cleanup(func() { osExecutable = old })
+	if Supported() {
+		t.Fatal("Supported() = true with an unlocatable executable")
+	}
+}
+
+func TestApplyAlreadyLatest(t *testing.T) {
+	newInstallFixture(t)
+	newReleaseServer(t, "v0.1.0", map[string][]byte{}) // same as buildinfo.Version pinned by fixture
+	err := Apply(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "already on the latest") {
+		t.Fatalf("err = %v, want already-on-latest", err)
+	}
+}
+
+func TestApplyNoArchiveForPlatform(t *testing.T) {
+	fix := newInstallFixture(t)
+	newReleaseServer(t, "v0.2.0", map[string][]byte{"something-else.zip": []byte("x")})
+	err := Apply(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "no release archive") {
+		t.Fatalf("err = %v, want no-release-archive", err)
+	}
+	if got, _ := os.ReadFile(fix.exe); string(got) != fix.oldBin {
+		t.Errorf("binary touched on failed update: %q", got)
+	}
+}
+
+// SECURITY: a release with no checksums.txt must abort, not silently install an
+// unverified archive. Every real release ships checksums.txt (.goreleaser.yaml
+// name_template), so a missing one only ever means a broken or tampered release.
+func TestApplyRefusesReleaseWithoutChecksums(t *testing.T) {
+	fix := newInstallFixture(t)
+	name := archiveNameFor("0.2.0")
+	archive := makeTarGz(t, []tarEntry{{name: "unitill-pos", body: "NEW-BINARY-v2"}})
+	newReleaseServer(t, "v0.2.0", map[string][]byte{name: archive}) // no checksums.txt
+	err := Apply(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "checksums.txt") {
+		t.Fatalf("err = %v, want refusal over missing checksums.txt", err)
+	}
+	if got, _ := os.ReadFile(fix.exe); string(got) != fix.oldBin {
+		t.Errorf("unverified archive was installed: %q", got)
+	}
+}
+
+func TestApplyDownloadFailureAborts(t *testing.T) {
+	fix := newInstallFixture(t)
+	name := archiveNameFor("0.2.0")
+	// Archive listed in the release but 404s on download (nil body).
+	newReleaseServer(t, "v0.2.0", map[string][]byte{
+		name:            nil,
+		"checksums.txt": []byte("irrelevant"),
+	})
+	err := Apply(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "download") {
+		t.Fatalf("err = %v, want download failure", err)
+	}
+	if got, _ := os.ReadFile(fix.exe); string(got) != fix.oldBin {
+		t.Errorf("binary touched on failed download: %q", got)
+	}
+}
+
+func TestApplyChecksumMismatchAborts(t *testing.T) {
+	fix := newInstallFixture(t)
+	name := archiveNameFor("0.2.0")
+	archive := makeTarGz(t, []tarEntry{{name: "unitill-pos", body: "NEW-BINARY-v2"}})
+	newReleaseServer(t, "v0.2.0", map[string][]byte{
+		name:            archive,
+		"checksums.txt": []byte(strings.Repeat("0", 64) + "  " + name + "\n"),
+	})
+	err := Apply(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("err = %v, want checksum mismatch", err)
+	}
+	if got, _ := os.ReadFile(fix.exe); string(got) != fix.oldBin {
+		t.Errorf("binary touched after checksum mismatch: %q", got)
+	}
+	if _, err := os.Stat(fix.exe + ".bak"); !os.IsNotExist(err) {
+		t.Errorf(".bak created before verification passed: %v", err)
+	}
+}
+
+func TestApplyArchiveMissingBinary(t *testing.T) {
+	fix := newInstallFixture(t)
+	name := archiveNameFor("0.2.0")
+	archive := makeTarGz(t, []tarEntry{{name: "web", dir: true}, {name: "web/index.html", body: "W"}})
+	newReleaseServer(t, "v0.2.0", map[string][]byte{
+		name:            archive,
+		"checksums.txt": []byte(sha256hex(archive) + "  " + name + "\n"),
+	})
+	err := Apply(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "update archive missing") {
+		t.Fatalf("err = %v, want archive-missing-binary", err)
+	}
+	if got, _ := os.ReadFile(fix.exe); string(got) != fix.oldBin {
+		t.Errorf("binary touched: %q", got)
+	}
+}
+
+func TestApplyBackupFailureLeavesBinary(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; read-only dir does not block rename")
+	}
+	fix := newInstallFixture(t)
+	name := archiveNameFor("0.2.0")
+	archive := makeTarGz(t, []tarEntry{{name: "unitill-pos", body: "NEW-BINARY-v2"}})
+	newReleaseServer(t, "v0.2.0", map[string][]byte{
+		name:            archive,
+		"checksums.txt": []byte(sha256hex(archive) + "  " + name + "\n"),
+	})
+	if err := os.Chmod(fix.dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(fix.dir, 0o755) })
+	err := Apply(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "back up current binary") {
+		t.Fatalf("err = %v, want backup failure", err)
+	}
+	if got, _ := os.ReadFile(fix.exe); string(got) != fix.oldBin {
+		t.Errorf("binary changed despite backup failure: %q", got)
+	}
+}
+
+// fetchLatest error branches ------------------------------------------------
+
+func TestFetchLatestHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	t.Cleanup(srv.Close)
+	old := releasesLatest
+	releasesLatest = srv.URL
+	t.Cleanup(func() { releasesLatest = old })
+	_, err := fetchLatest(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "HTTP 502") {
+		t.Fatalf("err = %v, want HTTP 502", err)
+	}
+}
+
+func TestFetchLatestBadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("{nope"))
+	}))
+	t.Cleanup(srv.Close)
+	old := releasesLatest
+	releasesLatest = srv.URL
+	t.Cleanup(func() { releasesLatest = old })
+	if _, err := fetchLatest(context.Background()); err == nil {
+		t.Fatal("want decode error, got nil")
+	}
+}
+
+// Helper units ---------------------------------------------------------------
+
+func TestDownload(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ok" {
+			w.Write([]byte("payload"))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	dst := filepath.Join(t.TempDir(), "f")
+	if err := download(context.Background(), srv.URL+"/ok", dst); err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if got, _ := os.ReadFile(dst); string(got) != "payload" {
+		t.Errorf("downloaded %q", got)
+	}
+	if err := download(context.Background(), srv.URL+"/missing", dst); err == nil || !strings.Contains(err.Error(), "HTTP 404") {
+		t.Errorf("err = %v, want HTTP 404", err)
+	}
+}
+
+func TestChecksumFor(t *testing.T) {
+	body := "ABCDEF0123  unitill-pos_0.2.0_linux_amd64.tar.gz\nmalformed line\ndeadbeef  other.tar.gz\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	got, err := checksumFor(context.Background(), srv.URL, "unitill-pos_0.2.0_linux_amd64.tar.gz")
+	if err != nil {
+		t.Fatalf("checksumFor: %v", err)
+	}
+	if got != "abcdef0123" { // lowercased
+		t.Errorf("checksum = %q", got)
+	}
+	if _, err := checksumFor(context.Background(), srv.URL, "absent.tar.gz"); err == nil || !strings.Contains(err.Error(), "checksum not found") {
+		t.Errorf("err = %v, want not-found", err)
+	}
+}
+
+func TestVerifySHA256(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "f")
+	if err := os.WriteFile(p, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	want := sha256hex([]byte("hello"))
+	if err := verifySHA256(p, want); err != nil {
+		t.Errorf("matching checksum rejected: %v", err)
+	}
+	if err := verifySHA256(p, strings.Repeat("0", 64)); err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Errorf("err = %v, want mismatch", err)
+	}
+	if err := verifySHA256(filepath.Join(t.TempDir(), "absent"), want); err == nil {
+		t.Error("missing file accepted")
+	}
+}
+
+func TestExtractTarGz(t *testing.T) {
+	dst := t.TempDir()
+	src := filepath.Join(t.TempDir(), "a.tar.gz")
+	archive := makeTarGz(t, []tarEntry{
+		{name: "bin", body: "B"},
+		{name: "web", dir: true},
+		{name: "web/x.css", body: "C", mode: 0o644},
+	})
+	if err := os.WriteFile(src, archive, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := extractTarGz(src, dst); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if got, _ := os.ReadFile(filepath.Join(dst, "web", "x.css")); string(got) != "C" {
+		t.Errorf("extracted %q", got)
+	}
+}
+
+func TestExtractTarGzRejectsTraversal(t *testing.T) {
+	dst := t.TempDir()
+	src := filepath.Join(t.TempDir(), "evil.tar.gz")
+	archive := makeTarGz(t, []tarEntry{{name: "../evil", body: "X"}})
+	if err := os.WriteFile(src, archive, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := extractTarGz(src, dst)
+	if err == nil || !strings.Contains(err.Error(), "unsafe path") {
+		t.Fatalf("err = %v, want unsafe-path rejection", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(filepath.Dir(dst), "evil")); statErr == nil {
+		t.Error("traversal file was written outside dst")
+	}
+}
+
+func TestExtractTarGzBadGzip(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "junk.tar.gz")
+	if err := os.WriteFile(src, []byte("not gzip at all"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := extractTarGz(src, t.TempDir()); err == nil {
+		t.Fatal("garbage input accepted")
+	}
+	if err := extractTarGz(filepath.Join(t.TempDir(), "absent"), t.TempDir()); err == nil {
+		t.Fatal("missing input accepted")
+	}
+}
+
+// An entry larger than the extraction cap must fail loudly, not silently
+// truncate — a truncated binary would pass the swap and brick the install
+// (the archive checksum is verified, the EXTRACTED files are not).
+func TestExtractTarGzRejectsOversizeEntry(t *testing.T) {
+	oldLimit := extractLimit
+	extractLimit = 16
+	t.Cleanup(func() { extractLimit = oldLimit })
+	dst := t.TempDir()
+	src := filepath.Join(t.TempDir(), "big.tar.gz")
+	archive := makeTarGz(t, []tarEntry{{name: "bin", body: strings.Repeat("A", 64)}})
+	if err := os.WriteFile(src, archive, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := extractTarGz(src, dst)
+	if err == nil {
+		got, _ := os.ReadFile(filepath.Join(dst, "bin"))
+		t.Fatalf("oversize entry extracted silently truncated to %d bytes, want error", len(got))
+	}
+}
+
+func TestMoveFileErrors(t *testing.T) {
+	if err := moveFile(filepath.Join(t.TempDir(), "absent"), filepath.Join(t.TempDir(), "dst")); err == nil {
+		t.Error("moving a missing file succeeded")
+	}
+	src := filepath.Join(t.TempDir(), "src")
+	if err := os.WriteFile(src, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// dst parent missing: rename fails, and so must the copy fallback.
+	if err := moveFile(src, filepath.Join(t.TempDir(), "no", "such", "dir", "dst")); err == nil {
+		t.Error("move into a missing directory succeeded")
+	}
+}
+
+func TestMoveDirErrors(t *testing.T) {
+	if err := moveDir(filepath.Join(t.TempDir(), "absent"), filepath.Join(t.TempDir(), "dst")); err == nil {
+		t.Error("moving a missing dir succeeded")
+	}
+}

--- a/internal/updates/updates.go
+++ b/internal/updates/updates.go
@@ -17,7 +17,9 @@ import (
 	"github.com/universaltill/universal-till/internal/buildinfo"
 )
 
-const releasesURL = "https://api.github.com/repos/universaltill/universal-till/releases/latest"
+// releasesURL is a var (not const) purely as a test seam: tests point it at a
+// local httptest server so no test ever talks to the real GitHub API.
+var releasesURL = "https://api.github.com/repos/universaltill/universal-till/releases/latest"
 
 // Status is the latest known release info.
 type Status struct {
@@ -48,10 +50,8 @@ func CheckNow(ctx context.Context) Status {
 // Start launches the background checker: once ~30s after boot, then daily.
 // Set UT_UPDATE_CHECK=0 to disable (e.g. air-gapped tills).
 func Start(ctx context.Context) {
-	if v := os.Getenv("UT_UPDATE_CHECK"); v != "" {
-		if on, err := strconv.ParseBool(v); err == nil && !on {
-			return
-		}
+	if !enabledFromEnv() {
+		return
 	}
 	go func() {
 		select {
@@ -71,6 +71,18 @@ func Start(ctx context.Context) {
 			}
 		}
 	}()
+}
+
+// enabledFromEnv reports whether the background checker should run at all:
+// only an explicit falsy UT_UPDATE_CHECK (e.g. "0", "false") disables it;
+// unset, truthy, or unparseable values leave it enabled.
+func enabledFromEnv() bool {
+	if v := os.Getenv("UT_UPDATE_CHECK"); v != "" {
+		if on, err := strconv.ParseBool(v); err == nil && !on {
+			return false
+		}
+	}
+	return true
 }
 
 func checkOnce(ctx context.Context) {

--- a/internal/updates/updates_test.go
+++ b/internal/updates/updates_test.go
@@ -1,6 +1,150 @@
 package updates
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/buildinfo"
+)
+
+// These tests share package-level state (the atomic status, the seam vars, the
+// build version) — none of them may use t.Parallel.
+
+// withCheckServer points releasesURL at a local httptest server and pins
+// buildinfo.Version, restoring both afterward. No test ever talks to the real
+// GitHub API.
+func withCheckServer(t *testing.T, version string, handler http.HandlerFunc) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	oldURL, oldVer := releasesURL, buildinfo.Version
+	releasesURL = srv.URL
+	buildinfo.Version = version
+	t.Cleanup(func() {
+		releasesURL = oldURL
+		buildinfo.Version = oldVer
+		srv.Close()
+	})
+}
+
+func resetState(t *testing.T) {
+	t.Helper()
+	state.Store(Status{})
+	t.Cleanup(func() { state.Store(Status{}) })
+}
+
+func TestCurrentZeroBeforeFirstCheck(t *testing.T) {
+	resetState(t)
+	if got := Current(); got != (Status{}) {
+		t.Fatalf("Current() before any check = %+v, want zero", got)
+	}
+}
+
+func TestCheckNowNewerRelease(t *testing.T) {
+	resetState(t)
+	withCheckServer(t, "0.1.2", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Accept"); got != "application/vnd.github+json" {
+			t.Errorf("Accept header = %q", got)
+		}
+		w.Write([]byte(`{"tag_name":"v0.2.0","html_url":"https://example.test/rel"}`))
+	})
+	got := CheckNow(context.Background())
+	want := Status{Available: true, Latest: "0.2.0", URL: "https://example.test/rel"}
+	if got != want {
+		t.Fatalf("CheckNow = %+v, want %+v", got, want)
+	}
+	if Current() != want {
+		t.Fatalf("Current after check = %+v, want %+v", Current(), want)
+	}
+}
+
+func TestCheckNowSameVersionNotAvailable(t *testing.T) {
+	resetState(t)
+	withCheckServer(t, "0.2.0", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"tag_name":"v0.2.0","html_url":"u"}`))
+	})
+	got := CheckNow(context.Background())
+	if got.Available {
+		t.Fatalf("same version reported Available: %+v", got)
+	}
+	if got.Latest != "0.2.0" {
+		t.Fatalf("Latest = %q, want 0.2.0", got.Latest)
+	}
+}
+
+// A failed check must leave the previously known status in place.
+func TestCheckFailuresLeaveStateUntouched(t *testing.T) {
+	prior := Status{Available: true, Latest: "9.9.9", URL: "prior"}
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{"http error", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusForbidden) }},
+		{"bad json", func(w http.ResponseWriter, r *http.Request) { w.Write([]byte("{not json")) }},
+		{"empty tag", func(w http.ResponseWriter, r *http.Request) { w.Write([]byte(`{"tag_name":"  ","html_url":"u"}`)) }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			resetState(t)
+			state.Store(prior)
+			withCheckServer(t, "0.1.0", c.handler)
+			if got := CheckNow(context.Background()); got != prior {
+				t.Fatalf("failed check overwrote state: %+v, want %+v", got, prior)
+			}
+		})
+	}
+}
+
+func TestCheckOnceUnreachableServer(t *testing.T) {
+	resetState(t)
+	// A server that is already closed → connection refused, state untouched.
+	srv := httptest.NewServer(http.NotFoundHandler())
+	srv.Close()
+	old := releasesURL
+	releasesURL = srv.URL
+	t.Cleanup(func() { releasesURL = old })
+	if got := CheckNow(context.Background()); got != (Status{}) {
+		t.Fatalf("unreachable server changed state: %+v", got)
+	}
+}
+
+func TestEnabledFromEnv(t *testing.T) {
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"", true}, // unset/empty → enabled
+		{"0", false},
+		{"false", false},
+		{"FALSE", false},
+		{"1", true},
+		{"true", true},
+		{"garbage", true}, // unparseable → enabled (documented: only explicit falsy disables)
+	}
+	for _, c := range cases {
+		t.Run("val="+c.val, func(t *testing.T) {
+			t.Setenv("UT_UPDATE_CHECK", c.val)
+			if got := enabledFromEnv(); got != c.want {
+				t.Errorf("enabledFromEnv() with %q = %v, want %v", c.val, got, c.want)
+			}
+		})
+	}
+}
+
+// Start with checks disabled must return without spawning the checker; with an
+// already-cancelled context the boot-wait goroutine exits on ctx.Done. Neither
+// timer branch (30s boot wait elapsing, 24h ticker) is exercisable in a unit
+// test without a fake clock — deliberately left uncovered rather than faked.
+func TestStartDisabledAndCancelled(t *testing.T) {
+	t.Setenv("UT_UPDATE_CHECK", "0")
+	Start(context.Background()) // must be a no-op
+
+	t.Setenv("UT_UPDATE_CHECK", "1")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	Start(ctx) // goroutine sees ctx.Done and returns
+}
 
 func TestNewer(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
Coverage batch 2 of the test-coverage push (QUEUE.md 🟡 remainder item).

- `internal/updates` 29.6% → **82.5%**, `internal/selfupdate` 5.0% → **76.3%** (darwin-measured; Linux CI excludes `macapp_darwin.go`).
- All tests hermetic: local `httptest` only (proven behind a dead proxy), the running binary is never swapped (stubbed `osExecutable`), re-exec stubbed (real one is `syscall.Exec`), macOS updater helper never executes.
- **Two real bugs found TDD-first and fixed:** fail-open checksum skip when a release lacks `checksums.txt`; silent 512MB truncation in `extractTarGz` that could swap in a corrupt binary.
- Independent different-model review (opus): **SAFE TO MERGE, no blocking findings** — re-proved both red/green arcs itself; 7/7 mutation probes caught. Record: `docs/code-reviews/2026-07-30-coverage-selfupdate-updates.md`.
- Honestly-untestable remainder (reexec `syscall.Exec`, post-download mac OS-glue, timer loop bodies) documented per-file in the review record, not faked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkpbKKWW8MMDFKtJCP1Xtj