### PR TITLE
test: cover internal/ui (26.7%->96.4%); fix Designer quoted-name add + barcode-less search 500

### DIFF
--- a/docs/code-reviews/2026-07-30-coverage-internal-ui.md
+++ b/docs/code-reviews/2026-07-30-coverage-internal-ui.md
@@ -1,0 +1,113 @@
+# Code review — coverage batch 4: `internal/ui` (26.7% → 96.4%)
+
+- **Date**: 2026-07-30
+- **Branch/PR**: `test/coverage-internal-ui`
+- **Author**: SDLC pipeline (fable), cycle 10
+- **Independent reviewer**: different model (opus), full re-verification
+- **Verdict**: **SAFE TO MERGE — no MUST-FIX or SHOULD-FIX findings**
+
+## Scope
+
+Fourth batch of the [QUEUE.md] test-coverage push. `internal/ui`
+(basket/journal view constructors, the shortcut-button store + HTTP
+handlers, the price-resolver adapter — all on the live sale screen and
+Designer paths) from 26.7% to **96.4%** of statements. All new tests
+hermetic: in-memory sqlite, embedded templates, `httptest` recorders;
+suite passes with `HTTP(S)_PROXY` poisoned to a dead port; `-race`
+clean; all 5 CI guards green.
+
+**Batch-pick honesty note**: the other named target,
+`internal/plugins/storage` (39.3%), was inspected first and found to be
+**dead code** — `CacheStore` has zero importers (the live download path
+is `internal/plugins/download_manager.go` + `installer_store.go`, with
+their own `.part` handling). Driving dead code to a high number would
+be coverage theater, so it was skipped and logged in QUEUE.md as its
+own decide-remove-vs-wire item (pairs with the plugin_api
+ghost-install decision).
+
+## Real bugs found TDD-first (both medium)
+
+1. **Designer add-button broke for any item name containing a double
+   quote.** `web/ui/partials/buttons_admin.html` interpolated raw
+   name/barcode/image fields into a JSON literal inside the `hx-vals`
+   attribute. `html/template` escapes `"` as `&#34;`; the browser
+   decodes that back to a literal `"` inside the JSON string before
+   htmx calls `JSON.parse` — invalid JSON, so tapping the search
+   result silently posted no fields and the add failed with 400.
+   Proven red first (`internal/pages/buttons_search_vals_test.go`
+   decodes entities then JSON-parses, exactly what browser+htmx do;
+   observed: `invalid character 'B' after object key:value pair` on
+   `{"label":"5" Blade",…}`). Fixed by marshaling server-side
+   (`ui.SearchResult.AddVals()`) and templating `hx-vals='{{ .AddVals }}'`.
+2. **Designer search 500'd whenever any matching item had no barcode**
+   (loose produce, services). `POSRepo.SearchItemsForShortcuts`
+   scanned a nullable barcode subquery into a plain `string` —
+   observed red: `Scan error on column index 2, name "barcode":
+   converting NULL to string is unsupported`, which failed the WHOLE
+   result set, surfacing as a 500 from `/api/buttons/search`. Fixed
+   with `COALESCE(…, '')` in `internal/data/pos_repo.go` (repository
+   layer — the only place SQL may change, per repo rules).
+
+## Also shipped
+
+- Removed dead unexported helpers `currentPrice`/`deref`/`nullIfEmpty`
+  from `internal/ui/buttons.go` (zero callers, compiler-verified;
+  `data`'s own `nullIfEmpty` is a separate copy, untouched).
+- `ButtonStore.Save` pinned by test and noted as having **no
+  production caller** today (the Designer adds/removes/reorders one
+  button at a time).
+
+## Tester false-pass hardening (mutation probes)
+
+Author probes, all caught: modifier-flag map keyed wrong (`b.Code`
+instead of `b.ItemID`) → caught; image-normalization dropped → caught;
+`AddVals` marshaling the wrong field → caught at BOTH the unit and the
+endpoint layer; `COALESCE` reverted → caught. (First modifier-flag
+probe variant hit a compile error, not a test — re-run with a
+compiling mutation before counting it.)
+
+## Independent review (different model, opus) — what it verified
+
+- **Re-proved both TDD arcs itself** by isolated reverts: exact
+  claimed failure modes reproduced, then green on restore.
+- **3 fresh mutation probes, 3/3 caught**: `AddVals` label→barcode
+  swap; `ORDER BY ib.is_primary DESC→ASC` (primary-barcode preference);
+  resolver `Qty: 1→2`.
+- **Validated the honesty disclosure**: collapsed the resolver's rungs
+  1–3 entirely — all tests still pass, confirming the 4-rung wrapper
+  chain in `PriceResolverAdapter.Resolve` is behaviorally redundant
+  over `POSRepo.ResolveShortcutLine`'s own internal fallthrough (an
+  accurate author disclosure, not a hidden coverage gap).
+- Re-ran build/vet/tests/`-race`/poisoned-proxy/guards independently;
+  confirmed template change has no other consumers and no e2e spec
+  covers the designer search flow; money-type usage in tests correct.
+
+### Reviewer findings (both NITPICK, non-blocking, logged to QUEUE.md)
+
+1. **Same latent hx-vals pattern in sibling templates** —
+   `catalog_variants.html`, `suggestions.html`, `self_order_grid.html`,
+   `basket.html` still interpolate raw fields into `hx-vals` JSON
+   literals (low real risk: codes/SKUs, not free-text names). Backlog:
+   apply the same server-side-marshal pattern.
+2. **Redundant resolver rung chain** — refactor candidate, deliberately
+   not restructured inside a coverage batch.
+
+## Honestly-untestable remainder (documented, not faked)
+
+- `Resolve` rungs 3–4 success returns: structurally unreachable — every
+  repo hit carries a non-empty `ItemID` (all queries `JOIN items`), so
+  rungs 1–2 always claim a hit first. No fake fixture with an `''`
+  item id was written to force them.
+- `Load`'s swallowed `ItemIDsWithModifiers` error (`hasMods, _ =`): a
+  DB failure silently renders tiles without the customize flag —
+  noted; behavior choice predates this batch.
+
+## Adjacent findings logged to QUEUE.md (not chased here)
+
+- `internal/plugins/storage` dead package (above).
+- `/api/buttons/search` writes a hardcoded English hint string
+  (`"Type 3+ characters"`) from Go — invisible to `guard-i18n.sh`,
+  which only scans templates/locales; Go-side string audit is a
+  guard-gap follow-up.
+- Barcode-less items are now searchable but still un-addable as tiles
+  (`shortcut_buttons` is barcode-keyed; Add requires a code) — UX gap.

--- a/docs/code-reviews/2026-07-30-coverage-internal-ui.md
+++ b/docs/code-reviews/2026-07-30-coverage-internal-ui.md
@@ -102,6 +102,41 @@ compiling mutation before counting it.)
   DB failure silently renders tiles without the customize flag —
   noted; behavior choice predates this batch.
 
+## Addendum — third real bug, found by the PR's own CI gate (medium)
+
+After the main review, the PR's playwright job failed **twice,
+deterministically**, on `settings-osk.spec.ts` + `ui-scale-basket.spec.ts`
+while main stayed green on identical runner images and the suite passed
+locally AND in a matching Linux container. Root-caused, not waved off as
+flake:
+
+- **The product bug**: the sale screen's scan input has `autofocus`; on
+  slow machines (busy CI runners — and the real field Pi) it gains focus
+  BEFORE the deferred `osk.js` attaches its `focusin` listener, and a
+  click on an already-focused input fires no focus events — so with OSK
+  forced on, the keyboard silently never appeared for the very first
+  field until focus left and came back. Empirically proven both ways:
+  on fast machines `#osk` is already open right after load (the
+  autofocus event itself lands after listener attach), which is the only
+  reason the old spec ever passed. Fixed in `web/public/osk.js`: at
+  init, catch up with `document.activeElement` (guarded by the same
+  `enabled`/`wantsOSK` conditions as the focusin handler).
+- **The cascade**: the failed OSK spec never reached its inline
+  `osk=auto` restore, so `ui-scale-basket` ran with the keyboard
+  covering its submit button and its scan click hung. Fixed by moving
+  the restore to `test.afterEach` (runs on failure too).
+- **Deterministic regression test**: new spec delays `osk.js` by 700ms
+  via `page.route` so autofocus always wins the race, then asserts the
+  keyboard appears with NO click. Proven red against unfixed osk.js
+  (exact CI failure mode), green with the fix.
+
+Independent addendum review (opus): **APPROVE ADDENDUM**, no MUST/
+SHOULD-FIX — re-proved the red/green arc itself with retries off, ran
+the full 20/20 suite, verified `show()` idempotence (double-show safe,
+`inputmode` save guarded), auto/non-touch short-circuit, kiosk/Android
+IME-suppression path unchanged, and no leftover servers. One cosmetic
+nitpick (unroute placement) accepted as-is.
+
 ## Adjacent findings logged to QUEUE.md (not chased here)
 
 - `internal/plugins/storage` dead package (above).

--- a/e2e/tests/settings-osk.spec.ts
+++ b/e2e/tests/settings-osk.spec.ts
@@ -1,22 +1,33 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { watchConsole } from './helpers';
+
+// The OSK mode is a SERVER-side setting shared by every spec on this
+// server. Restore 'auto' even when a test body fails — a failed run used
+// to leak osk=on into later specs (the open keyboard then covered the
+// scan submit button in ui-scale-basket.spec.ts and its click hung).
+async function setOskMode(page: Page, mode: string) {
+  await page.goto('/settings');
+  const osk = page.locator('form[hx-post="/api/settings/osk"] select');
+  await osk.selectOption(mode);
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/settings/osk')),
+    osk.locator('..').locator('button[type=submit]').click(),
+  ]);
+  await page.waitForEvent('load');
+}
+
+test.afterEach(async ({ page }) => {
+  await setOskMode(page, 'auto');
+});
 
 // Farshid's field report: "still don't see the on-screen keyboard". Auto
 // hides it on non-touch (this browser) BY DESIGN; forcing On in settings
 // must make the real keyboard appear when an input focuses.
 test('forcing the OSK on shows a real keyboard', async ({ page }) => {
   const assertClean = watchConsole(page);
-  await page.goto('/settings');
-  const osk = page.locator('form[hx-post="/api/settings/osk"] select');
-  await osk.selectOption('on');
-  // The form's after-request hook does window.location.reload(); wait for
-  // the POST *and then* the reload's load event, or the next goto races the
-  // reload and aborts (flaked on CI).
-  await Promise.all([
-    page.waitForResponse((r) => r.url().includes('/api/settings/osk')),
-    osk.locator('..').locator('button[type=submit]').click(),
-  ]);
-  await page.waitForEvent('load');
+  // setOskMode waits for the POST *and then* the reload's load event, or
+  // the next goto races the reload and aborts (flaked on CI).
+  await setOskMode(page, 'on');
 
   await page.goto('/');
   await expect(page.locator('body')).toHaveAttribute('data-osk', 'on');
@@ -28,15 +39,29 @@ test('forcing the OSK on shows a real keyboard', async ({ page }) => {
   await page.locator('#osk button[data-k="1"]').click();
   await expect(page.getByRole('textbox').first()).toHaveValue('1');
 
-  // Restore auto so later specs aren't covered by the keyboard (server-side
-  // setting shared by the whole suite).
-  await page.goto('/settings');
-  const osk2 = page.locator('form[hx-post="/api/settings/osk"] select');
-  await osk2.selectOption('auto');
-  await Promise.all([
-    page.waitForResponse((r) => r.url().includes('/api/settings/osk')),
-    osk2.locator('..').locator('button[type=submit]').click(),
-  ]);
-  await page.waitForEvent('load');
+  assertClean();
+});
+
+// Regression: the sale screen's scan input has `autofocus`, and on slow
+// devices (the real Pi, busy CI runners) it gains focus BEFORE the
+// deferred osk.js attaches its focusin listener — so no focusin ever
+// fires for it and the forced-on keyboard silently never appeared until
+// focus left and came back. Reproduced deterministically here by delaying
+// osk.js so autofocus always wins the race; osk.js must catch up with the
+// already-focused element at init.
+test('the OSK still appears when the autofocused field wins the load race', async ({ page }) => {
+  const assertClean = watchConsole(page);
+  await setOskMode(page, 'on');
+
+  await page.route('**/osk.js*', async (route) => {
+    await new Promise((r) => setTimeout(r, 700)); // autofocus fires well before this
+    await route.continue();
+  });
+  await page.goto('/');
+  await expect(page.locator('body')).toHaveAttribute('data-osk', 'on');
+  // No click, no refocus — the autofocused scan field alone must be enough.
+  await expect(page.locator('#osk')).toBeVisible();
+  await expect(page.locator('#osk .osk-key').first()).toBeVisible();
+  await page.unroute('**/osk.js*');
   assertClean();
 });

--- a/internal/data/pos_repo.go
+++ b/internal/data/pos_repo.go
@@ -2688,13 +2688,13 @@ func (r *POSRepo) SearchItemsForShortcuts(ctx context.Context, q string, offset,
 	rows, err := r.db.QueryContext(ctx, `
 SELECT i.id,
        i.name,
-       (
+       COALESCE((
          SELECT ib.barcode
          FROM item_barcodes ib
          WHERE ib.item_id = i.id
          ORDER BY ib.is_primary DESC
          LIMIT 1
-       ) AS barcode,
+       ), '') AS barcode,
        COALESCE(img.path, '')
 FROM items i
 LEFT JOIN item_images img ON img.item_id = i.id AND img.role = 'thumbnail'

--- a/internal/pages/buttons_search_vals_test.go
+++ b/internal/pages/buttons_search_vals_test.go
@@ -1,0 +1,53 @@
+package pages
+
+import (
+	"encoding/json"
+	"html"
+	"net/url"
+	"regexp"
+	"testing"
+)
+
+// hxValsRe extracts the hx-vals attribute the Designer's search results
+// carry — htmx parses that attribute's value with JSON.parse before
+// posting it to /api/buttons/add.
+var hxValsRe = regexp.MustCompile(`hx-vals='([^']*)'`)
+
+// TestButtonsSearchHxValsSurvivesQuotedNames guards the add-as-button flow
+// for items whose name (or barcode/image path) contains a double quote:
+// the template interpolates the raw name into a JSON literal inside an
+// HTML attribute, html/template escapes `"` as `&#34;`, and the browser
+// decodes that back to a literal `"` INSIDE the JSON string before htmx
+// calls JSON.parse — invalid JSON, so tapping the search result silently
+// posts no fields and the add fails with 400. The assertion below does
+// exactly what the browser+htmx do: decode HTML entities, then JSON-parse.
+func TestButtonsSearchHxValsSurvivesQuotedNames(t *testing.T) {
+	mux, d := newButtonsMux(t)
+
+	if _, err := d.Db.Exec(`INSERT INTO items(id, sku, name, base_price, is_active) VALUES('itmq','BLADE5','5" Blade', 700, 1)`); err != nil {
+		t.Fatalf("seed quoted item: %v", err)
+	}
+	if _, err := d.Db.Exec(`INSERT INTO item_barcodes(barcode, item_id, is_primary) VALUES('QB123','itmq',1)`); err != nil {
+		t.Fatalf("seed barcode: %v", err)
+	}
+
+	rec := postForm(mux, "/api/buttons/search", url.Values{"q": {"Blade"}}, nil)
+	if rec.Code != 200 {
+		t.Fatalf("search = %d (%s)", rec.Code, rec.Body.String())
+	}
+	m := hxValsRe.FindStringSubmatch(rec.Body.String())
+	if m == nil {
+		t.Fatalf("no hx-vals attribute in search results: %s", rec.Body.String())
+	}
+	decoded := html.UnescapeString(m[1]) // what the browser hands htmx
+	var vals map[string]string
+	if err := json.Unmarshal([]byte(decoded), &vals); err != nil {
+		t.Fatalf("hx-vals is not valid JSON after browser decoding (htmx JSON.parse would fail, add-button breaks for quoted names): %v\nattr: %s", err, decoded)
+	}
+	if vals["label"] != `5" Blade` {
+		t.Fatalf("label = %q, want %q", vals["label"], `5" Blade`)
+	}
+	if vals["itemId"] != "itmq" || vals["code"] != "QB123" {
+		t.Fatalf("unexpected vals: %#v", vals)
+	}
+}

--- a/internal/ui/buttons.go
+++ b/internal/ui/buttons.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"html/template"
 	"net/http"
@@ -70,6 +71,22 @@ type SearchResult struct {
 	Name    string
 	Barcode string
 	Image   string
+}
+
+// AddVals returns the JSON payload the Designer's search-result button
+// posts to /api/buttons/add (htmx parses the hx-vals attribute with
+// JSON.parse). Marshaled server-side so a name/barcode/path containing a
+// double quote or backslash survives the HTML-attribute round trip —
+// interpolating the raw fields into a JSON literal inside the template
+// produced invalid JSON for any quoted name, silently breaking add.
+func (r SearchResult) AddVals() string {
+	b, _ := json.Marshal(map[string]string{
+		"label":    r.Name,
+		"code":     r.Barcode,
+		"itemId":   r.ItemID,
+		"imageUrl": r.Image,
+	})
+	return string(b)
 }
 
 // SearchItems finds items (and primary barcodes) to add as shortcuts.
@@ -327,25 +344,3 @@ func (a PriceResolverAdapter) resolve(ctx context.Context, code string) (pos.Bas
 	return line, true
 }
 
-func (s *ButtonStore) currentPrice(ctx context.Context, itemID *string, variantID *string, fallback int64) int64 {
-	// Unused after repo move; kept for interface compatibility if needed.
-	price, err := s.posRepo.ResolveCurrentPrice(ctx, deref(itemID), deref(variantID))
-	if err != nil {
-		return fallback
-	}
-	return price
-}
-
-func deref(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
-}
-
-func nullIfEmpty(s string) any {
-	if strings.TrimSpace(s) == "" {
-		return nil
-	}
-	return s
-}

--- a/internal/ui/buttons_http_test.go
+++ b/internal/ui/buttons_http_test.go
@@ -1,0 +1,177 @@
+package ui
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/httpx"
+)
+
+// newButtonsHTTP wires ButtonsHTTP exactly as internal/pages does: the
+// real embedded templates via NewRenderer, the real store over sqlite.
+func newButtonsHTTP(t *testing.T, partial string) (*ButtonsHTTP, *ButtonStore) {
+	t.Helper()
+	db := setupFullTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	store := NewButtonStore(db)
+	renderer, err := NewRenderer(
+		filepath.Join("web", "ui", "layouts", "base.html"),
+		filepath.Join("web", "ui", "pages", "index.html"),
+		filepath.Join("web", "ui", "partials", partial),
+		httpx.FuncsFor("en"),
+	)
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	mustExec(t, db, `INSERT INTO items(id, sku, name, base_price, is_active) VALUES('i1','S1','Coffee', 350, 1)`)
+	return &ButtonsHTTP{Store: *store, View: renderer}, store
+}
+
+func TestButtonsHTTPList_RendersTiles(t *testing.T) {
+	h, store := newButtonsHTTP(t, "buttons.html")
+	if err := store.Add(Button{Label: "Coffee Tile", Code: "C1", ItemID: "i1"}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest("GET", "/ui/buttons", nil))
+	if rec.Code != 200 {
+		t.Fatalf("List = %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "Coffee Tile") {
+		t.Fatalf("rendered fragment missing tile label: %s", rec.Body.String())
+	}
+}
+
+func TestButtonsHTTPAdd_NormalizesImageAndRendersGrid(t *testing.T) {
+	h, store := newButtonsHTTP(t, "buttons_admin.html")
+
+	cases := []struct {
+		in, want string
+	}{
+		{"coffee.png", "/public/images/coffee.png"},                // bare filename -> local images folder
+		{"/public/uploads/c.png", "/public/uploads/c.png"},         // already public path, untouched
+		{"https://cdn.example/c.png", "https://cdn.example/c.png"}, // absolute URL, untouched
+	}
+	for i, tc := range cases {
+		form := url.Values{"label": {"Coffee"}, "code": {"C" + string(rune('1'+i))}, "itemId": {"i1"}, "imageUrl": {tc.in}}
+		req := httptest.NewRequest("POST", "/api/buttons/add", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		rec := httptest.NewRecorder()
+		h.Add(rec, req)
+		if rec.Code != 200 {
+			t.Fatalf("Add(%q) = %d (%s)", tc.in, rec.Code, rec.Body.String())
+		}
+		if !strings.Contains(rec.Body.String(), "buttons-grid-admin") {
+			t.Fatalf("Add did not re-render admin grid: %s", rec.Body.String())
+		}
+	}
+	btns, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(btns) != len(cases) {
+		t.Fatalf("buttons = %d, want %d", len(btns), len(cases))
+	}
+	got := map[string]string{}
+	for _, b := range btns {
+		got[b.Code] = b.ImageURL
+	}
+	for i, tc := range cases {
+		code := "C" + string(rune('1'+i))
+		if got[code] != tc.want {
+			t.Fatalf("image for %s = %q, want %q", code, got[code], tc.want)
+		}
+	}
+}
+
+func TestButtonsHTTPAdd_ErrorPaths(t *testing.T) {
+	h, _ := newButtonsHTTP(t, "buttons_admin.html")
+
+	// Store validation error -> 400 (missing itemId).
+	form := url.Values{"label": {"X"}, "code": {"C9"}}
+	req := httptest.NewRequest("POST", "/api/buttons/add", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	h.Add(rec, req)
+	if rec.Code != 400 {
+		t.Fatalf("Add missing fields = %d, want 400", rec.Code)
+	}
+
+	// Malformed percent-encoding -> ParseForm error -> 400.
+	req = httptest.NewRequest("POST", "/api/buttons/add", strings.NewReader("label=%zz"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec = httptest.NewRecorder()
+	h.Add(rec, req)
+	if rec.Code != 400 {
+		t.Fatalf("Add bad form = %d, want 400", rec.Code)
+	}
+}
+
+func TestButtonsHTTPRemove_DeletesAndRerenders(t *testing.T) {
+	h, store := newButtonsHTTP(t, "buttons_admin.html")
+	if err := store.Add(Button{Label: "Coffee", Code: "C1", ItemID: "i1"}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	form := url.Values{"code": {"C1"}}
+	req := httptest.NewRequest("POST", "/api/buttons/remove", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	h.Remove(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("Remove = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if btns, _ := store.Load(); len(btns) != 0 {
+		t.Fatalf("button not removed: %+v", btns)
+	}
+
+	// Malformed body -> 400.
+	req = httptest.NewRequest("POST", "/api/buttons/remove", strings.NewReader("code=%zz"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec = httptest.NewRecorder()
+	h.Remove(rec, req)
+	if rec.Code != 400 {
+		t.Fatalf("Remove bad form = %d, want 400", rec.Code)
+	}
+}
+
+func TestButtonsHTTPRemove_StoreErrorIs400(t *testing.T) {
+	db := setupFullTestDB(t)
+	store := NewButtonStore(db)
+	renderer, err := NewRenderer(
+		filepath.Join("web", "ui", "layouts", "base.html"),
+		filepath.Join("web", "ui", "pages", "index.html"),
+		filepath.Join("web", "ui", "partials", "buttons_admin.html"),
+		httpx.FuncsFor("en"),
+	)
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	h := &ButtonsHTTP{Store: *store, View: renderer}
+	db.Close() // repo delete will fail
+
+	form := url.Values{"code": {"C1"}}
+	req := httptest.NewRequest("POST", "/api/buttons/remove", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	h.Remove(rec, req)
+	if rec.Code != 400 {
+		t.Fatalf("Remove with failing store = %d, want 400", rec.Code)
+	}
+}
+
+func TestNewRenderer_ErrorOnMissingTemplate(t *testing.T) {
+	_, err := NewRenderer(
+		filepath.Join("web", "ui", "layouts", "base.html"),
+		filepath.Join("web", "ui", "pages", "does-not-exist.html"),
+		filepath.Join("web", "ui", "partials", "buttons.html"),
+		httpx.FuncsFor("en"),
+	)
+	if err == nil {
+		t.Fatalf("expected error for missing template")
+	}
+}

--- a/internal/ui/buttons_store_test.go
+++ b/internal/ui/buttons_store_test.go
@@ -1,0 +1,275 @@
+package ui
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+)
+
+// setupFullTestDB extends the base schema with the variant + modifier
+// tables the resolver chain and Load's modifier flag actually query.
+func setupFullTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db := setupTestDB(t)
+	stmts := []string{
+		`CREATE TABLE item_variants (id TEXT PRIMARY KEY, item_id TEXT NOT NULL, name TEXT, price INTEGER NOT NULL, is_active INTEGER NOT NULL DEFAULT 1);`,
+		`CREATE TABLE item_modifier_groups (id TEXT PRIMARY KEY, item_id TEXT NOT NULL, name TEXT, is_active INTEGER NOT NULL DEFAULT 1);`,
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("setup stmt failed: %v", err)
+		}
+	}
+	return db
+}
+
+func TestToVM_MapsAllFieldsAndEmptyInput(t *testing.T) {
+	in := []Button{{
+		Label:        "Coffee",
+		Code:         "C1",
+		ItemID:       "itm1",
+		ImageURL:     "/public/images/coffee.png",
+		Price:        350,
+		HasModifiers: true,
+	}}
+	out := ToVM(in)
+	if len(out) != 1 {
+		t.Fatalf("len = %d, want 1", len(out))
+	}
+	got := out[0]
+	if got.Label != "Coffee" || got.Code != "C1" || got.ItemID != "itm1" ||
+		got.ImageURL != "/public/images/coffee.png" || got.Price != 350 || !got.HasModifiers {
+		t.Fatalf("unexpected VM: %+v", got)
+	}
+
+	empty := ToVM(nil)
+	if empty == nil || len(empty) != 0 {
+		t.Fatalf("ToVM(nil) = %#v, want empty non-nil slice", empty)
+	}
+}
+
+// TestSearchResultAddVals pins the server-side hx-vals payload: it must be
+// valid JSON even when fields contain quotes/backslashes (the template used
+// to interpolate raw fields into a JSON literal, which broke JSON.parse in
+// the Designer for any quoted item name).
+func TestSearchResultAddVals_QuotesAndBackslashesSurvive(t *testing.T) {
+	r := SearchResult{ItemID: "i1", Name: `5" Blade \ "special"`, Barcode: `B"1`, Image: `img"x.png`}
+	var vals map[string]string
+	if err := json.Unmarshal([]byte(r.AddVals()), &vals); err != nil {
+		t.Fatalf("AddVals not valid JSON: %v (%s)", err, r.AddVals())
+	}
+	if vals["label"] != r.Name || vals["code"] != r.Barcode || vals["itemId"] != "i1" || vals["imageUrl"] != r.Image {
+		t.Fatalf("unexpected vals: %#v", vals)
+	}
+}
+
+func TestButtonStoreLoad_ThumbnailFallbackPriceOrderAndModifiers(t *testing.T) {
+	db := setupFullTestDB(t)
+	defer db.Close()
+
+	mustExec(t, db, `INSERT INTO items(id, sku, name, base_price, is_active) VALUES('itm1','SKU1','Coffee', 350, 1)`)
+	mustExec(t, db, `INSERT INTO items(id, sku, name, base_price, is_active) VALUES('itm2','SKU2','Tea', 250, 1)`)
+	// itm1 has no explicit button image but a catalog thumbnail -> fallback.
+	mustExec(t, db, `INSERT INTO item_images(id, item_id, role, path) VALUES('img1','itm1','thumbnail','/public/images/coffee.png')`)
+	// itm1 is customizable (active modifier group); itm2 has only an INACTIVE group.
+	mustExec(t, db, `INSERT INTO item_modifier_groups(id, item_id, name, is_active) VALUES('g1','itm1','Milk',1)`)
+	mustExec(t, db, `INSERT INTO item_modifier_groups(id, item_id, name, is_active) VALUES('g2','itm2','Old',0)`)
+	// Deliberately inserted out of display order: sort_order must win.
+	mustExec(t, db, `INSERT INTO shortcut_buttons(barcode,label,item_id,image_path,sort_order) VALUES('T1','Tea Tile','itm2','/public/images/tea-explicit.png',0)`)
+	mustExec(t, db, `INSERT INTO shortcut_buttons(barcode,label,item_id,image_path,sort_order) VALUES('C1','Coffee Tile','itm1',NULL,1)`)
+
+	store := NewButtonStore(db)
+	btns, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(btns) != 2 {
+		t.Fatalf("len = %d, want 2", len(btns))
+	}
+	tea, coffee := btns[0], btns[1]
+	if tea.Label != "Tea Tile" || coffee.Label != "Coffee Tile" {
+		t.Fatalf("sort_order not honored: %+v", btns)
+	}
+	if tea.ImageURL != "/public/images/tea-explicit.png" {
+		t.Fatalf("explicit image lost: %q", tea.ImageURL)
+	}
+	if coffee.ImageURL != "/public/images/coffee.png" {
+		t.Fatalf("thumbnail fallback missing: %q", coffee.ImageURL)
+	}
+	if coffee.Price != 350 || tea.Price != 250 {
+		t.Fatalf("prices wrong: %+v", btns)
+	}
+	if !coffee.HasModifiers {
+		t.Fatalf("coffee should flag modifiers (active group)")
+	}
+	if tea.HasModifiers {
+		t.Fatalf("tea must not flag modifiers (group inactive)")
+	}
+}
+
+// Save has no production caller today (the Designer adds/removes/reorders
+// one button at a time) — this pins its replace-all contract so wiring it
+// up later doesn't inherit surprises.
+func TestButtonStoreSave_ReplacesAllAndPersistsOrder(t *testing.T) {
+	db := setupFullTestDB(t)
+	defer db.Close()
+	store := NewButtonStore(db)
+
+	if err := store.Save([]Button{
+		{Label: "B", Code: "B1", ItemID: "i1"},
+		{Label: "A", Code: "A1", ItemID: "i2"},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	btns, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(btns) != 2 || btns[0].Code != "B1" || btns[1].Code != "A1" {
+		t.Fatalf("list order not persisted: %+v", btns)
+	}
+
+	// Second Save fully replaces, never merges.
+	if err := store.Save([]Button{{Label: "C", Code: "C1", ItemID: "i3"}}); err != nil {
+		t.Fatalf("Save replace: %v", err)
+	}
+	btns, _ = store.Load()
+	if len(btns) != 1 || btns[0].Code != "C1" {
+		t.Fatalf("Save did not replace: %+v", btns)
+	}
+}
+
+func TestButtonStoreUpdateOrderAndRemove(t *testing.T) {
+	db := setupFullTestDB(t)
+	defer db.Close()
+	store := NewButtonStore(db)
+
+	mustExec(t, db, `INSERT INTO items(id, sku, name, base_price, is_active) VALUES('i1','S1','One', 100, 1)`)
+	mustExec(t, db, `INSERT INTO items(id, sku, name, base_price, is_active) VALUES('i2','S2','Two', 200, 1)`)
+	if err := store.Add(Button{Label: "One", Code: "B1", ItemID: "i1"}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := store.Add(Button{Label: "Two", Code: "B2", ItemID: "i2"}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	if err := store.UpdateOrder(context.Background(), []string{"B2", "B1"}); err != nil {
+		t.Fatalf("UpdateOrder: %v", err)
+	}
+	btns, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(btns) != 2 || btns[0].Code != "B2" || btns[1].Code != "B1" {
+		t.Fatalf("reorder not applied: %+v", btns)
+	}
+
+	if err := store.Remove("B2"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	btns, _ = store.Load()
+	if len(btns) != 1 || btns[0].Code != "B1" {
+		t.Fatalf("remove not applied: %+v", btns)
+	}
+}
+
+func TestButtonStoreAdd_TrimsAndUpserts(t *testing.T) {
+	db := setupFullTestDB(t)
+	defer db.Close()
+	store := NewButtonStore(db)
+	mustExec(t, db, `INSERT INTO items(id, sku, name, base_price, is_active) VALUES('i1','S1','One', 100, 1)`)
+
+	if err := store.Add(Button{Label: "  Padded  ", Code: " B1 ", ItemID: " i1 "}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	btns, _ := store.Load()
+	if len(btns) != 1 || btns[0].Label != "Padded" || btns[0].Code != "B1" || btns[0].ItemID != "i1" {
+		t.Fatalf("fields not trimmed: %+v", btns)
+	}
+
+	// Same code again updates in place (repo upserts on barcode).
+	if err := store.Add(Button{Label: "Renamed", Code: "B1", ItemID: "i1"}); err != nil {
+		t.Fatalf("Add upsert: %v", err)
+	}
+	btns, _ = store.Load()
+	if len(btns) != 1 || btns[0].Label != "Renamed" {
+		t.Fatalf("upsert did not update label: %+v", btns)
+	}
+}
+
+func TestSearchItems_MatchesNameSkuBarcodeWithPaging(t *testing.T) {
+	db := setupFullTestDB(t)
+	defer db.Close()
+	store := NewButtonStore(db)
+
+	mustExec(t, db, `INSERT INTO items(id, sku, name, base_price, is_active) VALUES('i1','APL-01','Apple Juice', 100, 1)`)
+	mustExec(t, db, `INSERT INTO items(id, sku, name, base_price, is_active) VALUES('i2','ORG-01','Orange Juice', 100, 1)`)
+	mustExec(t, db, `INSERT INTO items(id, sku, name, base_price, is_active) VALUES('i3','ZZZ-01','Inactive Juice', 100, 0)`)
+	mustExec(t, db, `INSERT INTO item_barcodes(barcode, item_id, is_primary) VALUES('111','i1',0)`)
+	mustExec(t, db, `INSERT INTO item_barcodes(barcode, item_id, is_primary) VALUES('222','i1',1)`)
+	mustExec(t, db, `INSERT INTO item_images(id, item_id, role, path) VALUES('im1','i1','thumbnail','/public/images/apple.png')`)
+
+	ctx := context.Background()
+
+	// Name match; primary barcode preferred; thumbnail carried through.
+	res, err := store.SearchItems(ctx, "Apple", 0, 10)
+	if err != nil {
+		t.Fatalf("SearchItems: %v", err)
+	}
+	if len(res) != 1 || res[0].ItemID != "i1" || res[0].Barcode != "222" || res[0].Image != "/public/images/apple.png" {
+		t.Fatalf("unexpected name-match result: %+v", res)
+	}
+
+	// SKU match — i2 deliberately has NO barcode rows: an item without a
+	// barcode (loose produce, services) must still be searchable, with an
+	// empty barcode, not fail the whole result set with a NULL-scan error.
+	res, err = store.SearchItems(ctx, "ORG-01", 0, 10)
+	if err != nil {
+		t.Fatalf("sku search errored (barcode-less item broke the scan): %v", err)
+	}
+	if len(res) != 1 || res[0].ItemID != "i2" || res[0].Barcode != "" {
+		t.Fatalf("sku match failed: %+v", res)
+	}
+	if res, _ = store.SearchItems(ctx, "111", 0, 10); len(res) != 1 || res[0].ItemID != "i1" {
+		t.Fatalf("barcode match failed: %+v", res)
+	}
+
+	// Inactive items are never offered.
+	if res, _ = store.SearchItems(ctx, "Inactive", 0, 10); len(res) != 0 {
+		t.Fatalf("inactive item leaked: %+v", res)
+	}
+
+	// Paging: "Juice" matches both active items; page size 1, offset walks.
+	if res, _ = store.SearchItems(ctx, "Juice", 0, 1); len(res) != 1 || res[0].Name != "Apple Juice" {
+		t.Fatalf("page 1 wrong: %+v", res)
+	}
+	if res, _ = store.SearchItems(ctx, "Juice", 1, 1); len(res) != 1 || res[0].Name != "Orange Juice" {
+		t.Fatalf("page 2 wrong: %+v", res)
+	}
+}
+
+func TestSearchItems_ErrorSurfaces(t *testing.T) {
+	db := setupFullTestDB(t)
+	store := NewButtonStore(db)
+	db.Close() // force the query to fail
+	if _, err := store.SearchItems(context.Background(), "anything", 0, 10); err == nil {
+		t.Fatalf("expected error from closed DB")
+	}
+}
+
+func TestLoad_ErrorSurfaces(t *testing.T) {
+	db := setupFullTestDB(t)
+	store := NewButtonStore(db)
+	db.Close()
+	if _, err := store.Load(); err == nil {
+		t.Fatalf("expected error from closed DB")
+	}
+}
+
+func mustExec(t *testing.T, db *sql.DB, q string, args ...any) {
+	t.Helper()
+	if _, err := db.Exec(q, args...); err != nil {
+		t.Fatalf("exec %q: %v", q, err)
+	}
+}

--- a/internal/ui/resolver_test.go
+++ b/internal/ui/resolver_test.go
@@ -1,0 +1,154 @@
+package ui
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// seedResolverFixture builds a small catalog exercising every rung of the
+// resolver fallthrough: a variant barcode, an item barcode, a
+// shortcut-only barcode, a SKU, and a name.
+func seedResolverFixture(t *testing.T) (*ButtonStore, *sql.DB) {
+	t.Helper()
+	db := setupFullTestDB(t)
+	t.Cleanup(func() { db.Close() })
+
+	mustExec(t, db, `INSERT INTO tax_codes(id, rate_basis_points) VALUES('tax-std', 2000)`)
+	mustExec(t, db, `INSERT INTO items(id, sku, name, base_price, tax_code_id, is_active, is_weighed) VALUES('itm-cof','COF-SKU','Coffee', 300, 'tax-std', 1, 0)`)
+	mustExec(t, db, `INSERT INTO items(id, sku, name, base_price, is_active, is_weighed) VALUES('itm-ban','BAN-SKU','Bananas', 89, 1, 1)`)
+	mustExec(t, db, `INSERT INTO item_images(id, item_id, role, path) VALUES('img-cof','itm-cof','thumbnail','/public/images/coffee.png')`)
+
+	// Variant: Coffee -> Large, own barcode + own price.
+	mustExec(t, db, `INSERT INTO item_variants(id, item_id, name, price, is_active) VALUES('var-lg','itm-cof','Large', 400, 1)`)
+	mustExec(t, db, `INSERT INTO variant_barcodes(barcode, variant_id, is_primary) VALUES('VB-1','var-lg',1)`)
+
+	// Item barcode for Coffee itself.
+	mustExec(t, db, `INSERT INTO item_barcodes(barcode, item_id, is_primary) VALUES('IB-1','itm-cof',1)`)
+
+	// Shortcut-only barcode (a Designer tile code that is NOT a real
+	// item/variant barcode) pointing at Bananas, with a label override.
+	mustExec(t, db, `INSERT INTO shortcut_buttons(barcode,label,item_id,sort_order) VALUES('SC-1','Loose Bananas','itm-ban',0)`)
+
+	return NewButtonStore(db), db
+}
+
+func TestResolve_VariantBarcode(t *testing.T) {
+	store, _ := seedResolverFixture(t)
+	r := PriceResolverAdapter{Store: store}
+
+	line, ok := r.Resolve("VB-1")
+	if !ok {
+		t.Fatalf("variant barcode did not resolve")
+	}
+	if line.VariantID != "var-lg" || line.ItemID != "itm-cof" {
+		t.Fatalf("unexpected ids: %+v", line)
+	}
+	if line.Name != "Coffee - Large" {
+		t.Fatalf("variant name = %q, want \"Coffee - Large\"", line.Name)
+	}
+	if line.PriceCents.Minor() != 400 {
+		t.Fatalf("variant price = %d, want 400", line.PriceCents.Minor())
+	}
+	if line.TaxRateBP != 2000 || line.TaxCodeID != "tax-std" {
+		t.Fatalf("tax not carried: %+v", line)
+	}
+	if line.ImageURL != "/public/images/coffee.png" {
+		t.Fatalf("image not carried: %q", line.ImageURL)
+	}
+	if line.Qty != 1 {
+		t.Fatalf("qty = %v, want 1", line.Qty)
+	}
+}
+
+func TestResolve_ItemBarcode(t *testing.T) {
+	store, _ := seedResolverFixture(t)
+	r := PriceResolverAdapter{Store: store}
+
+	line, ok := r.Resolve("IB-1")
+	if !ok {
+		t.Fatalf("item barcode did not resolve")
+	}
+	if line.ItemID != "itm-cof" || line.VariantID != "" {
+		t.Fatalf("unexpected ids: %+v", line)
+	}
+	if line.PriceCents.Minor() != 300 || line.Name != "Coffee" {
+		t.Fatalf("unexpected line: %+v", line)
+	}
+}
+
+func TestResolve_ShortcutBarcodeUsesLabelAndWeighedFlag(t *testing.T) {
+	store, _ := seedResolverFixture(t)
+	r := PriceResolverAdapter{Store: store}
+
+	line, ok := r.Resolve("SC-1")
+	if !ok {
+		t.Fatalf("shortcut barcode did not resolve")
+	}
+	if line.ItemID != "itm-ban" {
+		t.Fatalf("unexpected item: %+v", line)
+	}
+	if line.Name != "Loose Bananas" {
+		t.Fatalf("shortcut label override lost: %q", line.Name)
+	}
+	if !line.IsWeighed {
+		t.Fatalf("weighed flag lost: %+v", line)
+	}
+	if line.PriceCents.Minor() != 89 {
+		t.Fatalf("price = %d, want 89", line.PriceCents.Minor())
+	}
+}
+
+func TestResolve_SKUAndNameFallback(t *testing.T) {
+	store, _ := seedResolverFixture(t)
+	r := PriceResolverAdapter{Store: store}
+
+	// SKU exact.
+	line, ok := r.Resolve("BAN-SKU")
+	if !ok || line.ItemID != "itm-ban" {
+		t.Fatalf("sku resolve failed: ok=%v line=%+v", ok, line)
+	}
+
+	// Name substring (cashier types part of the name).
+	line, ok = r.Resolve("Banan")
+	if !ok || line.ItemID != "itm-ban" {
+		t.Fatalf("name resolve failed: ok=%v line=%+v", ok, line)
+	}
+}
+
+func TestResolve_PriceHistoryOverridesBase(t *testing.T) {
+	store, db := seedResolverFixture(t)
+	mustExec(t, db, `INSERT INTO price_history(id, item_id, price, starts_at) VALUES('ph1','itm-cof', 275, datetime('now','-1 hour'))`)
+	r := PriceResolverAdapter{Store: store}
+
+	line, ok := r.Resolve("IB-1")
+	if !ok {
+		t.Fatalf("resolve failed")
+	}
+	if line.PriceCents.Minor() != 275 {
+		t.Fatalf("price = %d, want current history price 275", line.PriceCents.Minor())
+	}
+}
+
+func TestResolve_MissAndEmpty(t *testing.T) {
+	store, _ := seedResolverFixture(t)
+	r := PriceResolverAdapter{Store: store}
+
+	if _, ok := r.Resolve("no-such-code"); ok {
+		t.Fatalf("expected miss for unknown code")
+	}
+	if _, ok := r.Resolve("   "); ok {
+		t.Fatalf("expected miss for blank code")
+	}
+}
+
+func TestResolve_InactiveItemDoesNotResolve(t *testing.T) {
+	store, db := seedResolverFixture(t)
+	mustExec(t, db, `UPDATE items SET is_active = 0 WHERE id = 'itm-ban'`)
+	r := PriceResolverAdapter{Store: store}
+
+	for _, code := range []string{"SC-1", "BAN-SKU", "Banan"} {
+		if _, ok := r.Resolve(code); ok {
+			t.Fatalf("inactive item resolved via %q", code)
+		}
+	}
+}

--- a/web/public/osk.js
+++ b/web/public/osk.js
@@ -228,4 +228,15 @@
       if (!wantsOSK(a) && (!osk || !osk.contains(a))) hide();
     }, 50);
   });
+
+  // An autofocused field (the sale screen's scan input) can gain focus
+  // BEFORE this deferred script attaches its focusin listener — on slow
+  // devices (the real Pi) the parser focuses it long before osk.js
+  // evaluates, so no focusin ever fires for it and the keyboard never
+  // appears until focus leaves and comes back. Catch up with the current
+  // focus state at init, mirroring exactly what the focusin handler would
+  // have done.
+  if (enabled && wantsOSK(document.activeElement)) {
+    show(document.activeElement);
+  }
 })();

--- a/web/ui/partials/buttons_admin.html
+++ b/web/ui/partials/buttons_admin.html
@@ -115,7 +115,7 @@ htmx.on('body', 'htmx:afterRequest', function(evt) {
             hx-post="/api/buttons/add"
             hx-target="#buttons-grid-admin"
             hx-swap="outerHTML"
-            hx-vals='{"label":"{{ .Name }}","code":"{{ .Barcode }}","itemId":"{{ .ItemID }}","imageUrl":"{{ .Image }}"}'
+            hx-vals='{{ .AddVals }}'
             hx-on="htmx:afterRequest: document.getElementById('search-results').style.display='none'">
       {{ if .Image }}<img class="thumb" src="{{ .Image }}" alt="{{ .Name }}" />{{ end }}
       <span class="text">


### PR DESCRIPTION
Coverage batch 4 of the test-coverage push (QUEUE.md). `internal/ui` 26.7% -> **96.4%** of statements, hermetic (-race clean, poisoned-proxy proven, all 5 CI guards green).

**Two real bugs found TDD-first (both medium), proven red before fix:**
1. Designer add-button broke for any item name containing a double quote — the template interpolated raw fields into an `hx-vals` JSON literal; `&#34;` round-trips to a literal quote and htmx's JSON.parse fails. Fixed with server-side marshaling (`SearchResult.AddVals`).
2. Designer search 500'd when any matching item had no barcode (NULL scanned into string). `COALESCE` fix in the repository layer.

Also removed dead unexported helpers from `internal/ui` and skipped the other candidate package `internal/plugins/storage` after finding it is entirely dead code (logged in QUEUE.md as its own decision item — no coverage theater).

Independent different-model review (opus): **SAFE TO MERGE**, no blocking findings — both TDD arcs re-proven by isolated revert, 3 fresh mutation probes 3/3 caught, hermeticity re-verified. Record: `docs/code-reviews/2026-07-30-coverage-internal-ui.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkpbKKWW8MMDFKtJCP1Xtj