### PR TITLE
test: cover internal/pages/catalog (53.3%->98%); fix item cost ignoring 0-decimal currencies

### DIFF
--- a/docs/code-reviews/2026-07-30-coverage-pages-catalog.md
+++ b/docs/code-reviews/2026-07-30-coverage-pages-catalog.md
@@ -1,0 +1,127 @@
+# Code review — coverage batch 6: `internal/pages/catalog` (2026-07-30)
+
+**Branch:** `coverage/pages-catalog` · **Scope:** test-coverage push batch 6
+(`ut-docs/QUEUE.md`, "Test-coverage push, remainder").
+**Coverage:** 53.3% → **98.0%** of statements.
+**Reviewer:** independent different-model review (opus subagent), author =
+pipeline dev (fable). **Verdict: SAFE TO MERGE — no blocking findings, no
+should-fix findings.**
+
+## What changed
+
+- 4 new test files: `cost_currency_test.go`, `lookup_endpoints_test.go`,
+  `handlers_coverage_test.go`, `handlers_errors_test.go` — httptest through
+  the real mux, real minimal-schema sqlite per test, DB-state assertions
+  after every mutation (not status-code-only).
+- Production changes, deliberately minimal:
+  - **Real bug fix (medium), TDD-first** — see below.
+  - A test seam: `var newLookupClient = func() *productlookup.Client`
+    replacing the inline construction in `Register`, so tests point the
+    barcode-lookup endpoints at hermetic httptest sources. Production
+    behavior identical; every test override restores via `t.Cleanup`
+    (reviewer grep-verified no leak).
+  - Removed the then-unused `fmt` import.
+  - `web/ui/partials/catalog_variants.html`: cost input `step`/`placeholder`
+    made currency-decimals-aware, matching its sibling price fields.
+
+## The real bug (medium): item cost-price ignored 0-decimal currencies
+
+`POST /api/catalog/item-cost` converted major→minor with a hardcoded
+`*100`, the variants panel rendered minor→major with a hardcoded
+`/100` + `%.2f`, and the template hardcoded `step="0.01"` — all wrong for
+0-decimal currencies (IRR/IRT/IQD/AFN/JPY, all in `httpx.currencies`;
+Iran is an explicit target market). A rial shop entering a 650,000-rial
+cost stored **65,000,000** — margin report 100× wrong — and a stored cost
+rendered back 100× too small. The modifier-option handler in the same
+file had already fixed exactly this class (its comment spells out the
+reasoning); the cost field predated that fix.
+
+**TDD arc, proven red first** (author, then re-proven by the reviewer via
+isolated revert of only the fix hunks):
+- `TestItemCost_RespectsZeroDecimalCurrency_OnSave` → red:
+  `want cost_price 650000, got 65000000`.
+- `TestItemCost_RespectsZeroDecimalCurrency_OnDisplay` → red: panel showed
+  `value="6500.00"` and `step="0.01"`.
+- `TestItemCost_TwoDecimalCurrencyRoundTrip` (GBP control) — green in BOTH
+  states (reviewer-confirmed), i.e. it guards the common path rather than
+  merely tracking the bug.
+
+Fix mirrors the established pattern:
+`httpx.CurrencyByCode(d.CurrentState().Currency).Decimals` with
+`math.Pow(10, decimals)` both directions; display via
+`strconv.FormatFloat(..., 'f', decimals, 64)`.
+
+## Hermeticity — proven, not claimed
+
+- Whole package suite passes with `HTTP_PROXY`/`HTTPS_PROXY` poisoned to
+  `http://127.0.0.1:9` and under `-race` (author and reviewer both ran it).
+- Barcode-lookup tests use httptest sources through the new seam;
+  lookup-image tests exercise the **real** `FetchImage` SSRF allowlist via
+  a stub `http.RoundTripper` for `https://images.openfoodfacts.org` — the
+  allowlist check runs before the transport is consulted, and the
+  disallowed-host case asserts the transport is never reached.
+- The lookup endpoint's audit trail is asserted for real (hit + miss rows
+  in `audit_log`, `found` flag correct) — the handler swallows audit
+  errors, so the test schema grows the table locally to observe them.
+
+## False-pass audit
+
+- Author probes (4/4 caught): variant-wins-over-item clearing removed in
+  the barcode handler; `IsActive` filter dropped from variant-options;
+  audit `found` hardcoded true; `saveLookupImage` call skipped.
+- Reviewer's own fresh probes (4/4 caught): `formCheckboxActive` forced
+  true; create-handler barcode-attach error swallowed; `hx-swap-oob`
+  injection dropped; variant handler's multi-value `isActive` scan reduced
+  to first-value-only.
+
+## Honestly-untestable remainder (documented, not faked)
+
+- `os.Create`/`png.Encode` error branches on just-created files/dirs in
+  both image-upload handlers and `saveLookupImage` — would require
+  faulting a path `MkdirAll` just succeeded on; not reachable hermetically
+  (the *MkdirAll* failures themselves ARE covered, via a file squatting on
+  the directory path).
+- `bufResponseWriter.WriteHeader` reads 0.0% because it is an empty-body
+  no-op (zero statements — cover display artifact); the contract test does
+  call it.
+
+## Gate
+
+`go build ./...` ✓ · `go vet ./...` ✓ · full `go test ./...` exit 0 ✓ ·
+all 5 `scripts/ci/guard-*.sh` ✓ · Playwright e2e 20/20 ✓ (author ran the
+full suite; reviewer verified harness enumeration — 20 tests in 9 files —
+and judged a re-run unwarranted for a backend-scoped change, stated
+honestly). No leftover test servers (checked ports/process list).
+
+## Resumed-session re-verification (2026-07-30, pre-commit)
+
+The pipeline session that produced this batch (and the review above) died
+before commit. The resuming session did **not** take the above on faith:
+
+- **Second independent different-model review (opus subagent), run fresh**:
+  SAFE TO MERGE, zero blocking / zero should-fix. It re-ran build/vet, the
+  package suite (98.0% confirmed), hermeticity (poisoned proxy + `-race`,
+  3.4s, clean), `guard-data-access` + `guard-i18n`, and 3 mutation probes of
+  its own (save-path `*100` re-hardcode, display-path `/100` re-hardcode,
+  audit `found` forced true) — all 3 caught by DB/behavior assertions, tree
+  restored byte-identical. Its nits: the `InitCurrency` cleanup restores a
+  hardcoded `"GBP"` rather than the prior value (safe today — serial tests,
+  GBP default; noted for the future), and the "Coca-Cola"/`5449000000996`
+  fixture is the canonical Open Food Facts sample, not a client name.
+- **TDD arc re-proven a second time** by the resuming session itself, in an
+  isolated tree copy: fix hunks reverted → `OnSave` red (`want cost_price
+  650000, got 65000000`), `OnDisplay` red (`value="6500.00"`,
+  `step="0.01"`), GBP control green in the broken state; restored → all
+  green.
+- Full gate re-run at commit time: `go build ./...` ✓ · `go vet ./...` ✓ ·
+  full `go test ./...` exit 0 ✓ · all 5 guards ✓.
+
+## Reviewer nitpicks (recorded, no action)
+
+- Cost value formats from `d.CurrentState().Currency` while the template
+  `step` reads the process-global `ActiveCurrency` — a pre-existing
+  dual-source pattern shared by every sibling field; production keeps the
+  two in sync via `httpx.InitCurrency`.
+- Cost threads as raw `int64` minor units at the DB boundary rather than
+  `money.Money`, matching the existing modifier-option handler —
+  pre-existing, out of scope for a coverage batch.

--- a/internal/pages/catalog/cost_currency_test.go
+++ b/internal/pages/catalog/cost_currency_test.go
@@ -1,0 +1,142 @@
+package catalog
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/httpx"
+	"github.com/universaltill/universal-till/internal/pages/common"
+	"github.com/universaltill/universal-till/internal/testsupport"
+)
+
+// The item cost-price field ("what the shop pays", feeds the margin report)
+// is entered in the shop's display currency, exactly like modifier-option
+// price deltas — and must honor the currency's minor-unit exponent the same
+// way. A 0-decimal currency (IRR/IRT/IQD/AFN/JPY, all supported — see
+// httpx.currencies) has no subdivision at all: 1 major = 1 minor. A
+// hardcoded *100 stores every cost 100x too high for those shops, and the
+// panel's hardcoded /100 "%.2f" then displays a stored cost 100x too low —
+// the margin report would be garbage either way. The modifier-option
+// handler in this same file already fixed exactly this class of bug; the
+// cost field predates that fix.
+func TestItemCost_RespectsZeroDecimalCurrency_OnSave(t *testing.T) {
+	chdirToRepoRoot(t)
+	db := setupCatalogPageDB(t)
+	defer db.Close()
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "RICE", Name: "Basmati 5kg", BasePrice: 900000, IsActive: true})
+
+	mux := http.NewServeMux()
+	Register(mux, &common.Deps{Db: db, State: common.RuntimeState{Theme: "default", Currency: "IRR"}, Menu: []common.MenuItem{}})
+
+	form := "panelItem=itm1&cost=650000"
+	req := httptest.NewRequest(http.MethodPost, "/api/catalog/item-cost", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var minor int64
+	if err := db.QueryRow(`SELECT cost_price FROM items WHERE id = 'itm1'`).Scan(&minor); err != nil {
+		t.Fatal(err)
+	}
+	if minor != 650000 {
+		t.Fatalf("IRR has 0 decimals (1 major = 1 minor): want cost_price 650000, got %d (looks like a hardcoded *100 was applied)", minor)
+	}
+}
+
+func TestItemCost_RespectsZeroDecimalCurrency_OnDisplay(t *testing.T) {
+	chdirToRepoRoot(t)
+	// The {{ currency }} template func reads the process-global currency
+	// (kept in sync with settings via httpx.InitCurrency in production —
+	// see internal/pages/init.go), so the template-side assertions need it
+	// set too, not just Deps.State.Currency.
+	httpx.InitCurrency("IRR")
+	t.Cleanup(func() { httpx.InitCurrency("GBP") })
+	db := setupCatalogPageDB(t)
+	defer db.Close()
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "RICE", Name: "Basmati 5kg", BasePrice: 900000, IsActive: true})
+	if _, err := db.Exec(`UPDATE items SET cost_price = 650000 WHERE id = 'itm1'`); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	Register(mux, &common.Deps{Db: db, State: common.RuntimeState{Theme: "default", Currency: "IRR"}, Menu: []common.MenuItem{}})
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/catalog/item-variants?item_id=itm1", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `value="650000"`) {
+		t.Fatalf("panel must show the stored 650000-rial cost as 650000 (0-decimal currency), body has: %s",
+			excerptAround(body, `name="cost"`))
+	}
+	if strings.Contains(body, `value="6500.00"`) {
+		t.Fatal("panel shows the rial cost divided by a hardcoded 100")
+	}
+	// The input's step must also follow the currency, matching the sibling
+	// variant/modifier price fields ("1" for a 0-decimal currency, "0.01"
+	// otherwise) — a step="0.01" field would let a rial shop type an
+	// impossible fractional rial.
+	if strings.Contains(body, `name="cost" step="0.01"`) {
+		t.Fatal(`cost input step is hardcoded to "0.01" for a 0-decimal currency`)
+	}
+}
+
+// Control: the 2-decimal path (the overwhelmingly common case) keeps
+// working — 12.34 GBP stores as 1234 pence and renders back as 12.34.
+func TestItemCost_TwoDecimalCurrencyRoundTrip(t *testing.T) {
+	chdirToRepoRoot(t)
+	db := setupCatalogPageDB(t)
+	defer db.Close()
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "TEA", Name: "Earl Grey", BasePrice: 300, IsActive: true})
+
+	mux := http.NewServeMux()
+	Register(mux, &common.Deps{Db: db, State: common.RuntimeState{Theme: "default", Currency: "GBP"}, Menu: []common.MenuItem{}})
+
+	form := "panelItem=itm1&cost=12.34"
+	req := httptest.NewRequest(http.MethodPost, "/api/catalog/item-cost", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var minor int64
+	if err := db.QueryRow(`SELECT cost_price FROM items WHERE id = 'itm1'`).Scan(&minor); err != nil {
+		t.Fatal(err)
+	}
+	if minor != 1234 {
+		t.Fatalf("want cost_price 1234 (12.34 GBP), got %d", minor)
+	}
+	// And it renders back in major units in the panel.
+	rec2 := httptest.NewRecorder()
+	mux.ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, "/api/catalog/item-variants?item_id=itm1", nil))
+	if !strings.Contains(rec2.Body.String(), `value="12.34"`) {
+		t.Fatalf("panel must render 1234 pence back as 12.34, body has: %s",
+			excerptAround(rec2.Body.String(), `name="cost"`))
+	}
+}
+
+// excerptAround returns a short window of s around the first occurrence of
+// marker, for readable failure messages against full-page HTML bodies.
+func excerptAround(s, marker string) string {
+	i := strings.Index(s, marker)
+	if i < 0 {
+		return "(marker " + marker + " not found)"
+	}
+	start := i - 120
+	if start < 0 {
+		start = 0
+	}
+	end := i + 200
+	if end > len(s) {
+		end = len(s)
+	}
+	return s[start:end]
+}

--- a/internal/pages/catalog/handlers.go
+++ b/internal/pages/catalog/handlers.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"image"
 	_ "image/jpeg"
 	"image/png"
@@ -29,12 +28,18 @@ import (
 	"github.com/universaltill/universal-till/internal/pos"
 )
 
+// newLookupClient is a test seam: production resolves barcodes against the
+// real Open*Facts product databases; tests swap in a client pointed at
+// hermetic httptest servers so nothing in this package can ever touch the
+// network under test.
+var newLookupClient = func() *productlookup.Client { return productlookup.NewClient(nil, nil) }
+
 // Register mounts catalog list/create and barcode attach endpoints.
 // func Register(mux *http.ServeMux, db *sql.DB, theme string, menu []map[string]string) {
 func Register(mux *http.ServeMux, d *common.Deps) {
 	repo := data.NewCatalogRepo(d.Db)
 	posRepo := data.NewPOSRepo(d.Db)
-	lookupClient := productlookup.NewClient(nil, nil)
+	lookupClient := newLookupClient()
 
 	writeJSON := func(w http.ResponseWriter, status int, data any, errMsg string) {
 		w.Header().Set("Content-Type", "application/json")
@@ -93,7 +98,11 @@ func Register(mux *http.ServeMux, d *common.Deps) {
 				cost, _ := repo.ItemCostPrice(r.Context(), itemID)
 				costMajor := ""
 				if cost > 0 {
-					costMajor = fmt.Sprintf("%.2f", float64(cost)/100)
+					// Decimal-aware, same as the modifier-option price
+					// handling below: a 0-decimal currency (IRR/JPY/…)
+					// renders whole units, never a hardcoded /100.
+					decimals := httpx.CurrencyByCode(d.CurrentState().Currency).Decimals
+					costMajor = strconv.FormatFloat(float64(cost)/math.Pow(10, float64(decimals)), 'f', decimals, 64)
 				}
 				// ADR-0020: shows deactivated groups/options too (unlike the
 				// sale-time ListGroupsForItem) so a manager can reactivate one.
@@ -165,7 +174,12 @@ func Register(mux *http.ServeMux, d *common.Deps) {
 				http.Error(w, "invalid cost", http.StatusBadRequest)
 				return
 			}
-			minor = int64(math.Round(f * 100))
+			// Decimal-aware major→minor conversion (see the identical
+			// reasoning on the modifier-option handler below): a hardcoded
+			// *100 would store every cost 100x too high for a 0-decimal
+			// currency shop and wreck the margin report.
+			decimals := httpx.CurrencyByCode(d.CurrentState().Currency).Decimals
+			minor = int64(math.Round(f * math.Pow(10, float64(decimals))))
 		}
 		if err := repo.SetItemCostPrice(r.Context(), itemID, minor); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/pages/catalog/handlers_coverage_test.go
+++ b/internal/pages/catalog/handlers_coverage_test.go
@@ -1,0 +1,496 @@
+package catalog
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/pages/common"
+	"github.com/universaltill/universal-till/internal/testsupport"
+)
+
+// newCatalogMux is the standard harness for this file: fresh minimal-schema
+// DB, fresh mux, default GBP/theme deps.
+func newCatalogMux(t *testing.T) (*http.ServeMux, *sql.DB) {
+	t.Helper()
+	chdirToRepoRoot(t)
+	db := setupCatalogPageDB(t)
+	t.Cleanup(func() { db.Close() })
+	mux := http.NewServeMux()
+	Register(mux, &common.Deps{Db: db, State: common.RuntimeState{Theme: "default"}, Menu: []common.MenuItem{}})
+	return mux, db
+}
+
+func postForm(t *testing.T, mux *http.ServeMux, path, form string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func get(t *testing.T, mux *http.ServeMux, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+	return rec
+}
+
+// Every mutation endpoint registered without a method pattern must refuse
+// non-POST — a GET reaching a mutation would let a prefetching browser or a
+// crawler on the LAN admin UI mutate the catalog.
+func TestCatalogMutationEndpoints_RejectGET(t *testing.T) {
+	mux, _ := newCatalogMux(t)
+	for _, path := range []string{
+		"/api/catalog/item",
+		"/api/catalog/item/update",
+		"/api/catalog/item/deactivate",
+		"/api/catalog/variant",
+		"/api/catalog/variant/deactivate",
+		"/api/catalog/modifier-group",
+		"/api/catalog/modifier-option",
+		"/api/catalog/barcode",
+	} {
+		rec := get(t, mux, path)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("GET %s: want 405, got %d", path, rec.Code)
+		}
+	}
+}
+
+func TestVariantOptions_ReturnsOnlyActiveVariants(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "S1", Name: "Shirt", BasePrice: 100, IsActive: true})
+	testsupport.SeedVariant(t, db, testsupport.VariantSeed{ID: "v1", ItemID: "itm1", SKU: "S1-M", Name: "Medium", Price: 100, IsActive: true})
+	testsupport.SeedVariant(t, db, testsupport.VariantSeed{ID: "v2", ItemID: "itm1", SKU: "S1-L", Name: "Large", Price: 120, IsActive: false})
+
+	rec := get(t, mux, "/api/catalog/variant-options?item_id=itm1")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var envelope struct {
+		Data []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("bad JSON: %v: %s", err, rec.Body.String())
+	}
+	if len(envelope.Data) != 1 || envelope.Data[0].ID != "v1" || envelope.Data[0].Name != "Medium" {
+		t.Fatalf("want only the active variant, got %+v", envelope.Data)
+	}
+
+	// No variants: an empty array, not null — the picker iterates it.
+	rec2 := get(t, mux, "/api/catalog/variant-options?item_id=absent")
+	if !strings.Contains(rec2.Body.String(), `"data":[]`) {
+		t.Fatalf("want empty array for unknown item, got %s", rec2.Body.String())
+	}
+}
+
+func TestVariantOptions_RepoErrorIs500(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	if _, err := db.Exec(`DROP TABLE item_variants`); err != nil {
+		t.Fatal(err)
+	}
+	rec := get(t, mux, "/api/catalog/variant-options?item_id=itm1")
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestItemCost_ValidationAndClear(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "S1", Name: "Tea", BasePrice: 100, IsActive: true})
+
+	if rec := postForm(t, mux, "/api/catalog/item-cost", "cost=1.00"); rec.Code != http.StatusBadRequest {
+		t.Errorf("missing item: want 400, got %d", rec.Code)
+	}
+	for _, bad := range []string{"abc", "-1"} {
+		if rec := postForm(t, mux, "/api/catalog/item-cost", "panelItem=itm1&cost="+bad); rec.Code != http.StatusBadRequest {
+			t.Errorf("cost=%q: want 400, got %d", bad, rec.Code)
+		}
+	}
+
+	// Set then clear: an empty cost stores 0 ("unknown"), the margin report's
+	// no-data sentinel, and must succeed.
+	if rec := postForm(t, mux, "/api/catalog/item-cost", "panelItem=itm1&cost=2.50"); rec.Code != http.StatusOK {
+		t.Fatalf("set: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec := postForm(t, mux, "/api/catalog/item-cost", "panelItem=itm1&cost="); rec.Code != http.StatusOK {
+		t.Fatalf("clear: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var minor int64
+	if err := db.QueryRow(`SELECT cost_price FROM items WHERE id = 'itm1'`).Scan(&minor); err != nil {
+		t.Fatal(err)
+	}
+	if minor != 0 {
+		t.Fatalf("clearing the field must store 0, got %d", minor)
+	}
+}
+
+func TestItemCost_RepoErrorIs500(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	if _, err := db.Exec(`DROP TABLE items`); err != nil {
+		t.Fatal(err)
+	}
+	if rec := postForm(t, mux, "/api/catalog/item-cost", "panelItem=itm1&cost=1.00"); rec.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestItemCreate_InputValidation(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedCategory(t, db, "cat1", "Drinks", true)
+
+	cases := []struct {
+		name, form, wantErr string
+	}{
+		{"missing name", "price=100", "name and price required"},
+		{"missing price", "name=Tea", "name and price required"},
+		{"non-integer price", "name=Tea&price=1.99", "invalid price"},
+		{"unknown category", "name=Tea&price=100&categoryId=nope", "invalid categories id"},
+		{"unknown brand", "name=Tea&price=100&brandId=nope", "invalid brands id"},
+		{"unknown tax code", "name=Tea&price=100&taxCode=nope", "invalid tax_codes id"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := postForm(t, mux, "/api/catalog/item", tc.form)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("want 400, got %d: %s", rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), tc.wantErr) {
+				t.Fatalf("want %q, got %s", tc.wantErr, rec.Body.String())
+			}
+		})
+	}
+	var n int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM items`).Scan(&n)
+	if n != 0 {
+		t.Fatalf("no item should have been created by rejected input, found %d", n)
+	}
+}
+
+// A create carrying a barcode that cannot attach (here: the item row itself
+// was created inactive, and AddBarcode refuses inactive targets) reports the
+// split outcome honestly: item created, attach failed, 400.
+func TestItemCreate_BarcodeAttachFailureIsReported(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	rec := postForm(t, mux, "/api/catalog/item", "name=Ghost&price=100&isActive=0&barcode=5000000000001")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "item created, but barcode attach failed") {
+		t.Fatalf("want the split-outcome message, got %s", rec.Body.String())
+	}
+	var n int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM items`).Scan(&n)
+	if n != 1 {
+		t.Fatalf("the item itself should still exist, found %d rows", n)
+	}
+	_ = db.QueryRow(`SELECT COUNT(*) FROM item_barcodes`).Scan(&n)
+	if n != 0 {
+		t.Fatalf("no barcode row should exist, found %d", n)
+	}
+}
+
+// parseItemInput's checkbox/flag branches, observed through the DB row a
+// real create produces.
+func TestItemCreate_WeighedFlagAndFields(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedCategory(t, db, "cat1", "Produce", true)
+	testsupport.SeedBrand(t, db, "b1", "Farm", true)
+	testsupport.SeedTaxCode(t, db, "tax0", "Zero", 0)
+
+	rec := postForm(t, mux, "/api/catalog/item",
+		"name=Loose+Apples&price=89&sku=APL&isWeighed=on&unit=kg&description=Braeburn&categoryId=cat1&brandId=b1&taxCode=tax0")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var weighed int
+	var unit, desc, cat, brand, tax string
+	if err := db.QueryRow(`SELECT is_weighed, unit, description, category_id, brand_id, tax_code_id FROM items WHERE sku = 'APL'`).
+		Scan(&weighed, &unit, &desc, &cat, &brand, &tax); err != nil {
+		t.Fatal(err)
+	}
+	if weighed != 1 || unit != "kg" || desc != "Braeburn" || cat != "cat1" || brand != "b1" || tax != "tax0" {
+		t.Fatalf("row wrong: weighed=%d unit=%q desc=%q cat=%q brand=%q tax=%q", weighed, unit, desc, cat, brand, tax)
+	}
+}
+
+func TestItemUpdate_PersistsAndValidates(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "S1", Name: "Old Name", BasePrice: 100, IsActive: true})
+	testsupport.SeedCategory(t, db, "cat1", "Drinks", true)
+
+	rec := postForm(t, mux, "/api/catalog/item/update", "id=itm1&name=New+Name&price=250&sku=S1&categoryId=cat1&isActive=1")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var name string
+	var price int64
+	var cat string
+	if err := db.QueryRow(`SELECT name, base_price, category_id FROM items WHERE id = 'itm1'`).Scan(&name, &price, &cat); err != nil {
+		t.Fatal(err)
+	}
+	if name != "New Name" || price != 250 || cat != "cat1" {
+		t.Fatalf("update not persisted: name=%q price=%d cat=%q", name, price, cat)
+	}
+
+	if rec := postForm(t, mux, "/api/catalog/item/update", "id=itm1&name=X&price=abc"); rec.Code != http.StatusBadRequest {
+		t.Errorf("invalid price: want 400, got %d", rec.Code)
+	}
+	if rec := postForm(t, mux, "/api/catalog/item/update", "id=itm1&name=X&price=100&categoryId=nope"); rec.Code != http.StatusBadRequest {
+		t.Errorf("unknown category: want 400, got %d", rec.Code)
+	}
+}
+
+func TestItemDeactivate_RequiresID(t *testing.T) {
+	mux, _ := newCatalogMux(t)
+	if rec := postForm(t, mux, "/api/catalog/item/deactivate", ""); rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", rec.Code)
+	}
+}
+
+func TestVariantCreate_WithCostAndValidation(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "S1", Name: "Coffee", BasePrice: 300, IsActive: true})
+
+	// Create through the vf-new form shape: price+cost arrive in minor units
+	// (the template's utCurrency JS converts before submit).
+	rec := postForm(t, mux, "/api/catalog/variant", "itemId=itm1&name=Large&sku=S1-L&price=350&costPrice=120&isActive=1")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var price, cost int64
+	if err := db.QueryRow(`SELECT price, cost_price FROM item_variants WHERE sku = 'S1-L'`).Scan(&price, &cost); err != nil {
+		t.Fatal(err)
+	}
+	if price != 350 || cost != 120 {
+		t.Fatalf("variant stored wrong: price=%d cost=%d", price, cost)
+	}
+
+	cases := []struct{ name, form string }{
+		{"missing itemId", "name=Large&price=350"},
+		{"missing price", "itemId=itm1&name=Large"},
+		{"non-integer price", "itemId=itm1&name=Large&price=3.50"},
+		{"non-integer costPrice", "itemId=itm1&name=Large&price=350&costPrice=1.20"},
+		{"duplicate sku", "itemId=itm1&name=Another&sku=S1-L&price=100"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if rec := postForm(t, mux, "/api/catalog/variant", tc.form); rec.Code != http.StatusBadRequest {
+				t.Fatalf("want 400, got %d: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestVariantDeactivate_PanelAndValidation(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "S1", Name: "Coffee", BasePrice: 300, IsActive: true})
+	testsupport.SeedVariant(t, db, testsupport.VariantSeed{ID: "v1", ItemID: "itm1", SKU: "S1-L", Name: "Large", Price: 350, IsActive: true})
+
+	if rec := postForm(t, mux, "/api/catalog/variant/deactivate", ""); rec.Code != http.StatusBadRequest {
+		t.Errorf("missing id: want 400, got %d", rec.Code)
+	}
+
+	// With panelItem: deactivates AND answers with the panel + oob table.
+	rec := postForm(t, mux, "/api/catalog/variant/deactivate", "id=v1&panelItem=itm1")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `id="catalog-table" hx-swap-oob="true"`) {
+		t.Fatal("panel-scoped deactivate must carry the out-of-band items table")
+	}
+	var active int
+	if err := db.QueryRow(`SELECT is_active FROM item_variants WHERE id = 'v1'`).Scan(&active); err != nil {
+		t.Fatal(err)
+	}
+	if active != 0 {
+		t.Fatalf("variant still active: %d", active)
+	}
+}
+
+func TestModifierGroup_UpdateRenameAndDeactivate(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "S1", Name: "Coffee", BasePrice: 300, IsActive: true})
+	if _, err := db.Exec(`INSERT INTO item_modifier_groups (id, item_id, name, required, min_select, max_select, sort_order, is_active) VALUES ('g1','itm1','Extras',0,0,2,1,1)`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rename + deactivate in one update (unchecked box: only the hidden 0).
+	rec := postForm(t, mux, "/api/catalog/modifier-group", "panelItem=itm1&itemId=itm1&id=g1&name=Add-ons&minSelect=0&maxSelect=2&isActive=0")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var name string
+	var active int
+	if err := db.QueryRow(`SELECT name, is_active FROM item_modifier_groups WHERE id = 'g1'`).Scan(&name, &active); err != nil {
+		t.Fatal(err)
+	}
+	if name != "Add-ons" || active != 0 {
+		t.Fatalf("group update wrong: name=%q active=%d", name, active)
+	}
+}
+
+func TestModifierGroup_Validation(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "S1", Name: "Coffee", BasePrice: 300, IsActive: true})
+
+	if rec := postForm(t, mux, "/api/catalog/modifier-group", "itemId=itm1"); rec.Code != http.StatusBadRequest {
+		t.Errorf("missing name: want 400, got %d", rec.Code)
+	}
+	if rec := postForm(t, mux, "/api/catalog/modifier-group", "name=Extras"); rec.Code != http.StatusBadRequest {
+		t.Errorf("missing itemId: want 400, got %d", rec.Code)
+	}
+
+	// A missing/garbage maxSelect falls back to 1, never 0 — a max_select of
+	// 0 would make every option unpickable at sale time.
+	rec := postForm(t, mux, "/api/catalog/modifier-group", "panelItem=itm1&itemId=itm1&name=Size&isActive=1&maxSelect=garbage")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var maxSelect int
+	if err := db.QueryRow(`SELECT max_select FROM item_modifier_groups WHERE name = 'Size'`).Scan(&maxSelect); err != nil {
+		t.Fatal(err)
+	}
+	if maxSelect != 1 {
+		t.Fatalf("want max_select fallback 1, got %d", maxSelect)
+	}
+}
+
+func TestModifierOption_Validation(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "S1", Name: "Coffee", BasePrice: 300, IsActive: true})
+	if _, err := db.Exec(`INSERT INTO item_modifier_groups (id, item_id, name, required, min_select, max_select, sort_order, is_active) VALUES ('g1','itm1','Extras',0,0,2,1,1)`); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct{ name, form string }{
+		{"missing name", "groupId=g1&itemId=itm1"},
+		{"missing groupId", "itemId=itm1&name=Shot"},
+		{"missing itemId", "groupId=g1&name=Shot"},
+		{"non-numeric priceDeltaMajor", "groupId=g1&itemId=itm1&name=Shot&priceDeltaMajor=abc"},
+		{"negative priceDeltaMajor", "groupId=g1&itemId=itm1&name=Shot&priceDeltaMajor=-0.50"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if rec := postForm(t, mux, "/api/catalog/modifier-option", tc.form); rec.Code != http.StatusBadRequest {
+				t.Fatalf("want 400, got %d: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestBarcodeAttach_VariantWinsOverItem(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "S1", Name: "Coffee", BasePrice: 300, IsActive: true})
+	testsupport.SeedVariant(t, db, testsupport.VariantSeed{ID: "v1", ItemID: "itm1", SKU: "S1-L", Name: "Large", Price: 350, IsActive: true})
+
+	// The form posts both (item row picked + variant chosen): the variant
+	// must win and no item_barcodes row may appear.
+	rec := postForm(t, mux, "/api/catalog/barcode", "barcode=5000001&itemId=itm1&variantId=v1&isPrimary=on")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var variantID string
+	var primary int
+	if err := db.QueryRow(`SELECT variant_id, is_primary FROM variant_barcodes WHERE barcode = '5000001'`).Scan(&variantID, &primary); err != nil {
+		t.Fatalf("variant barcode not attached: %v", err)
+	}
+	if variantID != "v1" || primary != 1 {
+		t.Fatalf("attached wrong: variant=%q primary=%d", variantID, primary)
+	}
+	var n int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM item_barcodes WHERE barcode = '5000001'`).Scan(&n)
+	if n != 0 {
+		t.Fatal("barcode must attach to exactly one target — item_barcodes row found too")
+	}
+}
+
+func TestBarcodeAttach_Validation(t *testing.T) {
+	mux, _ := newCatalogMux(t)
+	if rec := postForm(t, mux, "/api/catalog/barcode", "itemId=itm1"); rec.Code != http.StatusBadRequest {
+		t.Errorf("missing barcode: want 400, got %d", rec.Code)
+	}
+	// Unknown target item: the repo refuses, handler maps to 400.
+	if rec := postForm(t, mux, "/api/catalog/barcode", "barcode=5000001&itemId=ghost"); rec.Code != http.StatusBadRequest {
+		t.Errorf("unknown item: want 400, got %d", rec.Code)
+	}
+}
+
+func TestBarcodeDelete_Validation(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	if rec := postForm(t, mux, "/api/catalog/barcode/delete", ""); rec.Code != http.StatusBadRequest {
+		t.Errorf("missing barcode: want 400, got %d", rec.Code)
+	}
+	// Repo failure surfaces as 400, not a silent 200.
+	if _, err := db.Exec(`DROP TABLE variant_barcodes`); err != nil {
+		t.Fatal(err)
+	}
+	if rec := postForm(t, mux, "/api/catalog/barcode/delete", "barcode=123456"); rec.Code != http.StatusBadRequest {
+		t.Errorf("repo error: want 400, got %d", rec.Code)
+	}
+}
+
+func TestCatalogPage_RepoErrorsAre500(t *testing.T) {
+	t.Run("lookup tables missing", func(t *testing.T) {
+		mux, db := newCatalogMux(t)
+		if _, err := db.Exec(`DROP TABLE categories`); err != nil {
+			t.Fatal(err)
+		}
+		if rec := get(t, mux, "/catalog"); rec.Code != http.StatusInternalServerError {
+			t.Fatalf("want 500, got %d", rec.Code)
+		}
+	})
+	t.Run("items table missing", func(t *testing.T) {
+		mux, db := newCatalogMux(t)
+		if _, err := db.Exec(`DROP TABLE items`); err != nil {
+			t.Fatal(err)
+		}
+		if rec := get(t, mux, "/catalog"); rec.Code != http.StatusInternalServerError {
+			t.Fatalf("want 500, got %d", rec.Code)
+		}
+	})
+}
+
+// An unknown item id renders the empty panel (pick-an-item state), not an
+// error — the page loads before any row is chosen.
+func TestVariantsPanel_UnknownItemRendersEmptyState(t *testing.T) {
+	mux, _ := newCatalogMux(t)
+	rec := get(t, mux, "/api/catalog/item-variants?item_id=ghost")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "catalog-detail-grid") {
+		t.Fatal("unknown item must render the empty panel, not the detail grid")
+	}
+}
+
+// bufResponseWriter backs the out-of-band table render; it must satisfy the
+// http.ResponseWriter contract templates rely on: a non-nil, stable header
+// map, buffered writes, and a status sink that never touches the real
+// response (the outer handler already committed its own status).
+func TestBufResponseWriter_Contract(t *testing.T) {
+	var buf bytes.Buffer
+	w := newBufResponseWriter(&buf)
+	if w.Header() == nil {
+		t.Fatal("Header() must not be nil")
+	}
+	w.Header().Set("X-Probe", "1")
+	if got := w.Header().Get("X-Probe"); got != "1" {
+		t.Fatalf("header map not stable: %q", got)
+	}
+	w.WriteHeader(http.StatusTeapot) // must be a no-op, not a panic
+	if _, err := w.Write([]byte("fragment")); err != nil {
+		t.Fatal(err)
+	}
+	if buf.String() != "fragment" {
+		t.Fatalf("writes must land in the buffer, got %q", buf.String())
+	}
+}

--- a/internal/pages/catalog/handlers_errors_test.go
+++ b/internal/pages/catalog/handlers_errors_test.go
@@ -1,0 +1,302 @@
+package catalog
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/pages/common"
+	"github.com/universaltill/universal-till/internal/paths"
+	"github.com/universaltill/universal-till/internal/testsupport"
+)
+
+func TestItemCreate_DuplicateSKUIs400(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "DUP", Name: "First", BasePrice: 100, IsActive: true})
+	rec := postForm(t, mux, "/api/catalog/item", "name=Second&price=200&sku=DUP&isActive=1")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 for duplicate sku, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestItemUpdate_DuplicateSKUIs400(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "A", Name: "One", BasePrice: 100, IsActive: true})
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm2", SKU: "B", Name: "Two", BasePrice: 100, IsActive: true})
+	rec := postForm(t, mux, "/api/catalog/item/update", "id=itm2&name=Two&price=100&sku=A&isActive=1")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 for duplicate sku on update, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestItemDeactivate_RepoErrorIs400(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	if _, err := db.Exec(`DROP TABLE items`); err != nil {
+		t.Fatal(err)
+	}
+	if rec := postForm(t, mux, "/api/catalog/item/deactivate", "id=itm1"); rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", rec.Code)
+	}
+}
+
+// The variant endpoint's own checkbox-pair handling: a checked box submits
+// the hidden 0 AND the checkbox 1 (DOM order) and must read as active.
+func TestVariantUpdate_CheckedCheckboxPairReadsActive(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "S1", Name: "Coffee", BasePrice: 300, IsActive: true})
+	testsupport.SeedVariant(t, db, testsupport.VariantSeed{ID: "v1", ItemID: "itm1", SKU: "S1-L", Name: "Large", Price: 350, IsActive: false})
+
+	rec := postForm(t, mux, "/api/catalog/variant", "id=v1&itemId=itm1&name=Large&sku=S1-L&price=350&isActive=0&isActive=1")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var active int
+	if err := db.QueryRow(`SELECT is_active FROM item_variants WHERE id = 'v1'`).Scan(&active); err != nil {
+		t.Fatal(err)
+	}
+	if active != 1 {
+		t.Fatal("hidden-0-plus-checkbox-1 submission must reactivate the variant")
+	}
+}
+
+func TestVariantUpdate_DuplicateSKUIs400(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "S1", Name: "Coffee", BasePrice: 300, IsActive: true})
+	testsupport.SeedVariant(t, db, testsupport.VariantSeed{ID: "v1", ItemID: "itm1", SKU: "S1-L", Name: "Large", Price: 350, IsActive: true})
+	testsupport.SeedVariant(t, db, testsupport.VariantSeed{ID: "v2", ItemID: "itm1", SKU: "S1-M", Name: "Medium", Price: 300, IsActive: true})
+
+	rec := postForm(t, mux, "/api/catalog/variant", "id=v2&itemId=itm1&name=Medium&sku=S1-L&price=300&isActive=1")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 for duplicate variant sku, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestModifierGroupAndOption_RepoErrorsAre400(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "S1", Name: "Coffee", BasePrice: 300, IsActive: true})
+	if _, err := db.Exec(`DROP TABLE item_modifier_options`); err != nil {
+		t.Fatal(err)
+	}
+	if rec := postForm(t, mux, "/api/catalog/modifier-option", "groupId=g1&itemId=itm1&name=Shot&isActive=1"); rec.Code != http.StatusBadRequest {
+		t.Errorf("create option repo error: want 400, got %d", rec.Code)
+	}
+	if rec := postForm(t, mux, "/api/catalog/modifier-option", "id=o1&groupId=g1&itemId=itm1&name=Shot&isActive=1"); rec.Code != http.StatusBadRequest {
+		t.Errorf("update option repo error: want 400, got %d", rec.Code)
+	}
+	if _, err := db.Exec(`DROP TABLE item_modifier_groups`); err != nil {
+		t.Fatal(err)
+	}
+	if rec := postForm(t, mux, "/api/catalog/modifier-group", "itemId=itm1&name=Extras&isActive=1"); rec.Code != http.StatusBadRequest {
+		t.Errorf("create group repo error: want 400, got %d", rec.Code)
+	}
+	if rec := postForm(t, mux, "/api/catalog/modifier-group", "id=g1&itemId=itm1&name=Extras&isActive=1"); rec.Code != http.StatusBadRequest {
+		t.Errorf("update group repo error: want 400, got %d", rec.Code)
+	}
+}
+
+func TestVariantDeactivate_TableResponseAndRepoError(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "S1", Name: "Coffee", BasePrice: 300, IsActive: true})
+	testsupport.SeedVariant(t, db, testsupport.VariantSeed{ID: "v1", ItemID: "itm1", SKU: "S1-L", Name: "Large", Price: 350, IsActive: true})
+
+	// Without panelItem the response is the refreshed items table.
+	rec := postForm(t, mux, "/api/catalog/variant/deactivate", "id=v1")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `id="catalog-table"`) {
+		t.Fatal("table-scoped deactivate must answer with the items table")
+	}
+
+	if _, err := db.Exec(`DROP TABLE item_variants`); err != nil {
+		t.Fatal(err)
+	}
+	if rec := postForm(t, mux, "/api/catalog/variant/deactivate", "id=v1"); rec.Code != http.StatusBadRequest {
+		t.Fatalf("repo error: want 400, got %d", rec.Code)
+	}
+}
+
+func TestImageUploads_RejectNonMultipartBody(t *testing.T) {
+	mux, _ := newCatalogMux(t)
+	for _, path := range []string{"/api/catalog/item/image", "/api/catalog/variant/image"} {
+		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader("item_id=x"))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: want 400 for a non-multipart body, got %d", path, rec.Code)
+		}
+	}
+}
+
+func TestVariantImageUpload_Validation(t *testing.T) {
+	mux, db := imageUploadTestDeps(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "S1", Name: "Coffee", BasePrice: 300, IsActive: true})
+	testsupport.SeedVariant(t, db, testsupport.VariantSeed{ID: "v1", ItemID: "itm1", SKU: "S1-L", Name: "Large", Price: 350, IsActive: true})
+
+	send := func(fields map[string]string, filename string, fileBytes []byte) *httptest.ResponseRecorder {
+		body, ct := multipartUpload(t, fields, filename, fileBytes)
+		req := httptest.NewRequest(http.MethodPost, "/api/catalog/variant/image", body)
+		req.Header.Set("Content-Type", ct)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		return rec
+	}
+
+	if rec := send(map[string]string{"variant_id": "v1"}, "p.png", validPNG(t)); rec.Code != http.StatusBadRequest {
+		t.Errorf("missing panelItem: want 400, got %d", rec.Code)
+	}
+	if rec := send(map[string]string{"variant_id": "v1", "panelItem": "../evil"}, "p.png", validPNG(t)); rec.Code != http.StatusBadRequest {
+		t.Errorf("traversal panelItem: want 400, got %d", rec.Code)
+	}
+	if rec := send(map[string]string{"variant_id": "v1", "panelItem": "itm1"}, "", nil); rec.Code != http.StatusBadRequest {
+		t.Errorf("missing file: want 400, got %d", rec.Code)
+	}
+	if rec := send(map[string]string{"variant_id": "v1", "panelItem": "itm1"}, "n.txt", []byte("not an image")); rec.Code != http.StatusBadRequest {
+		t.Errorf("non-image: want 400, got %d", rec.Code)
+	}
+}
+
+// A plain file squatting where the item's asset DIRECTORY must go makes
+// os.MkdirAll fail — the handler must answer 500, not crash or pretend
+// success while the photo silently vanished.
+func TestItemImageUpload_MkdirFailureIs500(t *testing.T) {
+	mux, db := imageUploadTestDeps(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "S1", Name: "Coffee", BasePrice: 300, IsActive: true})
+
+	blocker := paths.Data("public", "assets", "items", "itm1")
+	if err := os.MkdirAll(filepath.Dir(blocker), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(blocker, []byte("i am a file, not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	body, ct := multipartUpload(t, map[string]string{"item_id": "itm1"}, "p.png", validPNG(t))
+	req := httptest.NewRequest(http.MethodPost, "/api/catalog/item/image", body)
+	req.Header.Set("Content-Type", ct)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500 when the asset dir cannot be created, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestBarcodeAttach_PanelResponse(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "S1", Name: "Coffee", BasePrice: 300, IsActive: true})
+
+	rec := postForm(t, mux, "/api/catalog/barcode", "barcode=5000001&itemId=itm1&panelItem=itm1")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `id="catalog-table" hx-swap-oob="true"`) {
+		t.Fatal("panel-scoped attach must carry the out-of-band items table")
+	}
+	if !strings.Contains(body, "5000001") {
+		t.Fatal("panel must show the newly attached barcode")
+	}
+}
+
+func TestBarcodeDelete_TableResponse(t *testing.T) {
+	mux, db := newCatalogMux(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "S1", Name: "Coffee", BasePrice: 300, IsActive: true})
+	testsupport.SeedBarcode(t, db, "5000001", "itm1", true)
+
+	// Without panelItem the response is the refreshed items table.
+	rec := postForm(t, mux, "/api/catalog/barcode/delete", "barcode=5000001")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `id="catalog-table"`) {
+		t.Fatal("table-scoped delete must answer with the items table")
+	}
+	var n int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM item_barcodes WHERE barcode = '5000001'`).Scan(&n)
+	if n != 0 {
+		t.Fatal("barcode not deleted")
+	}
+}
+
+func TestVariantImageUpload_MkdirFailureIs500(t *testing.T) {
+	mux, db := imageUploadTestDeps(t)
+	testsupport.SeedItem(t, db, testsupport.ItemSeed{ID: "itm1", SKU: "S1", Name: "Coffee", BasePrice: 300, IsActive: true})
+	testsupport.SeedVariant(t, db, testsupport.VariantSeed{ID: "v1", ItemID: "itm1", SKU: "S1-L", Name: "Large", Price: 350, IsActive: true})
+
+	blocker := paths.Data("public", "assets", "items", "itm1", "variants")
+	if err := os.MkdirAll(filepath.Dir(blocker), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(blocker, []byte("file, not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	body, ct := multipartUpload(t, map[string]string{"variant_id": "v1", "panelItem": "itm1"}, "p.png", validPNG(t))
+	req := httptest.NewRequest(http.MethodPost, "/api/catalog/variant/image", body)
+	req.Header.Set("Content-Type", ct)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500 when the variant asset dir cannot be created, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// saveLookupImage's MkdirAll failure: the created item's id is a fresh
+// uuid, so the blocker sits one level up — the items/ tree itself is a
+// plain file. The create must still succeed (image save is best-effort).
+func TestCatalogCreate_LookupImageMkdirFailureIsNonFatal(t *testing.T) {
+	chdirToRepoRoot(t)
+	paths.Init(t.TempDir())
+	t.Cleanup(func() { paths.Init("") })
+	db := setupCatalogPageDB(t)
+	defer db.Close()
+	stubLookupClient(t, func(w http.ResponseWriter, r *http.Request) {}, imageTransport(t, "http://never-used", func() *http.Response {
+		return pngResponse(t)
+	}))
+
+	blocker := paths.Data("public", "assets", "items")
+	if err := os.MkdirAll(filepath.Dir(blocker), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(blocker, []byte("file, not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	Register(mux, &common.Deps{Db: db, State: common.RuntimeState{Theme: "default"}})
+	form := "name=Cola&price=150&isActive=1&imageUrl=https%3A%2F%2Fimages.openfoodfacts.org%2Ff.png"
+	rec := postForm(t, mux, "/api/catalog/item", form)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("item create must survive an unsavable image: got %d: %s", rec.Code, rec.Body.String())
+	}
+	var n int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM items`).Scan(&n)
+	if n != 1 {
+		t.Fatalf("item should exist, found %d", n)
+	}
+}
+
+func TestCatalogPage_BrandAndTaxLookupErrorsAre500(t *testing.T) {
+	t.Run("brands table missing", func(t *testing.T) {
+		mux, db := newCatalogMux(t)
+		if _, err := db.Exec(`DROP TABLE brands`); err != nil {
+			t.Fatal(err)
+		}
+		if rec := get(t, mux, "/catalog"); rec.Code != http.StatusInternalServerError {
+			t.Fatalf("want 500, got %d", rec.Code)
+		}
+	})
+	t.Run("tax_codes table missing", func(t *testing.T) {
+		mux, db := newCatalogMux(t)
+		if _, err := db.Exec(`DROP TABLE tax_codes`); err != nil {
+			t.Fatal(err)
+		}
+		if rec := get(t, mux, "/catalog"); rec.Code != http.StatusInternalServerError {
+			t.Fatalf("want 500, got %d", rec.Code)
+		}
+	})
+}

--- a/internal/pages/catalog/lookup_endpoints_test.go
+++ b/internal/pages/catalog/lookup_endpoints_test.go
@@ -1,0 +1,276 @@
+package catalog
+
+import (
+	"bytes"
+	"database/sql"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	productlookup "github.com/universaltill/universal-till/internal/lookup"
+	"github.com/universaltill/universal-till/internal/pages/common"
+	"github.com/universaltill/universal-till/internal/paths"
+)
+
+// addAuditTable gives the shared minimal catalog schema the audit_log table
+// the lookup endpoint writes to (its InsertAudit error is deliberately
+// swallowed by the handler, so tests that want to assert the audit trail —
+// real behavior on a real till, every lookup is audited — must create it).
+func addAuditTable(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.Exec(`CREATE TABLE audit_log (id TEXT PRIMARY KEY, actor_id TEXT, entity_type TEXT NOT NULL, entity_id TEXT NOT NULL, action TEXT NOT NULL, data_json TEXT, created_at TEXT NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// stubLookupClient swaps the package's lookup-client seam for one whose
+// product-database sources are hermetic httptest servers and whose image
+// fetches are answered by transport (a RoundTripper stub), so the real
+// FetchImage host allowlist still runs but no request leaves the process.
+// Restores the real constructor on cleanup.
+func stubLookupClient(t *testing.T, handler http.HandlerFunc, images http.RoundTripper) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	orig := newLookupClient
+	t.Cleanup(func() { newLookupClient = orig })
+	hc := &http.Client{}
+	if images != nil {
+		hc.Transport = images
+	} else {
+		// No test should reach the wire when it didn't stub images.
+		hc.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			// httptest sources are contacted via their own URLs below; only
+			// image fetches (allowlisted https hosts) land here.
+			if strings.HasPrefix(r.URL.String(), srv.URL) {
+				return http.DefaultTransport.RoundTrip(r)
+			}
+			t.Errorf("unexpected outbound request in test: %s", r.URL)
+			return nil, http.ErrUseLastResponse
+		})
+	}
+	newLookupClient = func() *productlookup.Client {
+		return productlookup.NewClient(hc, []productlookup.Source{{Name: "test-db", BaseURL: srv.URL}})
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// pngResponse builds a canned 200 response carrying a real decodable PNG.
+func pngResponse(t *testing.T) *http.Response {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	img.Set(1, 0, color.RGBA{G: 255, A: 255})
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatal(err)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(buf.Bytes())),
+		Header:     http.Header{},
+	}
+}
+
+// imageTransport answers image fetches for allowlisted hosts from memory and
+// records what was requested; anything routed at the given source server
+// still goes through for barcode lookups.
+func imageTransport(t *testing.T, srvURL string, body func() *http.Response) roundTripFunc {
+	t.Helper()
+	return func(r *http.Request) (*http.Response, error) {
+		if strings.HasPrefix(r.URL.String(), srvURL) {
+			return http.DefaultTransport.RoundTrip(r)
+		}
+		if r.URL.Scheme == "https" && strings.HasSuffix(r.URL.Hostname(), ".openfoodfacts.org") {
+			return body(), nil
+		}
+		t.Errorf("unexpected outbound request in test: %s", r.URL)
+		return nil, http.ErrUseLastResponse
+	}
+}
+
+func TestCatalogLookup_HitReturnsProductAndAudits(t *testing.T) {
+	chdirToRepoRoot(t)
+	db := setupCatalogPageDB(t)
+	defer db.Close()
+	addAuditTable(t, db)
+	stubLookupClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status":1,"product":{"product_name":"Coca-Cola","brands":"Coca-Cola","quantity":"330 ml"}}`))
+	}, nil)
+
+	mux := http.NewServeMux()
+	Register(mux, &common.Deps{Db: db, State: common.RuntimeState{Theme: "default"}})
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/catalog/lookup?barcode=5449000000996", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Coca-Cola") || !strings.Contains(body, `"error":null`) {
+		t.Fatalf("want product JSON envelope, got %s", body)
+	}
+	var action string
+	var dataJSON string
+	if err := db.QueryRow(`SELECT action, data_json FROM audit_log WHERE entity_id = '5449000000996'`).Scan(&action, &dataJSON); err != nil {
+		t.Fatalf("lookup not audited: %v", err)
+	}
+	if action != "barcode_lookup" || !strings.Contains(dataJSON, `"found":true`) {
+		t.Fatalf("audit row wrong: action=%q data=%s", action, dataJSON)
+	}
+}
+
+func TestCatalogLookup_NotFoundIs404AndAuditedAsMiss(t *testing.T) {
+	chdirToRepoRoot(t)
+	db := setupCatalogPageDB(t)
+	defer db.Close()
+	addAuditTable(t, db)
+	stubLookupClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}, nil)
+
+	mux := http.NewServeMux()
+	Register(mux, &common.Deps{Db: db, State: common.RuntimeState{Theme: "default"}})
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/catalog/lookup?barcode=40084107", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "not found in product databases") {
+		t.Fatalf("want not-found envelope, got %s", rec.Body.String())
+	}
+	var dataJSON string
+	if err := db.QueryRow(`SELECT data_json FROM audit_log WHERE entity_id = '40084107'`).Scan(&dataJSON); err != nil {
+		t.Fatalf("miss not audited: %v", err)
+	}
+	if !strings.Contains(dataJSON, `"found":false`) {
+		t.Fatalf("audit row should record the miss: %s", dataJSON)
+	}
+}
+
+// Transport failure (shop offline, databases down) is a 502, not a 404 —
+// the form must be able to tell "unknown barcode" from "try again later".
+func TestCatalogLookup_UnreachableSourcesAre502(t *testing.T) {
+	chdirToRepoRoot(t)
+	db := setupCatalogPageDB(t)
+	defer db.Close()
+	addAuditTable(t, db)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close() // connection refused from here on
+	orig := newLookupClient
+	t.Cleanup(func() { newLookupClient = orig })
+	newLookupClient = func() *productlookup.Client {
+		return productlookup.NewClient(nil, []productlookup.Source{{Name: "dead", BaseURL: srv.URL}})
+	}
+
+	mux := http.NewServeMux()
+	Register(mux, &common.Deps{Db: db, State: common.RuntimeState{Theme: "default"}})
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/catalog/lookup?barcode=40084107", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("want 502, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "unreachable") {
+		t.Fatalf("want unreachable envelope, got %s", rec.Body.String())
+	}
+}
+
+// The auto-fill create flow: a create carrying the looked-up imageUrl saves
+// the product photo as the item's thumb.png via the real allowlist code —
+// hermetically, through a stubbed transport.
+func TestCatalogCreate_SavesLookupImage(t *testing.T) {
+	chdirToRepoRoot(t)
+	paths.Init(t.TempDir())
+	t.Cleanup(func() { paths.Init("") })
+	db := setupCatalogPageDB(t)
+	defer db.Close()
+
+	stub := func(w http.ResponseWriter, r *http.Request) {}
+	stubbed := false
+	stubLookupClient(t, stub, imageTransport(t, "http://never-used", func() *http.Response {
+		stubbed = true
+		return pngResponse(t)
+	}))
+
+	mux := http.NewServeMux()
+	Register(mux, &common.Deps{Db: db, State: common.RuntimeState{Theme: "default"}})
+
+	form := "name=Cola&price=150&isActive=1&imageUrl=" +
+		"https%3A%2F%2Fimages.openfoodfacts.org%2Fimages%2Ffront.png"
+	req := httptest.NewRequest(http.MethodPost, "/api/catalog/item", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !stubbed {
+		t.Fatal("image transport never consulted — saveLookupImage did not run")
+	}
+	itemID := extractItemID(t, db)
+	thumb := paths.Data("public", "assets", "items", itemID, "thumb.png")
+	raw, err := os.ReadFile(thumb)
+	if err != nil {
+		t.Fatalf("lookup image not stored at %s: %v", thumb, err)
+	}
+	if _, _, err := image.Decode(bytes.NewReader(raw)); err != nil {
+		t.Fatalf("stored thumb is not a decodable image: %v", err)
+	}
+}
+
+// A disallowed image host (SSRF attempt or stale URL) must not fail the
+// create — the item lands, the photo is skipped. Same for undecodable bytes.
+func TestCatalogCreate_LookupImageFailuresAreNonFatal(t *testing.T) {
+	cases := []struct {
+		name     string
+		imageURL string
+		resp     func(t *testing.T) *http.Response
+	}{
+		{"disallowed host is refused by the allowlist", "https://evil.example.com/x.png", nil},
+		{"non-image body is skipped", "https://images.openfoodfacts.org/x.png", func(t *testing.T) *http.Response {
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader("not a png")), Header: http.Header{}}
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			chdirToRepoRoot(t)
+			paths.Init(t.TempDir())
+			t.Cleanup(func() { paths.Init("") })
+			db := setupCatalogPageDB(t)
+			defer db.Close()
+			stubLookupClient(t, func(w http.ResponseWriter, r *http.Request) {}, imageTransport(t, "http://never-used", func() *http.Response {
+				if tc.resp == nil {
+					t.Error("allowlist should have refused before any request was made")
+					return &http.Response{StatusCode: 500, Body: io.NopCloser(strings.NewReader("")), Header: http.Header{}}
+				}
+				return tc.resp(t)
+			}))
+
+			mux := http.NewServeMux()
+			Register(mux, &common.Deps{Db: db, State: common.RuntimeState{Theme: "default"}})
+
+			form := "name=Widget&price=99&isActive=1&imageUrl=" + strings.ReplaceAll(tc.imageURL, ":", "%3A")
+			req := httptest.NewRequest(http.MethodPost, "/api/catalog/item", strings.NewReader(form))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("item create must survive a failed image fetch: got %d: %s", rec.Code, rec.Body.String())
+			}
+			itemID := extractItemID(t, db)
+			if _, err := os.Stat(paths.Data("public", "assets", "items", itemID, "thumb.png")); err == nil {
+				t.Fatal("no thumb should have been written for a failed fetch")
+			}
+		})
+	}
+}

--- a/web/ui/partials/catalog_variants.html
+++ b/web/ui/partials/catalog_variants.html
@@ -32,9 +32,9 @@
       <div class="muted catalog-detail-label">{{ T "catalog.cost_price" }}</div>
       <form class="chip-add" hx-post="/api/catalog/item-cost" hx-target="#catalog-variants" hx-swap="outerHTML">
         <input type="hidden" name="panelItem" value="{{ .ItemID }}">
-        <input type="number" name="cost" step="0.01" min="0" style="max-inline-size:7rem"
+        <input type="number" name="cost" step="{{ if eq currency.Decimals 0 }}1{{ else }}0.01{{ end }}" min="0" style="max-inline-size:7rem"
                value="{{ .CostMajor }}"
-               placeholder="0.00" title="{{ T "catalog.cost_price_hint" }}">
+               placeholder="{{ if eq currency.Decimals 0 }}0{{ else }}0.00{{ end }}" title="{{ T "catalog.cost_price_hint" }}">
         <button class="btn secondary" type="submit">{{ T "common.save" }}</button>
       </form>
     </aside>


### PR DESCRIPTION
Coverage push batch 6 (`ut-docs/QUEUE.md` → "Test-coverage push, remainder").

- `internal/pages/catalog`: **53.3% → 98.0%** of statements. Four new test files through the real mux, per-test real sqlite, DB-state assertions after every mutation; hermetic (poisoned-proxy + `-race` proven), barcode-lookup endpoints via a `newLookupClient` seam with `t.Cleanup` restores.
- **Real bug fixed, TDD-first (medium):** `POST /api/catalog/item-cost` hardcoded `*100`/`/100`+`%.2f`/`step="0.01"` — wrong for every 0-decimal currency (IRR/JPY/…; Iran is a target market). A 650,000-rial cost was stored as 65,000,000 (margin report 100× wrong) and rendered back 100× too small. Fix mirrors the modifier-option handler's established decimals-aware pattern.
- Two independent different-model (opus) reviews — the original session's and a full re-review after that session died pre-commit: **SAFE TO MERGE**, zero blocking/should-fix; 8 author/tester + 3 fresh reviewer mutation probes, all caught. TDD red/green arc proven three times total (author, reviewer, resuming session via isolated-tree revert).
- Honestly-untestable remainder documented per-file in `docs/code-reviews/2026-07-30-coverage-pages-catalog.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJZvKj4hxAA5AWo9JyVqkz