### PR TITLE
test: cover internal/data auth repo + stragglers (58.5%→63.3%)

### DIFF
--- a/docs/code-reviews/2026-07-30-coverage-data-batch7.md
+++ b/docs/code-reviews/2026-07-30-coverage-data-batch7.md
@@ -1,0 +1,91 @@
+# Code review — coverage batch 7: internal/data (auth_repo + stragglers)
+
+- **Date:** 2026-07-30
+- **Branch/PR:** `coverage-batch7-internal-data`
+- **Author:** pipeline (fable)
+- **Independent reviewer:** opus subagent (different model, adversarial brief)
+- **Scope:** tests-only — `internal/data/auth_repo_test.go` (new),
+  `internal/data/batch7_stragglers_test.go` (new). No production code changed.
+
+## What shipped
+
+Batch 7 of the coverage push (`ut-docs/QUEUE.md` "Test-coverage push,
+remainder"). Package `internal/data`: **58.5% → 63.3%**. Scope was honestly
+split — `internal/data` is 12k lines with 246 functions under 100%, so this
+batch took the security-relevant zero-coverage surface plus the small
+stragglers; `pos_repo.go` (42 uncovered funcs) and `plugin_repo.go` (25) are
+queued as batches 8–9.
+
+- **`auth_repo.go` (0% → ~85%)** — first-ever coverage of the operator-auth
+  surface: user CRUD (unique usernames, COALESCE'd NULL pin_hash), login
+  candidates (active + non-empty PIN only, both NULL and `''` excluded),
+  last-admin-lockout guard (`CountOtherActiveAdminsWithPIN` matrix), and the
+  full session lifecycle — expired, revoked, and deactivated-user sessions
+  all proven to deny; purge keeps live + grace-window rows and deletes
+  revoked + long-expired; user-wide revoke leaves other users untouched.
+- **Stragglers** — `InvoiceRepo.BySale`/`ByDisplayNo` (kind-filtered),
+  `Create` series numbering (per-series sequential, replica prefix embeds,
+  `UNIQUE(sale_id,kind)` duplicate guard verified against the real index),
+  `InstallStatusRepo.Get`, `SettingsRepo.All` (+ wrap/wrapf error branches
+  via closed-DB probes), `ModifierRepo.ItemIDsWithModifiers` (active-only,
+  empty-input no-SQL path), `POSRepo.InsertSaleLineModifiers` (in-tx,
+  NULL-vs-`""` id columns, empty-mods no-op).
+
+All covered functions verified live (every one has real production callers —
+no dead-surface coverage theater, per the batch-4 honesty rule).
+
+## Verification
+
+- **9 mutation probes total, all failing correctly against broken code**:
+  4 by the pipeline pre-review (LookupSession revoked filter,
+  CountOtherActiveAdmins exclusion, ItemIDsWithModifiers active filter,
+  PurgeDeadSessions cutoff — the first two attempts at #2/#4 turned out to be
+  semantically equivalent mutations and were redone with real ones), 5 fresh
+  ones by the independent reviewer (expiry rejection, deactivated-user
+  filter, nullableString NULL persistence, empty-pin exclusion, and
+  TouchSession's revoked guard — see finding 1).
+- Reviewer cross-checked caller contracts: `internal/auth/service.go`'s
+  `VerifyPIN(pin, u.PinHash)` needs the hash populated (asserted), idle-lock
+  reads `LastSeenAt` (parse layouts asserted); kitchen-ticket read path
+  unaffected by the modifier-id nullability.
+- Full gate: `go build ./...`, `go vet`, full-repo `go test` (zero failures),
+  `internal/data` under `-race`, guard-data-access + guard-i18n — all green,
+  re-run after the review fixes.
+- Tests-only diff → no runtime surface to drive; no e2e needed.
+
+## Independent review findings (all addressed)
+
+1. **SHOULD-FIX (real false-pass, fixed):** the TouchSession revoked-no-op
+   assertion could never fire — TouchSession writes 1-second-resolution
+   RFC3339 and the test runs in milliseconds, so before/after strings
+   collided identically even with the guard deleted. Fixed with a sentinel
+   `last_seen_at` (a real write can never equal it); the previously-surviving
+   mutation (drop `AND revoked_at IS NULL`) now fails the test — re-verified
+   personally, restored, suite green.
+2. **Misleading comment (fixed):** the modifier test claimed empty-string ids
+   "would violate the FK" — `sale_line_modifiers.group_id`/`option_id` have
+   no FK (migration 017); comment corrected to the real rationale (NULL keeps
+   "no source group" queryable) and now states the empty-id case is
+   defensive, not a live write path (reviewer's nit 3, same comment).
+3. **Nit (heeded):** three unrelated untracked `docs/*.md` planning files in
+   the tree (they have their own QUEUE.md item) — commit adds files
+   explicitly so they can't be swept in.
+
+Real-name check clean ("Task Runner" + generics only); no secrets; no
+wall-clock flakiness (minute/hour margins only); per-test temp DBs, no
+ordering deps.
+
+## Accepted remainder (documented, not covered)
+
+The batch files' residual <100% is error branches on a healthy DB
+(QueryContext/Exec/Scan failures, rows.Err) — reachable only by fault
+injection disproportionate to their risk; `repoObservability.wrap`'s
+nil-logger branch is unreachable in practice (logging always initialised).
+`invoice_repo.Create`'s retry loop is covered for first-attempt success and
+permanent-duplicate break; a transient-then-success retry would need a
+racing writer harness — deferred.
+
+## Verdict
+
+**SAFE TO MERGE** (reviewer's explicit verdict; both its should-fixes
+resolved and re-verified before commit).

--- a/internal/data/auth_repo_test.go
+++ b/internal/data/auth_repo_test.go
@@ -1,0 +1,502 @@
+package data
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/universaltill/universal-till/internal/db"
+)
+
+// The whole operator-auth surface (PIN login, sessions, the users admin
+// page) sits on this repo, and none of it had coverage until this batch.
+// These tests run against a real migrated schema — the users table's
+// UNIQUE(username), the sessions FK, and migration 010's last_seen_at
+// backfill are all part of the behavior under test.
+
+func newAuthTestRepo(t *testing.T) (*AuthRepo, *db.DB) {
+	t.Helper()
+	d := openMigratedDB(t, "auth.db")
+	return NewAuthRepo(d.DB), d
+}
+
+func TestAuthRepo_CreateGetListUsers(t *testing.T) {
+	ctx := context.Background()
+	repo, d := newAuthTestRepo(t)
+
+	id, err := repo.CreateUser(ctx, "zara", "Zara", "manager")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if id == "" {
+		t.Fatal("CreateUser returned empty id")
+	}
+
+	// A brand-new user is active, has no PIN yet (NULL in the DB — the
+	// COALESCE in userCols must surface it as ""), and round-trips fields.
+	u, ok, err := repo.GetUser(ctx, id)
+	if err != nil || !ok {
+		t.Fatalf("GetUser: ok=%v err=%v", ok, err)
+	}
+	if u.Username != "zara" || u.DisplayName != "Zara" || u.Role != "manager" {
+		t.Fatalf("unexpected user: %+v", u)
+	}
+	if !u.IsActive {
+		t.Fatal("new user must default to active")
+	}
+	if u.PinHash != "" {
+		t.Fatalf("new user must have empty PinHash, got %q", u.PinHash)
+	}
+
+	// Unknown id: not found, not an error.
+	if _, ok, err := repo.GetUser(ctx, "nope"); err != nil || ok {
+		t.Fatalf("GetUser(unknown): ok=%v err=%v", ok, err)
+	}
+
+	// usernames are UNIQUE in the schema — a duplicate must fail loudly.
+	if _, err := repo.CreateUser(ctx, "zara", "Other Zara", "cashier"); err == nil {
+		t.Fatal("duplicate username must error")
+	}
+
+	// ListUsers shows inactive users too (the admin page needs them),
+	// ordered by username.
+	id2, err := repo.CreateUser(ctx, "amir", "Amir", "cashier")
+	if err != nil {
+		t.Fatalf("CreateUser amir: %v", err)
+	}
+	if err := repo.SetUserActive(ctx, id2, false); err != nil {
+		t.Fatalf("SetUserActive: %v", err)
+	}
+	users, err := repo.ListUsers(ctx)
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+	// The migrated schema seeds its own users (admin, kiosk, …) — assert
+	// on ours relative to each other rather than an absolute count.
+	posAmir, posZara := -1, -1
+	for i, u := range users {
+		switch u.Username {
+		case "amir":
+			posAmir = i
+			if u.IsActive {
+				t.Fatal("amir was deactivated; ListUsers must still return him, inactive")
+			}
+		case "zara":
+			posZara = i
+		}
+	}
+	if posAmir == -1 || posZara == -1 {
+		t.Fatalf("ListUsers missing created users: %+v", users)
+	}
+	if posAmir > posZara {
+		t.Fatal("ListUsers must order by username (amir before zara)")
+	}
+	_ = d
+}
+
+func TestAuthRepo_ListActiveUsersWithPIN(t *testing.T) {
+	ctx := context.Background()
+	repo, d := newAuthTestRepo(t)
+
+	// Login candidates are exactly: active AND a non-empty pin_hash.
+	mk := func(username string, active bool, pin string) string {
+		t.Helper()
+		id, err := repo.CreateUser(ctx, username, username, "cashier")
+		if err != nil {
+			t.Fatalf("CreateUser %s: %v", username, err)
+		}
+		if pin != "" {
+			if err := repo.SetUserPIN(ctx, id, pin); err != nil {
+				t.Fatalf("SetUserPIN %s: %v", username, err)
+			}
+		}
+		if !active {
+			if err := repo.SetUserActive(ctx, id, false); err != nil {
+				t.Fatalf("SetUserActive %s: %v", username, err)
+			}
+		}
+		return id
+	}
+	inID := mk("can-login", true, "hash-1")
+	mk("no-pin", true, "")
+	mk("inactive", false, "hash-2")
+	// Empty-string pin_hash (as opposed to NULL) must also be excluded.
+	emptyID := mk("empty-pin", true, "x")
+	mustExec(t, d, `UPDATE users SET pin_hash = '' WHERE id = ?`, emptyID)
+
+	got, err := repo.ListActiveUsersWithPIN(ctx)
+	if err != nil {
+		t.Fatalf("ListActiveUsersWithPIN: %v", err)
+	}
+	found := map[string]bool{}
+	for _, u := range got {
+		found[u.Username] = true
+	}
+	if !found["can-login"] {
+		t.Fatal("active user with PIN missing from login candidates")
+	}
+	for _, bad := range []string{"no-pin", "inactive", "empty-pin"} {
+		if found[bad] {
+			t.Fatalf("%s must not be a login candidate", bad)
+		}
+	}
+	// And the returned row carries the hash PIN login verifies against.
+	for _, u := range got {
+		if u.ID == inID && u.PinHash != "hash-1" {
+			t.Fatalf("login candidate lost its pin hash: %+v", u)
+		}
+	}
+}
+
+func TestAuthRepo_SetUserPIN(t *testing.T) {
+	ctx := context.Background()
+	repo, d := newAuthTestRepo(t)
+
+	id, err := repo.CreateUser(ctx, "pat", "Pat", "cashier")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := repo.SetUserPIN(ctx, id, "new-hash"); err != nil {
+		t.Fatalf("SetUserPIN: %v", err)
+	}
+	var stored string
+	if err := d.DB.QueryRow(`SELECT pin_hash FROM users WHERE id = ?`, id).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored != "new-hash" {
+		t.Fatalf("pin_hash not persisted: %q", stored)
+	}
+
+	// Unknown user: loud error, not a silent no-op — the admin UI relies
+	// on this to report a failed reset.
+	if err := repo.SetUserPIN(ctx, "ghost", "h"); err == nil {
+		t.Fatal("SetUserPIN(unknown) must error")
+	}
+}
+
+func TestAuthRepo_SetUserActive(t *testing.T) {
+	ctx := context.Background()
+	repo, d := newAuthTestRepo(t)
+
+	id, err := repo.CreateUser(ctx, "sam", "Sam", "cashier")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := repo.SetUserActive(ctx, id, false); err != nil {
+		t.Fatalf("SetUserActive(false): %v", err)
+	}
+	var active int
+	if err := d.DB.QueryRow(`SELECT is_active FROM users WHERE id = ?`, id).Scan(&active); err != nil {
+		t.Fatal(err)
+	}
+	if active != 0 {
+		t.Fatal("user not deactivated in DB")
+	}
+	if err := repo.SetUserActive(ctx, id, true); err != nil {
+		t.Fatalf("SetUserActive(true): %v", err)
+	}
+	if err := d.DB.QueryRow(`SELECT is_active FROM users WHERE id = ?`, id).Scan(&active); err != nil {
+		t.Fatal(err)
+	}
+	if active != 1 {
+		t.Fatal("user not reactivated in DB")
+	}
+	if err := repo.SetUserActive(ctx, "ghost", true); err == nil {
+		t.Fatal("SetUserActive(unknown) must error")
+	}
+}
+
+func TestAuthRepo_CountOtherActiveAdminsWithPIN(t *testing.T) {
+	ctx := context.Background()
+	repo, d := newAuthTestRepo(t)
+
+	// The migrated schema may seed its own admin — measure the baseline
+	// first so this test asserts deltas, not absolute counts.
+	baseline, err := repo.CountOtherActiveAdminsWithPIN(ctx, "none")
+	if err != nil {
+		t.Fatalf("baseline count: %v", err)
+	}
+
+	mkAdmin := func(username string, active bool, pin string) string {
+		t.Helper()
+		id, err := repo.CreateUser(ctx, username, username, "admin")
+		if err != nil {
+			t.Fatalf("CreateUser %s: %v", username, err)
+		}
+		if pin != "" {
+			if err := repo.SetUserPIN(ctx, id, pin); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if !active {
+			if err := repo.SetUserActive(ctx, id, false); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return id
+	}
+	a1 := mkAdmin("admin-a", true, "h1")
+	mkAdmin("admin-b", true, "h2")
+	mkAdmin("admin-inactive", false, "h3") // must not count
+	mkAdmin("admin-no-pin", true, "")      // must not count
+	// A non-admin with a PIN must not count either.
+	cid, err := repo.CreateUser(ctx, "cashier-c", "C", "cashier")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.SetUserPIN(ctx, cid, "h4"); err != nil {
+		t.Fatal(err)
+	}
+
+	// From admin-a's perspective: only admin-b (plus any seeded baseline).
+	n, err := repo.CountOtherActiveAdminsWithPIN(ctx, a1)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != baseline+1 {
+		t.Fatalf("expected %d other admins, got %d", baseline+1, n)
+	}
+	// From an outsider's perspective both count.
+	n, err = repo.CountOtherActiveAdminsWithPIN(ctx, "unrelated")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != baseline+2 {
+		t.Fatalf("expected %d admins, got %d", baseline+2, n)
+	}
+	_ = d
+}
+
+func TestAuthRepo_SessionLifecycle(t *testing.T) {
+	ctx := context.Background()
+	repo, d := newAuthTestRepo(t)
+
+	uid, err := repo.CreateUser(ctx, "ops", "Ops", "manager")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expiry := time.Now().Add(1 * time.Hour)
+	sid, err := repo.InsertSession(ctx, "tok-live", uid, expiry)
+	if err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+	if sid == "" {
+		t.Fatal("InsertSession returned empty id")
+	}
+
+	s, ok, err := repo.LookupSession(ctx, "tok-live")
+	if err != nil || !ok {
+		t.Fatalf("LookupSession: ok=%v err=%v", ok, err)
+	}
+	if s.SessionID != sid || s.UserID != uid || s.Username != "ops" || s.Role != "manager" {
+		t.Fatalf("unexpected session row: %+v", s)
+	}
+	if s.ExpiresAt.Unix() != expiry.UTC().Truncate(time.Second).Unix() {
+		t.Fatalf("expiry mismatch: got %v want %v", s.ExpiresAt, expiry)
+	}
+	// last_seen_at is NULL right after insert; the COALESCE falls back to
+	// created_at (sqlite datetime('now') format) — the second accepted
+	// layout. It must parse, not stay zero.
+	if s.LastSeenAt.IsZero() {
+		t.Fatal("LastSeenAt must fall back to created_at, not zero")
+	}
+
+	// Wrong token: no session.
+	if _, ok, err := repo.LookupSession(ctx, "tok-wrong"); err != nil || ok {
+		t.Fatalf("LookupSession(wrong): ok=%v err=%v", ok, err)
+	}
+
+	// An expired session must not resolve, even though the row exists.
+	if _, err := repo.InsertSession(ctx, "tok-expired", uid, time.Now().Add(-1*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := repo.LookupSession(ctx, "tok-expired"); ok {
+		t.Fatal("expired session must not resolve")
+	}
+
+	// A revoked session must not resolve.
+	if err := repo.RevokeSession(ctx, "tok-live"); err != nil {
+		t.Fatalf("RevokeSession: %v", err)
+	}
+	if _, ok, _ := repo.LookupSession(ctx, "tok-live"); ok {
+		t.Fatal("revoked session must not resolve")
+	}
+	var revokedAt *string
+	if err := d.DB.QueryRow(`SELECT revoked_at FROM sessions WHERE id = ?`, sid).Scan(&revokedAt); err != nil {
+		t.Fatal(err)
+	}
+	if revokedAt == nil {
+		t.Fatal("revoked_at not written")
+	}
+
+	// A deactivated user's (still-live) session must not resolve — this is
+	// the "deactivate locks them out NOW" guarantee the admin page promises.
+	if _, err := repo.InsertSession(ctx, "tok-deact", uid, time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.SetUserActive(ctx, uid, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := repo.LookupSession(ctx, "tok-deact"); ok {
+		t.Fatal("deactivated user's session must not resolve")
+	}
+}
+
+func TestAuthRepo_TouchSession(t *testing.T) {
+	ctx := context.Background()
+	repo, d := newAuthTestRepo(t)
+
+	uid, err := repo.CreateUser(ctx, "ops", "Ops", "cashier")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.InsertSession(ctx, "tok-a", uid, time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.TouchSession(ctx, "tok-a"); err != nil {
+		t.Fatalf("TouchSession: %v", err)
+	}
+	var lastSeen *string
+	if err := d.DB.QueryRow(`SELECT last_seen_at FROM sessions WHERE token_hash = 'tok-a'`).Scan(&lastSeen); err != nil {
+		t.Fatal(err)
+	}
+	if lastSeen == nil {
+		t.Fatal("TouchSession must write last_seen_at")
+	}
+	if _, err := time.Parse(time.RFC3339, *lastSeen); err != nil {
+		t.Fatalf("last_seen_at not RFC3339 (%q): %v — LookupSession's first parse layout depends on this", *lastSeen, err)
+	}
+	// After a touch, LookupSession must surface the RFC3339 value (first
+	// layout), not the created_at fallback.
+	s, ok, err := repo.LookupSession(ctx, "tok-a")
+	if err != nil || !ok {
+		t.Fatal(err)
+	}
+	if s.LastSeenAt.IsZero() {
+		t.Fatal("LastSeenAt zero after touch")
+	}
+
+	// Touching a revoked session is a silent no-op (the row keeps its
+	// pre-revocation last_seen_at). A plain before/after comparison would be
+	// a false-pass here: TouchSession writes at 1-second RFC3339 resolution
+	// and this test runs in milliseconds, so two writes would collide into
+	// identical strings. Seed a sentinel value instead — any real write is
+	// time.Now()-derived and can never equal it.
+	if err := repo.RevokeSession(ctx, "tok-a"); err != nil {
+		t.Fatal(err)
+	}
+	const sentinel = "2001-01-01T00:00:00Z"
+	mustExec(t, d, `UPDATE sessions SET last_seen_at = ? WHERE token_hash = 'tok-a'`, sentinel)
+	if err := repo.TouchSession(ctx, "tok-a"); err != nil {
+		t.Fatalf("TouchSession(revoked): %v", err)
+	}
+	var after *string
+	if err := d.DB.QueryRow(`SELECT last_seen_at FROM sessions WHERE token_hash = 'tok-a'`).Scan(&after); err != nil {
+		t.Fatal(err)
+	}
+	if after == nil || *after != sentinel {
+		t.Fatalf("TouchSession must not update a revoked session (got %v, want sentinel)", after)
+	}
+}
+
+func TestAuthRepo_PurgeDeadSessions(t *testing.T) {
+	ctx := context.Background()
+	repo, d := newAuthTestRepo(t)
+
+	uid, err := repo.CreateUser(ctx, "ops", "Ops", "cashier")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	// live: expires in the future, never revoked — must survive.
+	if _, err := repo.InsertSession(ctx, "tok-live", uid, now.Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	// revoked: still unexpired, but revoked — must be purged.
+	if _, err := repo.InsertSession(ctx, "tok-revoked", uid, now.Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.RevokeSession(ctx, "tok-revoked"); err != nil {
+		t.Fatal(err)
+	}
+	// long-expired: expired before the cutoff — must be purged.
+	if _, err := repo.InsertSession(ctx, "tok-old", uid, now.Add(-48*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	// recently-expired: expired, but after the cutoff — must survive (the
+	// grace window exists so an in-flight request can still see its row).
+	if _, err := repo.InsertSession(ctx, "tok-recent", uid, now.Add(-1*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.PurgeDeadSessions(ctx, now.Add(-24*time.Hour)); err != nil {
+		t.Fatalf("PurgeDeadSessions: %v", err)
+	}
+
+	remaining := map[string]bool{}
+	rows, err := d.DB.Query(`SELECT token_hash FROM sessions WHERE user_id = ?`, uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var tok string
+		if err := rows.Scan(&tok); err != nil {
+			t.Fatal(err)
+		}
+		remaining[tok] = true
+	}
+	if !remaining["tok-live"] || !remaining["tok-recent"] {
+		t.Fatalf("purge deleted sessions it must keep: %v", remaining)
+	}
+	if remaining["tok-revoked"] || remaining["tok-old"] {
+		t.Fatalf("purge kept sessions it must delete: %v", remaining)
+	}
+}
+
+func TestAuthRepo_RevokeUserSessions(t *testing.T) {
+	ctx := context.Background()
+	repo, d := newAuthTestRepo(t)
+
+	u1, err := repo.CreateUser(ctx, "one", "One", "cashier")
+	if err != nil {
+		t.Fatal(err)
+	}
+	u2, err := repo.CreateUser(ctx, "two", "Two", "cashier")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tok := range []string{"u1-a", "u1-b"} {
+		if _, err := repo.InsertSession(ctx, tok, u1, time.Now().Add(time.Hour)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := repo.InsertSession(ctx, "u2-a", u2, time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.RevokeUserSessions(ctx, u1); err != nil {
+		t.Fatalf("RevokeUserSessions: %v", err)
+	}
+
+	var revokedU1, revokedU2 int
+	if err := d.DB.QueryRow(`SELECT COUNT(*) FROM sessions WHERE user_id = ? AND revoked_at IS NOT NULL`, u1).Scan(&revokedU1); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.DB.QueryRow(`SELECT COUNT(*) FROM sessions WHERE user_id = ? AND revoked_at IS NOT NULL`, u2).Scan(&revokedU2); err != nil {
+		t.Fatal(err)
+	}
+	if revokedU1 != 2 {
+		t.Fatalf("expected both of u1's sessions revoked, got %d", revokedU1)
+	}
+	if revokedU2 != 0 {
+		t.Fatal("u2's session must be untouched")
+	}
+	// And neither of u1's tokens resolves anymore.
+	for _, tok := range []string{"u1-a", "u1-b"} {
+		if _, ok, _ := repo.LookupSession(ctx, tok); ok {
+			t.Fatalf("session %s still resolves after user-wide revoke", tok)
+		}
+	}
+}

--- a/internal/data/batch7_stragglers_test.go
+++ b/internal/data/batch7_stragglers_test.go
@@ -1,0 +1,343 @@
+package data
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/db"
+)
+
+// Coverage batch 7's straggler gaps: the last zero-coverage functions in
+// InvoiceRepo, InstallStatusRepo, SettingsRepo, ModifierRepo, and the
+// POSRepo sale-line-modifier writer that Phase-5 kitchen tickets read back.
+
+func TestInvoiceRepo_BySaleAndByDisplayNo(t *testing.T) {
+	dbo, err := db.Open(filepath.Join(t.TempDir(), "invoices.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbo.Close()
+	ctx := context.Background()
+
+	mustExec(t, dbo, `INSERT INTO sales(id, receipt_no, status, sale_type, currency, subtotal, discount_total, tax_total, total, created_at, completed_at)
+VALUES('sale1', 'R1', 'completed', 'sale', 'GBP', 100, 0, 20, 120, '2026-01-01T10:00:00Z', '2026-01-01T10:00:00Z')`)
+
+	repo := NewInvoiceRepo(dbo.DB)
+	inv, err := repo.Create(ctx, InvoiceInput{
+		Kind: "invoice", SaleID: "sale1",
+		CustomerName: "Walk-in", SellerJSON: "{}", VATBreakdownJSON: "[]",
+		NetTotal: 100, TaxTotal: 20, GrossTotal: 120,
+		IssuedAt: "2026-01-01T10:05:00Z", IssuedBy: "user1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	credit, err := repo.Create(ctx, InvoiceInput{
+		Kind: "credit_note", SaleID: "sale1",
+		CustomerName: "Walk-in", SellerJSON: "{}", VATBreakdownJSON: "[]",
+		NetTotal: -100, TaxTotal: -20, GrossTotal: -120,
+		IssuedAt: "2026-01-02T10:05:00Z", IssuedBy: "user1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// BySale is kind-filtered: the refund page asks for the credit note
+	// specifically and must not get the invoice back (and vice versa).
+	got, ok, err := repo.BySale(ctx, "sale1", "invoice")
+	if err != nil || !ok {
+		t.Fatalf("BySale(invoice): ok=%v err=%v", ok, err)
+	}
+	if got.ID != inv.ID || got.Kind != "invoice" {
+		t.Fatalf("BySale(invoice) returned wrong row: %+v", got)
+	}
+	got, ok, err = repo.BySale(ctx, "sale1", "credit_note")
+	if err != nil || !ok || got.ID != credit.ID {
+		t.Fatalf("BySale(credit_note): got %+v ok=%v err=%v", got, ok, err)
+	}
+	if _, ok, err := repo.BySale(ctx, "sale-none", "invoice"); err != nil || ok {
+		t.Fatalf("BySale(unknown sale) must be not-found: ok=%v err=%v", ok, err)
+	}
+
+	// ByDisplayNo resolves the printed number a customer reads out.
+	got, ok, err = repo.ByDisplayNo(ctx, inv.DisplayNo)
+	if err != nil || !ok || got.ID != inv.ID {
+		t.Fatalf("ByDisplayNo(%q): got %+v ok=%v err=%v", inv.DisplayNo, got, ok, err)
+	}
+	if _, ok, err := repo.ByDisplayNo(ctx, "INV-9999"); err != nil || ok {
+		t.Fatalf("ByDisplayNo(unknown) must be not-found: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestInstallStatusRepo_Get(t *testing.T) {
+	dbo, err := db.Open(filepath.Join(t.TempDir(), "install.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbo.Close()
+	ctx := context.Background()
+	repo := NewInstallStatusRepo(dbo.DB)
+
+	row := InstallStatusRow{
+		ListingID: "listing-1", PluginID: "com.example.a", PluginName: "Example",
+		TargetVersion: "1.2.0", CurrentVersion: "1.1.0", State: "installing",
+		MessageKey: "plugins.install.downloading", Retryable: true,
+		UpdatedAt: "2026-01-01T00:00:00Z",
+	}
+	if err := repo.Upsert(ctx, row); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok, err := repo.Get(ctx, "listing-1")
+	if err != nil || !ok {
+		t.Fatalf("Get: ok=%v err=%v", ok, err)
+	}
+	if got != row {
+		t.Fatalf("Get round-trip mismatch:\n got %+v\nwant %+v", got, row)
+	}
+	if _, ok, err := repo.Get(ctx, "listing-none"); err != nil || ok {
+		t.Fatalf("Get(unknown) must be not-found: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestSettingsRepo_All(t *testing.T) {
+	dbo, err := db.Open(filepath.Join(t.TempDir(), "settings.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbo.Close()
+	ctx := context.Background()
+	repo := NewSettingsRepo(dbo.DB)
+
+	// The migrated schema may seed settings — clear so the empty case is real.
+	mustExec(t, dbo, `DELETE FROM settings`)
+
+	all, err := repo.All(ctx)
+	if err != nil {
+		t.Fatalf("All(empty): %v", err)
+	}
+	if all == nil || len(all) != 0 {
+		t.Fatalf("All on empty table must be an empty, non-nil map, got %#v", all)
+	}
+
+	if err := repo.Set(ctx, "shop.name", "Task Runner"); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Set(ctx, "display.mode", "self_order"); err != nil {
+		t.Fatal(err)
+	}
+	all, err = repo.All(ctx)
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(all) != 2 || all["shop.name"] != "Task Runner" || all["display.mode"] != "self_order" {
+		t.Fatalf("All returned wrong map: %#v", all)
+	}
+
+	// Error paths (also exercise repoObservability's wrap and wrapf non-nil
+	// branches): a closed DB must surface an error, not a silent empty map.
+	dbo.Close()
+	if _, err := repo.All(ctx); err == nil {
+		t.Fatal("All on a closed DB must error")
+	}
+	if _, _, err := repo.Get(ctx, "shop.name"); err == nil {
+		t.Fatal("Get on a closed DB must error")
+	}
+}
+
+func TestInvoiceRepo_Create_SeriesNumberingAndDuplicateGuard(t *testing.T) {
+	dbo, err := db.Open(filepath.Join(t.TempDir(), "invoices2.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbo.Close()
+	ctx := context.Background()
+	repo := NewInvoiceRepo(dbo.DB)
+
+	for _, sale := range []string{"s1", "s2", "s3"} {
+		mustExec(t, dbo, `INSERT INTO sales(id, receipt_no, status, sale_type, currency, subtotal, discount_total, tax_total, total, created_at, completed_at)
+VALUES(?, 'R-'||?, 'completed', 'sale', 'GBP', 100, 0, 0, 100, '2026-01-01T10:00:00Z', '2026-01-01T10:00:00Z')`, sale, sale)
+	}
+	mk := func(series, kind, sale string) (InvoiceRow, error) {
+		return repo.Create(ctx, InvoiceInput{
+			Series: series, Kind: kind, SaleID: sale,
+			CustomerName: "Walk-in", SellerJSON: "{}", VATBreakdownJSON: "[]",
+			NetTotal: 100, GrossTotal: 100,
+			IssuedAt: "2026-01-01T10:05:00Z", IssuedBy: "u1",
+		})
+	}
+
+	// Numbering is per-series and sequential; the printed number embeds the
+	// series prefix (a replica till's receipt prefix keeps its invoices from
+	// colliding with the primary's).
+	inv1, err := mk("", "invoice", "s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inv1.InvoiceNo != 1 || inv1.DisplayNo != "INV-000001" {
+		t.Fatalf("first invoice numbering wrong: %+v", inv1)
+	}
+	inv2, err := mk("", "invoice", "s2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inv2.InvoiceNo != 2 || inv2.DisplayNo != "INV-000002" {
+		t.Fatalf("second invoice numbering wrong: %+v", inv2)
+	}
+	invT2, err := mk("T2-", "invoice", "s3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if invT2.InvoiceNo != 1 || invT2.DisplayNo != "T2-INV-000001" {
+		t.Fatalf("replica-series invoice must number independently with its prefix: %+v", invT2)
+	}
+
+	// UNIQUE(sale_id, kind): a sale can't be invoiced twice — and the retry
+	// loop must recognize this as permanent, not spin on it.
+	if _, err := mk("", "invoice", "s1"); err == nil {
+		t.Fatal("second invoice for the same sale must error")
+	}
+	var n int
+	if err := dbo.DB.QueryRow(`SELECT COUNT(*) FROM invoices WHERE sale_id = 's1' AND kind = 'invoice'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("duplicate attempt must not insert, got %d rows", n)
+	}
+}
+
+func TestModifierRepo_ItemIDsWithModifiers(t *testing.T) {
+	dbo, err := db.Open(filepath.Join(t.TempDir(), "mods.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbo.Close()
+	ctx := context.Background()
+	repo := NewModifierRepo(dbo.DB)
+
+	mustExec(t, dbo, `INSERT INTO items (id, sku, name, base_price, is_active) VALUES ('itm-mod','SKU-M','Coffee',300,1)`)
+	mustExec(t, dbo, `INSERT INTO items (id, sku, name, base_price, is_active) VALUES ('itm-retired','SKU-R','Old Coffee',300,1)`)
+	mustExec(t, dbo, `INSERT INTO items (id, sku, name, base_price, is_active) VALUES ('itm-plain','SKU-P','Water',100,1)`)
+	if _, err := repo.CreateGroup(ctx, "g-active", "itm-mod", "Extras", false, 0, 2, 0); err != nil {
+		t.Fatal(err)
+	}
+	gid, err := repo.CreateGroup(ctx, "g-retired", "itm-retired", "Extras", false, 0, 2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustExec(t, dbo, `UPDATE item_modifier_groups SET is_active = 0 WHERE id = ?`, gid)
+
+	// Empty input: nothing to look up, and no SQL "IN ()" syntax error.
+	got, err := repo.ItemIDsWithModifiers(ctx, nil)
+	if err != nil {
+		t.Fatalf("ItemIDsWithModifiers(nil): %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty result for empty input, got %#v", got)
+	}
+
+	got, err = repo.ItemIDsWithModifiers(ctx, []string{"itm-mod", "itm-retired", "itm-plain", "itm-ghost"})
+	if err != nil {
+		t.Fatalf("ItemIDsWithModifiers: %v", err)
+	}
+	if !got["itm-mod"] {
+		t.Fatal("item with an active group must be flagged")
+	}
+	// The button grid uses "absent == no customization step" — an item whose
+	// only group was retired must NOT be flagged, or every tap would open a
+	// modifier picker with nothing in it.
+	for _, id := range []string{"itm-retired", "itm-plain", "itm-ghost"} {
+		if got[id] {
+			t.Fatalf("%s must not be flagged: %#v", id, got)
+		}
+	}
+}
+
+func TestPOSRepo_InsertSaleLineModifiers(t *testing.T) {
+	dbo, err := db.Open(filepath.Join(t.TempDir(), "slm.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbo.Close()
+	ctx := context.Background()
+	repo := NewPOSRepo(dbo.DB)
+
+	mustExec(t, dbo, `INSERT INTO items (id, sku, name, base_price, is_active) VALUES ('itm-1','SKU1','Flat White',370,1)`)
+	mustExec(t, dbo, `INSERT INTO sales (id, receipt_no, status, sale_type, currency, subtotal, discount_total, tax_total, total, created_at) VALUES ('sale-1','R-1','completed','sale','GBP',470,0,0,470,datetime('now'))`)
+	mustExec(t, dbo, `INSERT INTO sale_lines (id, sale_id, line_no, item_id, name_snapshot, quantity, unit_price, line_discount, tax_rate_bp, tax_amount, total_before_tax, total_after_tax) VALUES ('line-1','sale-1',1,'itm-1','Flat White',1,470,0,0,0,470,470)`)
+
+	// Runs inside the same tx as InsertSaleLine in production — honor that.
+	tx, err := dbo.DB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mods := []SelectedModifier{
+		{GroupID: "g1", OptionID: "o1", GroupName: "Extras", OptionName: "Extra shot", PriceDeltaMinor: 50},
+		// Empty group/option ids must persist as NULL, not "" — the columns
+		// are nullable with no FK (migration 017), and NULL is what keeps
+		// "no source group" queryable via IS NULL. The live sale write path
+		// (pos_modifiers_api.go) always supplies real ids, so this exercises
+		// the repo's defensive nullableString handling, not a live flow.
+		{GroupID: "", OptionID: "", GroupName: "Extras", OptionName: "Oat milk", PriceDeltaMinor: 50},
+	}
+	if err := repo.InsertSaleLineModifiers(ctx, tx, "line-1", mods); err != nil {
+		tx.Rollback()
+		t.Fatalf("InsertSaleLineModifiers: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	type row struct {
+		groupID, optionID     *string
+		groupName, optionName string
+		delta                 int64
+	}
+	var rows []row
+	res, err := dbo.DB.Query(`SELECT group_id, option_id, group_name_snapshot, option_name_snapshot, price_delta_minor FROM sale_line_modifiers WHERE sale_line_id = 'line-1' ORDER BY option_name_snapshot`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Close()
+	for res.Next() {
+		var r row
+		if err := res.Scan(&r.groupID, &r.optionID, &r.groupName, &r.optionName, &r.delta); err != nil {
+			t.Fatal(err)
+		}
+		rows = append(rows, r)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 modifier rows, got %d", len(rows))
+	}
+	// "Extra shot" sorts first.
+	if rows[0].groupID == nil || *rows[0].groupID != "g1" || rows[0].optionID == nil || *rows[0].optionID != "o1" {
+		t.Fatalf("first row lost its ids: %+v", rows[0])
+	}
+	if rows[0].optionName != "Extra shot" || rows[0].delta != 50 {
+		t.Fatalf("first row snapshot wrong: %+v", rows[0])
+	}
+	if rows[1].groupID != nil || rows[1].optionID != nil {
+		t.Fatalf("empty ids must persist as NULL: %+v", rows[1])
+	}
+
+	// Empty mods: a no-op that must not touch the table or error.
+	tx2, err := dbo.DB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.InsertSaleLineModifiers(ctx, tx2, "line-1", nil); err != nil {
+		tx2.Rollback()
+		t.Fatalf("InsertSaleLineModifiers(nil): %v", err)
+	}
+	if err := tx2.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	var n int
+	if err := dbo.DB.QueryRow(`SELECT COUNT(*) FROM sale_line_modifiers WHERE sale_line_id = 'line-1'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("empty-mods call must not change rows, got %d", n)
+	}
+}


### PR DESCRIPTION
Batch 7 of the coverage push (queue item: *Test-coverage push, remainder*). Tests-only diff.

- **`auth_repo.go` 0% → ~85%** — first-ever coverage of the operator-auth surface: session lifecycle (expired/revoked/deactivated-user sessions all proven to deny), login-candidate filtering (NULL and empty-string PIN both excluded), last-admin-lockout count, purge grace window, user-wide revoke.
- **Stragglers**: invoice `BySale`/`ByDisplayNo`/series numbering + `UNIQUE(sale_id,kind)` duplicate guard, install-status `Get`, settings `All` (+ wrap/wrapf error branches), `ItemIDsWithModifiers`, `InsertSaleLineModifiers` (NULL-vs-`""` snapshot ids).
- **9 mutation probes** (4 pipeline + 5 independent opus review) — all fail against deliberately broken code. The independent review caught one real false-pass (TouchSession revoked-no-op collided at RFC3339 second resolution) — fixed with a sentinel; the previously surviving mutation now fails.
- All covered functions verified to have live production callers (no dead-surface coverage). `pos_repo.go`/`plugin_repo.go` queued as batches 8–9.

Review record: `docs/code-reviews/2026-07-30-coverage-data-batch7.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJZvKj4hxAA5AWo9JyVqkz