### PR TITLE
test: fix mobile data-dir cleanup flake (unjoined background writers)

### DIFF
--- a/docs/code-reviews/2026-07-30-mobile-test-cleanup-race.md
+++ b/docs/code-reviews/2026-07-30-mobile-test-cleanup-race.md
@@ -1,0 +1,70 @@
+# Code review — mobile test data-dir cleanup flake (main CI red)
+
+- **Date:** 2026-07-30
+- **Branch/PR:** `fix-mobile-test-cleanup-race`
+- **Author:** pipeline (fable)
+- **Independent reviewer:** opus subagent (different model)
+- **Scope:** `mobile/mobile_test.go` only (tests-only)
+
+## What happened
+
+Post-merge `ci` on main (run 30531313594, the PR #95 merge commit) failed:
+`TestIsRunning_DetectsServerDiedWithoutStop` →
+`testing.go:1369: TempDir RemoveAll cleanup: unlinkat .../002: directory not
+empty`. Neither PR #95 nor #96 touched `mobile/` — an intermittent flake
+that had been latent.
+
+## The review earned its keep — the first diagnosis was wrong
+
+The author's first fix assumed a LIFO-ordering bug (`t.Cleanup(Stop)`
+registered before the data-dir `t.TempDir()`, so RemoveAll would run before
+Stop). The independent reviewer **disproved this** by reading Go's
+`testing.makeTempDir` (the RemoveAll cleanup is registered only on a test's
+FIRST `t.TempDir()` call — which is the env-file one inside `mobileTestEnv`,
+already before `Stop`) and by empirically mirroring both call orders: Stop
+ran before RemoveAll in BOTH — the reordering was a no-op, and its comment
+would have misdirected future debugging.
+
+**Real root cause (reviewer's, verified against source):**
+`internal/app/app.go` starts `updates.Start`, `alerts.Start`, `enroll.Init`,
+and the plugin supervisor as detached goroutines and never joins them.
+`app.Run` returns as soon as the HTTP server stops, `mobile.Stop()`'s
+`<-done` unblocks, and a straggler goroutine can still write into the data
+dir (sqlite `-wal`/`-shm` etc.) while `RemoveAll` scans it — "directory not
+empty".
+
+## What shipped (final shape)
+
+- `mobileTestEnv` now owns the data dir via `os.MkdirTemp` (outside
+  `t.TempDir`'s cleanup machinery) and removes it in its own cleanup with a
+  5s retry window; `Stop` is registered after, so it runs first (LIFO). This
+  deterministically absorbs a straggler's last writes instead of racing them.
+- The helper's comment states the true cause and points at the queued
+  product fix.
+- Readability keep from the first attempt: tests use the returned data dir
+  instead of inline `t.TempDir()` calls.
+
+## Deferred (queued in ut-docs/QUEUE.md as its own 🟡 item)
+
+The product-shaped gap: `app.Run` should drain its background services
+before returning so "stopped" means no surviving writer (matters for the
+Android/iOS lifecycle path, not just tests). Plus the reviewer's nit:
+`mobile.Start` sets `UT_DATA_DIR` via raw `os.Setenv`, never restored.
+
+## Verification
+
+- Reviewer: LIFO claim empirically tested both ways; edge cases traced
+  (`TestStart_DifferentDataDirWhileRunningErrors`' inline dir never sees a
+  server write — Start fails before boot; `FastFail`'s failed Start leaves
+  no survivor); `go vet` + `go test ./mobile/ -count=5` green; verdict SAFE
+  TO MERGE with the comment correction, which was applied.
+- Author, post-correction: `go build ./...`, `go vet`, `go test ./mobile/
+  -count=5` green. The flake is timing-dependent (never reproduced locally
+  at `-count=15` pre-fix; one CI occurrence), so the proof here is the
+  traced mechanism plus a mitigation that cannot race by construction —
+  stated honestly rather than claiming a red/green repro.
+
+## Verdict
+
+**SAFE TO MERGE** (tests-only; misleading first-diagnosis comment corrected
+before commit; durable fix queued, not silently dropped).

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -5,23 +5,53 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // mobileTestEnv points the till at an isolated temp data dir and disables
 // auth (no PIN session needed to hit /healthz) for every test in this file —
 // mirrors how other live-verification runs in this repo set up a throwaway
 // till instance.
-func mobileTestEnv(t *testing.T) {
+// It also OWNS the data dir, deliberately NOT via t.TempDir(): app.Run's
+// background services (updates/alerts/enroll, the plugin supervisor) are
+// started as detached goroutines that app.Run does not join on shutdown, so
+// for a moment after Stop() returns a straggler can still write into the
+// data dir (sqlite -wal/-shm and friends). t.TempDir's own RemoveAll cleanup
+// races that and flakes with "TempDir RemoveAll cleanup: directory not
+// empty" (main CI 2026-07-30, run 30531313594). Until app.Run drains its
+// services before returning (queued in ut-docs/QUEUE.md), remove the dir
+// ourselves with a short retry window. Cleanup order (LIFO): Stop runs
+// first, then this retrying removal.
+func mobileTestEnv(t *testing.T) string {
 	t.Helper()
 	t.Setenv("UT_AUTH", "off")
 	t.Setenv("UT_ENV_FILE", t.TempDir()+"/does-not-exist.env") // don't pick up a stray local pos.env
+	dataDir, err := os.MkdirTemp("", "ut-mobile-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			err := os.RemoveAll(dataDir)
+			if err == nil {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Errorf("cleanup data dir: %v", err)
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	})
 	t.Cleanup(Stop)
+	return dataDir
 }
 
 func TestStartAndStop_RealServerBoots(t *testing.T) {
-	mobileTestEnv(t)
+	dataDir := mobileTestEnv(t)
 
-	addr, err := Start(t.TempDir())
+	addr, err := Start(dataDir)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -54,9 +84,8 @@ func TestStartAndStop_RealServerBoots(t *testing.T) {
 }
 
 func TestStart_IdempotentWhileRunning(t *testing.T) {
-	mobileTestEnv(t)
+	dataDir := mobileTestEnv(t)
 
-	dataDir := t.TempDir()
 	addr1, err := Start(dataDir)
 	if err != nil {
 		t.Fatalf("first Start: %v", err)
@@ -76,22 +105,23 @@ func TestStart_IdempotentWhileRunning(t *testing.T) {
 }
 
 func TestStart_DifferentDataDirWhileRunningErrors(t *testing.T) {
-	mobileTestEnv(t)
+	dataDir := mobileTestEnv(t)
 
-	if _, err := Start(t.TempDir()); err != nil {
+	if _, err := Start(dataDir); err != nil {
 		t.Fatalf("first Start: %v", err)
 	}
 
 	// A second Start with a DIFFERENT dataDir while already running must
 	// fail loudly, not silently ignore the request and keep serving the
-	// first dataDir under a caller's mistaken belief it switched.
+	// first dataDir under a caller's mistaken belief it switched. (This
+	// other dir sees no live server write, so an inline t.TempDir is fine.)
 	if _, err := Start(t.TempDir()); err == nil {
 		t.Fatal("expected Start against a different dataDir while running to error")
 	}
 }
 
 func TestStart_FastFailWhenServerDiesImmediately(t *testing.T) {
-	mobileTestEnv(t)
+	_ = mobileTestEnv(t) // Start below never boots a server; env setup only
 
 	// A regular FILE where the data dir should be a directory makes
 	// db.Open fail immediately (DBPath = filepath.Join(dataDir,
@@ -120,9 +150,8 @@ func TestStart_FastFailWhenServerDiesImmediately(t *testing.T) {
 // from the caller's point of view) simulates that, without needing to
 // engineer an actual server-internal failure.
 func TestIsRunning_DetectsServerDiedWithoutStop(t *testing.T) {
-	mobileTestEnv(t)
+	dataDir := mobileTestEnv(t)
 
-	dataDir := t.TempDir()
 	if _, err := Start(dataDir); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -154,7 +183,7 @@ func TestIsRunning_DetectsServerDiedWithoutStop(t *testing.T) {
 }
 
 func TestStop_SafeWhenNotRunning(t *testing.T) {
-	mobileTestEnv(t)
+	_ = mobileTestEnv(t)
 	Stop() // must not panic
 	if IsRunning() {
 		t.Fatal("IsRunning() should be false when Start was never called")


### PR DESCRIPTION
Main CI run 30531313594 (the PR #95 merge commit) flaked: `TestIsRunning_DetectsServerDiedWithoutStop` → "TempDir RemoveAll cleanup: directory not empty", in code neither open PR touched.

The independent (opus) review **disproved the first diagnosis** (a LIFO cleanup-ordering theory — Go registers TempDir's RemoveAll only on a test's *first* `t.TempDir` call, so `Stop` already ran first; verified empirically both ways) and traced the real cause: `app.Run` starts updates/alerts/enroll/plugin-supervisor goroutines it never joins, so a straggler can still write into the data dir after `Stop()` returns.

This PR is the test-side mitigation: `mobileTestEnv` owns the data dir via `os.MkdirTemp` and removes it with a 5s retry window after `Stop`, outside `t.TempDir`'s cleanup machinery — can't race a straggler by construction. The product-shaped fix (`app.Run` draining its services so "stopped" means no surviving writer) is queued in `ut-docs/QUEUE.md` as its own 🟡 item.

Review record: `docs/code-reviews/2026-07-30-mobile-test-cleanup-race.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJZvKj4hxAA5AWo9JyVqkz