### PR TITLE
test: cover the 42 zero-coverage pos_repo funcs (63.6%->76.2%); fix low-stock report poisoning + variant margin fallback

### DIFF
--- a/docs/code-reviews/2026-07-30-coverage-data-batch8.md
+++ b/docs/code-reviews/2026-07-30-coverage-data-batch8.md
@@ -1,0 +1,183 @@
+# Code review — coverage batch 8: `internal/data/pos_repo.go` (+2 real fixes)
+
+- **Date**: 2026-07-30
+- **Branch**: `test/coverage-data-batch8-pos-repo`
+- **Scope**: the 42 zero-coverage functions in `internal/data/pos_repo.go`
+  (per batch 7's closing note), plus two real product bugs the new tests
+  exposed, fixed TDD-style in the same batch.
+- **Author lanes**: four parallel same-session dev agents, one domain
+  group each (reports / inventory / sales lifecycle / lookups-ensure-
+  payments-pricing), each owning exactly one new test file; orchestrator
+  wrote the fixes + regression tests.
+- **Independent review**: different-model (opus) subagent, findings below.
+
+## What shipped
+
+Five new test files in `internal/data/`:
+
+- `pos_repo_batch8_reports_test.go` — SalesByDay, SlowItems, DeadStock,
+  TaxSummary, MarginByItem, DayTotal, SeasonalUpcoming, SalesByWeekday /
+  SalesByHour / busyBuckets, ItemDailySellRates (90–100% each).
+- `pos_repo_batch8_inventory_test.go` — AggregateInventory,
+  CheckNegativeInventory, RecordNegativeInventoryOverride,
+  GetLowStockItems, ListStockLocations, ListStockLevels, CurrentQty
+  (77–92% each).
+- `pos_repo_batch8_sales_test.go` — LookupUserRole, FindSaleIDByReceipt,
+  ListSaleLineSnapshots, GetReceiptNo, NextReceiptNo (incl. per-till
+  `sync.receipt_prefix` namespacing), InsertSale/InsertSaleLine roundtrip,
+  UpdateSaleStatus, RecordPaymentFailure, SaleTotals, SaleCompletedAt,
+  GetSaleDetailByID, ListRecentSales (80–100% each).
+- `pos_repo_batch8_lookups_test.go` — LookupCustomer, FindActivePromo,
+  EnsurePaymentMethod/EnsureRegister/EnsureUser idempotency,
+  ListActivePluginVersions, ListActivePaymentMethods,
+  **ListActiveNonCashPaymentMethods (the kiosk's cash-exclusion filter,
+  proven to exclude `type='cash'` and inactive methods)**,
+  AppendPriceHistoryItem/Variant close/open invariants, valueOrDefault
+  (77–100% each).
+- `pos_repo_batch8_fixes_test.go` — failing-first regression tests for
+  the two production fixes below.
+
+Package coverage: **63.6% → 76.2%** of statements. Every covered function
+was checked for live production callers first (all 42 have them; the two
+private helpers are covered via their exported callers) — no dead-surface
+coverage theater.
+
+## Two real bugs found by writing these tests, fixed here (TDD)
+
+Both confirmed failing-first with the exact predicted errors, then fixed,
+then passing; production diff is 2 lines total.
+
+1. **`GetLowStockItems` — one never-stocked item silently killed ALL
+   low-stock alerts.** `inv.location_id` came out of a LEFT JOIN
+   un-COALESCEd and was scanned into a plain `string`, so any item with
+   `reorder_level > 0` but no inventory row yet (a brand-new item before
+   first goods-receipt) made the whole query error — and the back-office
+   caller (`internal/pages/backoffice_page.go:39`) drops that error, so
+   the owner just saw no low-stock alerts at all. Fix:
+   `COALESCE(inv.location_id, '')`; never-stocked items now correctly
+   appear as qty 0. Known accepted limit: with a location filter the
+   `AND inv.location_id = ?` clause still excludes never-stocked items.
+2. **`MarginByItem` — variant sales vanished from the margin report
+   unless the variant had its own `cost_price`.** The doc comment says
+   "using the variant's cost when present, else the item's", but items
+   were joined on `sl.item_id`, which is NULL for variant lines (schema
+   CHECK: exactly one of item_id/variant_id) — so the item-cost fallback
+   could never fire. Fix: join items via
+   `COALESCE(NULLIF(sl.item_id,''), v.item_id)`, the same resolution
+   pattern `SeasonalUpcoming` already uses.
+
+## Suspected bugs found but deliberately NOT fixed here (queued instead)
+
+- `SaleCompletedAt` scans NULL `completed_at` into a plain string →
+  error; live caller `pos_api.go:616` swallows it and proceeds with a
+  zero time in the refund-window check. Low severity today (InsertSale
+  always writes completed_at); pinned in tests.
+- `UpdateSaleStatus` is a silent no-op for an unknown sale id (no
+  RowsAffected check). Pinned in tests.
+- `SalesByDay` has no `sale_type` filter, so completed returns count as
+  positive daily revenue on the owner dashboard — inconsistent with
+  TaxSummary (negates) and DayTotal/busyBuckets (exclude). Needs a
+  product-semantics call, left un-asserted.
+
+## Verification (pipeline side, performed personally by orchestrator)
+
+- Both regression tests seen failing pre-fix with the exact predicted
+  errors, passing post-fix.
+- **5 mutation probes, all killed**: low-stock `<`→`<=` (boundary),
+  kiosk non-cash filter removed (security-relevant), receipt-no `+1`→`+2`
+  (sequencing), TaxSummary return-negation removed (money math),
+  negative-inventory `<`→`<=` (sell-exactly-to-zero). Each failed the
+  right test; each reverted.
+- `go build ./...`, `go vet ./...`, full `go test ./...` green;
+  `guard-data-access.sh` and `guard-i18n.sh` pass.
+
+## Accepted remainder (said out loud, not silent)
+
+Driver/scan-failure branches (`rows.Scan`/`rows.Err`/`QueryContext` on a
+healthy migrated sqlite DB), interior transaction-failure branches in
+AppendPriceHistory*/RecordStockMovement, and `FindActivePromo`'s
+defensive `pType == ""` branch (unreachable: NOT NULL + CHECK constraint)
+— all would need fault injection disproportionate to their risk; the
+closed-DB error path IS covered for the report/lookup groups.
+
+## Independent (opus) review findings
+
+**No blockers.** The reviewer verified all five author claims
+independently: per-function coverage diff of two profiles confirmed
+exactly 42 `pos_repo.go` functions went 0% → covered (none remain at 0%);
+both fixes proven correct and minimal (both join keys are primary keys so
+the re-order cannot fan out; `inventory.location_id` is `NOT NULL` so the
+COALESCE can only ever represent "no inventory row"); isolation confirmed
+(per-test temp DBs, two `-shuffle=on` full-package runs green, no
+`t.Parallel()`, no rolling-window time bombs). It ran **17 fresh mutation
+probes** (different sites from the pipeline's five): 13 killed, including
+DeadStock value math, EnsurePaymentMethod `OR IGNORE`→`OR REPLACE`,
+FindActivePromo expiry guard, SaleTotals column swap, price-history
+close-previous UPDATE, and both production fixes re-reverted.
+
+**Findings fixed before commit (re-verified personally, mutations re-run
+and now killed):**
+
+1. *should-fix*: the weekday/hour bucket test derived expectations from
+   Go's `tm.Local()`, making it timezone-adaptive but timezone-blind —
+   under CI's `TZ=UTC` it couldn't catch a `%w`→`%u` weekday swap or
+   SQLite-vs-Go local-clock drift. Now derives expected slots from a
+   SQLite `strftime(...,'localtime')` control query plus a Go-local
+   sanity cross-check. Honest residual, documented in the test: a
+   production query that *dropped* `'localtime'` is behaviorally
+   invisible under `TZ=UTC` — only catchable on non-UTC machines.
+2. *should-fix*: `SeasonalUpcoming`'s Ceil rounding was untested (all
+   fixtures whole-numbered; reviewer's Floor mutation survived). Added a
+   weighed-stock case (2.5 sold, 1 on hand → suggest 2). Mutation re-run:
+   killed.
+3. *nit*: the `days<=0 → 28` default wasn't pinned (a 14-day default
+   survived). Added a −340d sale visible only under a 28-day window.
+   Mutation re-run: killed.
+4. *nit*: a dead assertion in the stock-levels test checked for the
+   variant id leaking, but a leaked variant inventory row would surface
+   under its PARENT item id — assertion now targets the parent.
+5. *nit*: misleading failure label in the EnsureUser idempotency test;
+   fixed.
+6. *nit*: a test comment claimed the UpdateSaleStatus unknown-id no-op
+   was "documented" — it isn't; reworded to "pins current behavior" with
+   a pointer at the QUEUE follow-up.
+
+**Reviewer findings accepted as-is (not fixed here, queued):**
+
+- `DeadStock`'s "has sold" subquery counts completed *returns* as sales,
+  and `TopItems` lacks the `sale_type='sale'` filter `SlowItems` has —
+  same family as the deferred `SalesByDay` returns issue; one QUEUE item.
+- Location-filtered `GetLowStockItems` still can't show never-stocked
+  items (`AND inv.location_id = ?` never matches a missed LEFT JOIN).
+  Not a regression — the filtered path never hit the NULL-scan bug — but
+  the reviewer rates it worth fixing (`OR inv.location_id IS NULL` is
+  safe given the column is `NOT NULL`); queued.
+- Fix (b) **changes reported business numbers, deliberately**: variant
+  lines without their own cost now enter the margin report at the parent
+  item's cost. For a premium variant this can understate cost/overstate
+  margin vs. excluding the line entirely — but it matches the function's
+  own doc-comment intent and the resolution pattern of
+  `SeasonalUpcoming`/`ItemDailySellRates`. Called out here because
+  `reports_page.go:25` drops the error, so the owner sees the new
+  numbers with no other signal.
+- Batch-8 test helper sprawl (four near-identical DB openers across the
+  four files) — consolidate in batch 9.
+- Some assertions pin exact migration-seed contents (kiosk user id,
+  3 seeded stock locations); they fail loudly, accepted.
+
+**Reviewer's ranking of the three deferred bugs** (adopted into the QUEUE
+follow-up): `SalesByDay` returns-as-revenue is the one to fix next — it
+feeds the reports page, back office AND the self-hosted AI Q&A
+(`ask_api.go:45`), and disagrees with `TaxSummary` on the same page.
+`UpdateSaleStatus` no-op is slightly worse than cosmetic (a void of an
+unknown sale id returns 204 AND writes a "voided" audit row for a sale
+that was never voided — audit-log poisoning; adjacent gap: `pos_api.go:668`
+passes an empty actorID, so voids record no operator). `SaleCompletedAt`
+NULL-scan is effectively unreachable in the field (the only production
+insert always writes `completed_at`).
+
+## Final gate (after review fixes)
+
+`go build ./...`, `go vet ./...`, full `go test ./...` all green;
+both CI guards pass; `git diff internal/data/pos_repo.go` = exactly the
+two intended 2-line hunks.

--- a/internal/data/pos_repo.go
+++ b/internal/data/pos_repo.go
@@ -499,7 +499,7 @@ SELECT
 	i.id,
 	i.name,
 	COALESCE(i.sku, ''),
-	inv.location_id,
+	COALESCE(inv.location_id, ''),
 	COALESCE(sl.name, ''),
 	COALESCE(inv.quantity, 0),
 	i.reorder_level
@@ -871,8 +871,8 @@ SELECT sl.name_snapshot,
        CAST(SUM(sl.quantity * COALESCE(v.cost_price, i.cost_price)) AS INTEGER) AS cost
 FROM sale_lines sl
 JOIN sales s ON s.id = sl.sale_id
-LEFT JOIN items i ON i.id = sl.item_id
 LEFT JOIN item_variants v ON v.id = sl.variant_id
+LEFT JOIN items i ON i.id = COALESCE(NULLIF(sl.item_id, ''), v.item_id)
 WHERE s.status = 'completed' AND s.sale_type = 'sale'
   AND s.created_at >= datetime('now', ?)
   AND COALESCE(v.cost_price, i.cost_price) IS NOT NULL

--- a/internal/data/pos_repo_batch8_fixes_test.go
+++ b/internal/data/pos_repo_batch8_fixes_test.go
@@ -1,0 +1,88 @@
+package data
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Coverage batch 8 surfaced two real POSRepo bugs; these are their
+// regression tests, written failing-first against the unfixed code.
+//
+// 1. GetLowStockItems: an item with reorder_level > 0 but no inventory
+//    row yet made the WHOLE query fail (NULL inv.location_id scanned
+//    into a plain string), so one never-stocked item silently killed
+//    every low-stock alert (the back-office caller drops the error).
+// 2. MarginByItem: doc-intent is "variant's cost when present, else the
+//    item's", but items were joined on sl.item_id, which is NULL for
+//    variant lines — a variant without its own cost_price vanished from
+//    the margin report even when its parent item had a cost.
+
+func TestGetLowStockItems_NeverStockedItemDoesNotPoisonReport(t *testing.T) {
+	d := b8OpenDB(t, "lowstock-fix.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	// Neutralize the demo seed catalog so the assertion set is exact.
+	mustExec(t, d, `DELETE FROM inventory`)
+	mustExec(t, d, `UPDATE items SET reorder_level = 0`)
+	mustExec(t, d, `INSERT INTO stock_locations (id, name) VALUES ('loc_fix', 'Fix Main')`)
+
+	b8Item(t, d, "fix-stocked", 500, nil, 1)
+	mustExec(t, d, `UPDATE items SET reorder_level = 5 WHERE id = 'fix-stocked'`)
+	mustExec(t, d, `INSERT INTO inventory (id, item_id, location_id, quantity) VALUES ('inv-fix', 'fix-stocked', 'loc_fix', 2)`)
+
+	// The poison pill: reorder level set, but no inventory row yet —
+	// a brand-new item a shop hasn't received stock for.
+	b8Item(t, d, "fix-never", 500, nil, 1)
+	mustExec(t, d, `UPDATE items SET reorder_level = 5 WHERE id = 'fix-never'`)
+
+	items, err := repo.GetLowStockItems(ctx, "")
+	if err != nil {
+		t.Fatalf("GetLowStockItems must survive a never-stocked item, got: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("want 2 low-stock rows (stocked-below-level + never-stocked), got %d: %+v", len(items), items)
+	}
+	// ORDER BY i.name: "Name fix-never" < "Name fix-stocked".
+	never, stocked := items[0], items[1]
+	if never.ItemID != "fix-never" || stocked.ItemID != "fix-stocked" {
+		t.Fatalf("wrong rows/order: %+v", items)
+	}
+	if never.CurrentQty != 0 || never.LocationID != "" || never.LocationName != "" {
+		t.Errorf("never-stocked row must report qty 0 with empty location, got %+v", never)
+	}
+	if stocked.CurrentQty != 2 || stocked.LocationID != "loc_fix" || stocked.LocationName != "Fix Main" || stocked.ReorderLevel != 5 {
+		t.Errorf("stocked row fields wrong: %+v", stocked)
+	}
+}
+
+func TestMarginByItem_VariantWithoutOwnCostFallsBackToItemCost(t *testing.T) {
+	d := b8OpenDB(t, "margin-fix.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	b8Item(t, d, "fix-parent", 300, int64(100), 1)
+	mustExec(t, d, `INSERT INTO item_variants (id, item_id, name, price) VALUES ('v-fix', 'fix-parent', 'Large', 300)`)
+
+	now := b8At(time.Now().Add(-1 * time.Hour))
+	b8Sale(t, d, "sale-fix", now, "completed", "sale", 0, 600)
+	b8Line(t, d, "sale-fix", 1, "", "v-fix", "Fix Parent Large", 2, 0, 0, 600, 600)
+
+	rows, err := repo.MarginByItem(ctx, 30, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got *MarginRow
+	for i := range rows {
+		if rows[i].Name == "Fix Parent Large" {
+			got = &rows[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("variant line (no variant cost, parent item cost 100) missing from margin report: %+v", rows)
+	}
+	if got.Revenue != 600 || got.Cost != 200 || got.Margin != 400 {
+		t.Errorf("want revenue 600 / cost 2x100=200 / margin 400, got %+v", *got)
+	}
+}

--- a/internal/data/pos_repo_batch8_inventory_test.go
+++ b/internal/data/pos_repo_batch8_inventory_test.go
@@ -1,0 +1,454 @@
+package data
+
+// Coverage batch 8 — POSRepo inventory/stock group:
+// AggregateInventory, CheckNegativeInventory, RecordNegativeInventoryOverride,
+// GetLowStockItems, ListStockLocations, ListStockLevels, CurrentQty.
+//
+// The init migration seeds demo data: 3 stock locations (loc_back "Back
+// Store", loc_main "Main Store", loc_wh "Warehouse"), ~50 items and ~62
+// inventory rows — but no seeded item has reorder_level > 0, so the
+// low-stock queries start empty. Tests below either assert against the
+// known seed (locations) or use "b8-" prefixed rows and filter to them.
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/db"
+)
+
+func openB8InvDB(t *testing.T) (*db.DB, *POSRepo) {
+	t.Helper()
+	dbo, err := db.Open(filepath.Join(t.TempDir(), "batch8.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { dbo.Close() })
+	return dbo, NewPOSRepo(dbo.DB)
+}
+
+// seedB8Item inserts an item (satisfying NOT NULL base_price) with a reorder level.
+func seedB8Item(t *testing.T, d *db.DB, id, sku, name string, reorder int, active int) {
+	t.Helper()
+	mustExec(t, d, `INSERT INTO items (id, sku, name, base_price, reorder_level, is_active) VALUES (?,?,?,100,?,?)`,
+		id, sku, name, reorder, active)
+}
+
+// seedB8Inventory inserts an item-level inventory row at a location.
+func seedB8Inventory(t *testing.T, d *db.DB, itemID, locationID string, qty float64) {
+	t.Helper()
+	mustExec(t, d, `INSERT INTO inventory (id, item_id, variant_id, location_id, quantity) VALUES (?,?,NULL,?,?)`,
+		"inv-"+itemID+"-"+locationID, itemID, locationID, qty)
+}
+
+// seedB8Variant inserts a parent item + variant and a variant-level inventory row.
+func seedB8Variant(t *testing.T, d *db.DB, itemID, variantID, locationID string, qty float64) {
+	t.Helper()
+	seedB8Item(t, d, itemID, "sku-"+itemID, "B8 Parent "+itemID, 0, 1)
+	mustExec(t, d, `INSERT INTO item_variants (id, item_id, name, price) VALUES (?,?,?,150)`,
+		variantID, itemID, "330ml")
+	mustExec(t, d, `INSERT INTO inventory (id, item_id, variant_id, location_id, quantity) VALUES (?,NULL,?,?,?)`,
+		"inv-"+variantID, variantID, locationID, qty)
+}
+
+func b8Tx(t *testing.T, d *db.DB) *sql.Tx {
+	t.Helper()
+	tx, err := d.DB.Begin()
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	t.Cleanup(func() { tx.Rollback() })
+	return tx
+}
+
+func TestAggregateInventory_Batch8(t *testing.T) {
+	d, repo := openB8InvDB(t)
+	ctx := context.Background()
+
+	// Validation errors — each mutually exclusive precondition.
+	if _, err := repo.AggregateInventory(ctx, nil, "", "b8-i1", ""); err == nil || !strings.Contains(err.Error(), "locationID required") {
+		t.Fatalf("empty location: want locationID error, got %v", err)
+	}
+	if _, err := repo.AggregateInventory(ctx, nil, "loc_main", "", ""); err == nil || !strings.Contains(err.Error(), "itemID or variantID required") {
+		t.Fatalf("no item/variant: want required error, got %v", err)
+	}
+	if _, err := repo.AggregateInventory(ctx, nil, "loc_main", "b8-i1", "b8-v1"); err == nil || !strings.Contains(err.Error(), "cannot specify both") {
+		t.Fatalf("both item+variant: want both error, got %v", err)
+	}
+
+	// Item stocked at two locations: quantity is per-location, never summed.
+	seedB8Item(t, d, "b8-agg", "b8-agg-sku", "B8 Agg", 0, 1)
+	seedB8Inventory(t, d, "b8-agg", "loc_main", 7.5)
+	seedB8Inventory(t, d, "b8-agg", "loc_back", 4)
+
+	if qty, err := repo.AggregateInventory(ctx, nil, "loc_main", "b8-agg", ""); err != nil || qty != 7.5 {
+		t.Fatalf("loc_main qty: got %v err=%v, want 7.5", qty, err)
+	}
+	if qty, err := repo.AggregateInventory(ctx, nil, "loc_back", "b8-agg", ""); err != nil || qty != 4 {
+		t.Fatalf("loc_back qty: got %v err=%v, want 4", qty, err)
+	}
+	// Third location with no row: 0 with nil error (ErrNoRows swallowed).
+	if qty, err := repo.AggregateInventory(ctx, nil, "loc_wh", "b8-agg", ""); err != nil || qty != 0 {
+		t.Fatalf("no-row location: got %v err=%v, want 0,<nil>", qty, err)
+	}
+	// Unknown item entirely: also 0, nil.
+	if qty, err := repo.AggregateInventory(ctx, nil, "loc_main", "b8-ghost", ""); err != nil || qty != 0 {
+		t.Fatalf("unknown item: got %v err=%v, want 0,<nil>", qty, err)
+	}
+
+	// Variant-level row: matched via variantID, and never via the parent item id.
+	seedB8Variant(t, d, "b8-aggp", "b8-aggv", "loc_main", 3)
+	if qty, err := repo.AggregateInventory(ctx, nil, "loc_main", "", "b8-aggv"); err != nil || qty != 3 {
+		t.Fatalf("variant qty: got %v err=%v, want 3", qty, err)
+	}
+	if qty, err := repo.AggregateInventory(ctx, nil, "loc_main", "b8-aggp", ""); err != nil || qty != 0 {
+		t.Fatalf("parent item must not see variant row: got %v err=%v, want 0", qty, err)
+	}
+	// An item id passed in the variant slot must not match an item-level row.
+	if qty, err := repo.AggregateInventory(ctx, nil, "loc_main", "", "b8-agg"); err != nil || qty != 0 {
+		t.Fatalf("item id in variant slot must not match: got %v err=%v, want 0", qty, err)
+	}
+
+	// Works inside a transaction, reading uncommitted writes.
+	tx := b8Tx(t, d)
+	if _, err := tx.Exec(`UPDATE inventory SET quantity = 9 WHERE item_id = 'b8-agg' AND location_id = 'loc_main'`); err != nil {
+		t.Fatalf("tx update: %v", err)
+	}
+	if qty, err := repo.AggregateInventory(ctx, tx, "loc_main", "b8-agg", ""); err != nil || qty != 9 {
+		t.Fatalf("in-tx qty: got %v err=%v, want 9", qty, err)
+	}
+}
+
+func TestCheckNegativeInventory_Batch8(t *testing.T) {
+	d, repo := openB8InvDB(t)
+	ctx := context.Background()
+
+	// Zero/negative requests are a no-op check — even without a transaction.
+	if err := repo.CheckNegativeInventory(ctx, nil, "loc_main", "b8-i", "", 0); err != nil {
+		t.Fatalf("qty 0: want nil, got %v", err)
+	}
+	if err := repo.CheckNegativeInventory(ctx, nil, "loc_main", "b8-i", "", -2); err != nil {
+		t.Fatalf("qty -2: want nil, got %v", err)
+	}
+	// A positive request requires a transaction.
+	if err := repo.CheckNegativeInventory(ctx, nil, "loc_main", "b8-i", "", 1); err == nil || !strings.Contains(err.Error(), "transaction required") {
+		t.Fatalf("nil tx: want transaction required, got %v", err)
+	}
+
+	seedB8Item(t, d, "b8-chk", "b8-chk-sku", "B8 Check", 0, 1)
+	seedB8Inventory(t, d, "b8-chk", "loc_main", 5)
+	seedB8Variant(t, d, "b8-chkp", "b8-chkv", "loc_main", 2)
+
+	tx := b8Tx(t, d)
+	// Selling exactly down to zero is allowed — threshold is strictly below zero.
+	if err := repo.CheckNegativeInventory(ctx, tx, "loc_main", "b8-chk", "", 5); err != nil {
+		t.Fatalf("exact-to-zero: want nil, got %v", err)
+	}
+	// One unit over goes negative — rejected with have/need in the message.
+	err := repo.CheckNegativeInventory(ctx, tx, "loc_main", "b8-chk", "", 6)
+	if err == nil || !strings.Contains(err.Error(), "insufficient stock") {
+		t.Fatalf("over stock: want insufficient stock, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "have 5.00, need 6.00") || !strings.Contains(err.Error(), "b8-chk") || !strings.Contains(err.Error(), "loc_main") {
+		t.Fatalf("error must carry item, location, have/need: %v", err)
+	}
+	// Fractional overshoot (weighed items) is also rejected.
+	if err := repo.CheckNegativeInventory(ctx, tx, "loc_main", "b8-chk", "", 5.01); err == nil {
+		t.Fatal("fractional overshoot: want error, got nil")
+	}
+	// No inventory row at all counts as zero on hand.
+	if err := repo.CheckNegativeInventory(ctx, tx, "loc_main", "b8-never-stocked", "", 1); err == nil || !strings.Contains(err.Error(), "have 0.00, need 1.00") {
+		t.Fatalf("never stocked: want have 0.00 error, got %v", err)
+	}
+	// Variant path: 2 on hand.
+	if err := repo.CheckNegativeInventory(ctx, tx, "loc_main", "", "b8-chkv", 2); err != nil {
+		t.Fatalf("variant exact: want nil, got %v", err)
+	}
+	if err := repo.CheckNegativeInventory(ctx, tx, "loc_main", "", "b8-chkv", 3); err == nil || !strings.Contains(err.Error(), "b8-chkv") {
+		t.Fatalf("variant over: want error naming variant, got %v", err)
+	}
+}
+
+func TestRecordNegativeInventoryOverride_Batch8(t *testing.T) {
+	d, repo := openB8InvDB(t)
+	ctx := context.Background()
+
+	if _, err := repo.RecordNegativeInventoryOverride(ctx, OverrideNegativeInventory{Reason: "r"}); err == nil || !strings.Contains(err.Error(), "actorID required") {
+		t.Fatalf("missing actor: got %v", err)
+	}
+	if _, err := repo.RecordNegativeInventoryOverride(ctx, OverrideNegativeInventory{ActorID: "system"}); err == nil || !strings.Contains(err.Error(), "reason required") {
+		t.Fatalf("missing reason: got %v", err)
+	}
+
+	// Item-level override — 'system' user is seeded by migration 003 and
+	// satisfies audit_log's actor FK.
+	id, err := repo.RecordNegativeInventoryOverride(ctx, OverrideNegativeInventory{
+		ActorID: "system", Reason: "manager approved oversell",
+		ItemID: "b8-item", LocationID: "loc_main", QtyBefore: -2.5,
+	})
+	if err != nil || id == "" {
+		t.Fatalf("override: id=%q err=%v", id, err)
+	}
+
+	var actorID, entityType, entityID, action, dataJSON string
+	row := d.DB.QueryRow(`SELECT actor_id, entity_type, entity_id, action, data_json FROM audit_log WHERE id = ?`, id)
+	if err := row.Scan(&actorID, &entityType, &entityID, &action, &dataJSON); err != nil {
+		t.Fatalf("audit row missing: %v", err)
+	}
+	if actorID != "system" || entityType != "inventory" || action != "negative_inventory_override" {
+		t.Fatalf("audit identity fields wrong: actor=%q type=%q action=%q", actorID, entityType, action)
+	}
+	if entityID != "loc_main:b8-item" {
+		t.Fatalf("entity_id: got %q, want loc_main:b8-item", entityID)
+	}
+	var payload struct {
+		Reason   string `json:"reason"`
+		Snapshot struct {
+			ItemID     string  `json:"item_id"`
+			VariantID  string  `json:"variant_id"`
+			LocationID string  `json:"location_id"`
+			QtyBefore  float64 `json:"qty_before"`
+		} `json:"snapshot"`
+	}
+	if err := json.Unmarshal([]byte(dataJSON), &payload); err != nil {
+		t.Fatalf("data_json not valid JSON: %v (%s)", err, dataJSON)
+	}
+	if payload.Reason != "manager approved oversell" {
+		t.Fatalf("reason: got %q", payload.Reason)
+	}
+	if payload.Snapshot.ItemID != "b8-item" || payload.Snapshot.LocationID != "loc_main" || payload.Snapshot.QtyBefore != -2.5 {
+		t.Fatalf("snapshot wrong: %+v", payload.Snapshot)
+	}
+
+	// Variant-level override: entity_id falls back to the variant id.
+	id2, err := repo.RecordNegativeInventoryOverride(ctx, OverrideNegativeInventory{
+		ActorID: "system", Reason: "variant oversell",
+		VariantID: "b8-var", LocationID: "loc_back", QtyBefore: 0,
+	})
+	if err != nil {
+		t.Fatalf("variant override: %v", err)
+	}
+	var entityID2 string
+	if err := d.DB.QueryRow(`SELECT entity_id FROM audit_log WHERE id = ?`, id2).Scan(&entityID2); err != nil {
+		t.Fatalf("variant audit row: %v", err)
+	}
+	if entityID2 != "loc_back:b8-var" {
+		t.Fatalf("variant entity_id: got %q, want loc_back:b8-var", entityID2)
+	}
+}
+
+func TestGetLowStockItems_Batch8(t *testing.T) {
+	d, repo := openB8InvDB(t)
+	ctx := context.Background()
+
+	// No seeded demo item carries a reorder level, so the report starts empty.
+	if items, err := repo.GetLowStockItems(ctx, ""); err != nil || len(items) != 0 {
+		t.Fatalf("baseline: got %d items err=%v, want 0", len(items), err)
+	}
+
+	// Names chosen so ORDER BY i.name is deterministic.
+	seedB8Item(t, d, "b8-low", "sku-low", "B8A Low", 10, 1)
+	seedB8Inventory(t, d, "b8-low", "loc_main", 4)
+	seedB8Item(t, d, "b8-just", "sku-just", "B8B JustBelow", 10, 1)
+	seedB8Inventory(t, d, "b8-just", "loc_main", 9)
+	seedB8Item(t, d, "b8-at", "sku-at", "B8C AtLevel", 10, 1)
+	seedB8Inventory(t, d, "b8-at", "loc_main", 10)
+	seedB8Item(t, d, "b8-oth", "sku-oth", "B8D OtherLoc", 5, 1)
+	seedB8Inventory(t, d, "b8-oth", "loc_back", 1)
+	seedB8Item(t, d, "b8-zero", "sku-zero", "B8E NoReorder", 0, 1)
+	seedB8Inventory(t, d, "b8-zero", "loc_main", 0)
+
+	// Unfiltered: strictly-below-reorder rows only, name order.
+	items, err := repo.GetLowStockItems(ctx, "")
+	if err != nil {
+		t.Fatalf("unfiltered: %v", err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("unfiltered: got %d items %+v, want 3", len(items), items)
+	}
+	wantIDs := []string{"b8-low", "b8-just", "b8-oth"}
+	for i, want := range wantIDs {
+		if items[i].ItemID != want {
+			t.Fatalf("order[%d]: got %q, want %q (full: %+v)", i, items[i].ItemID, want, items)
+		}
+	}
+	first := items[0]
+	if first.Name != "B8A Low" || first.SKU != "sku-low" || first.LocationID != "loc_main" ||
+		first.LocationName != "Main Store" || first.CurrentQty != 4 || first.ReorderLevel != 10 {
+		t.Fatalf("row fields wrong: %+v", first)
+	}
+	// At-level (10 of 10) is NOT low — the threshold is strictly below.
+	for _, it := range items {
+		if it.ItemID == "b8-at" || it.ItemID == "b8-zero" {
+			t.Fatalf("item %s must not be reported low", it.ItemID)
+		}
+	}
+
+	// Location filter narrows to that location's rows only.
+	mainOnly, err := repo.GetLowStockItems(ctx, "loc_main")
+	if err != nil || len(mainOnly) != 2 || mainOnly[0].ItemID != "b8-low" || mainOnly[1].ItemID != "b8-just" {
+		t.Fatalf("loc_main filter: got %+v err=%v", mainOnly, err)
+	}
+	backOnly, err := repo.GetLowStockItems(ctx, "loc_back")
+	if err != nil || len(backOnly) != 1 || backOnly[0].ItemID != "b8-oth" || backOnly[0].LocationName != "Back Store" || backOnly[0].CurrentQty != 1 {
+		t.Fatalf("loc_back filter: got %+v err=%v", backOnly, err)
+	}
+	if none, err := repo.GetLowStockItems(ctx, "loc-nope"); err != nil || len(none) != 0 {
+		t.Fatalf("unknown location: got %+v err=%v", none, err)
+	}
+}
+
+func TestListStockLocations_Batch8(t *testing.T) {
+	d, repo := openB8InvDB(t)
+	ctx := context.Background()
+
+	// Fresh DB carries exactly the three seeded locations, ordered by name.
+	locs, err := repo.ListStockLocations(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	wantSeed := []StockLocation{
+		{ID: "loc_back", Name: "Back Store"},
+		{ID: "loc_main", Name: "Main Store"},
+		{ID: "loc_wh", Name: "Warehouse"},
+	}
+	if len(locs) != 3 {
+		t.Fatalf("seeded locations: got %+v, want 3", locs)
+	}
+	for i, want := range wantSeed {
+		if locs[i] != want {
+			t.Fatalf("seed[%d]: got %+v, want %+v", i, locs[i], want)
+		}
+	}
+
+	// A new location sorts into place by name (here: first).
+	mustExec(t, d, `INSERT INTO stock_locations (id, name) VALUES ('loc_t8', 'AAA Front')`)
+	locs, err = repo.ListStockLocations(ctx)
+	if err != nil || len(locs) != 4 {
+		t.Fatalf("after insert: got %+v err=%v", locs, err)
+	}
+	if locs[0].ID != "loc_t8" || locs[0].Name != "AAA Front" {
+		t.Fatalf("name ordering: first is %+v, want loc_t8/AAA Front", locs[0])
+	}
+}
+
+func TestListStockLevels_Batch8(t *testing.T) {
+	d, repo := openB8InvDB(t)
+	ctx := context.Background()
+
+	seedB8Item(t, d, "b8-lvl", "sku-lvl", "B8 Level", 3, 1)
+	seedB8Inventory(t, d, "b8-lvl", "loc_main", 12.5)
+	seedB8Inventory(t, d, "b8-lvl", "loc_back", 2)
+	seedB8Item(t, d, "b8-lvl-off", "sku-lvl-off", "B8 Level Inactive", 3, 0)
+	seedB8Inventory(t, d, "b8-lvl-off", "loc_main", 99)
+	// Variant-level inventory (item_id NULL) is not part of this per-item view.
+	seedB8Variant(t, d, "b8-lvlp", "b8-lvlv", "loc_main", 6)
+
+	levels, err := repo.ListStockLevels(ctx)
+	if err != nil {
+		t.Fatalf("list levels: %v", err)
+	}
+	var mine []LowStockItem
+	for _, l := range levels {
+		switch l.ItemID {
+		case "b8-lvl":
+			mine = append(mine, l)
+		case "b8-lvl-off":
+			t.Fatalf("inactive item leaked into stock levels: %+v", l)
+		case "b8-lvlp":
+			// A leaked variant inventory row would surface under its
+			// PARENT item's id (the items JOIN resolves i.id), never
+			// the variant id — so this is the id that must be absent.
+			t.Fatalf("variant-level inventory surfaced through its parent item: %+v", l)
+		}
+	}
+	if len(mine) != 2 {
+		t.Fatalf("b8-lvl rows: got %+v, want 2 (one per location)", mine)
+	}
+	// Same item's rows are ordered by location name: Back Store, then Main Store.
+	back, main := mine[0], mine[1]
+	if back.LocationID != "loc_back" || back.LocationName != "Back Store" || back.CurrentQty != 2 {
+		t.Fatalf("back row: %+v", back)
+	}
+	if main.LocationID != "loc_main" || main.LocationName != "Main Store" || main.CurrentQty != 12.5 {
+		t.Fatalf("main row: %+v", main)
+	}
+	if back.Name != "B8 Level" || back.SKU != "sku-lvl" || back.ReorderLevel != 3 {
+		t.Fatalf("item fields: %+v", back)
+	}
+}
+
+func TestCurrentQty_Batch8(t *testing.T) {
+	d, repo := openB8InvDB(t)
+	ctx := context.Background()
+
+	// Not found: qty 0, found=false, no error.
+	if qty, found, err := repo.CurrentQty(ctx, nil, "loc_main", "b8-cq-ghost", ""); err != nil || found || qty != 0 {
+		t.Fatalf("not found: qty=%v found=%v err=%v", qty, found, err)
+	}
+
+	seedB8Item(t, d, "b8-cq", "sku-cq", "B8 CQ", 0, 1)
+	seedB8Inventory(t, d, "b8-cq", "loc_main", 7.5)
+	if qty, found, err := repo.CurrentQty(ctx, nil, "loc_main", "b8-cq", ""); err != nil || !found || qty != 7.5 {
+		t.Fatalf("found: qty=%v found=%v err=%v, want 7.5,true", qty, found, err)
+	}
+	// Same item, different location: independent row / not found.
+	if qty, found, err := repo.CurrentQty(ctx, nil, "loc_wh", "b8-cq", ""); err != nil || found || qty != 0 {
+		t.Fatalf("other location: qty=%v found=%v err=%v", qty, found, err)
+	}
+
+	// Variant path.
+	seedB8Variant(t, d, "b8-cqp", "b8-cqv", "loc_back", 3)
+	if qty, found, err := repo.CurrentQty(ctx, nil, "loc_back", "", "b8-cqv"); err != nil || !found || qty != 3 {
+		t.Fatalf("variant: qty=%v found=%v err=%v, want 3,true", qty, found, err)
+	}
+
+	// Inside a transaction it reads uncommitted state.
+	tx := b8Tx(t, d)
+	if _, err := tx.Exec(`UPDATE inventory SET quantity = 1.25 WHERE item_id = 'b8-cq'`); err != nil {
+		t.Fatalf("tx update: %v", err)
+	}
+	if qty, found, err := repo.CurrentQty(ctx, tx, "loc_main", "b8-cq", ""); err != nil || !found || qty != 1.25 {
+		t.Fatalf("in-tx: qty=%v found=%v err=%v, want 1.25,true", qty, found, err)
+	}
+}
+
+// TestCurrentQty_AfterStockMovements_Batch8 drives CurrentQty through the
+// write path callers actually use: EnsureStockLocation + RecordStockMovement
+// (receive then sale), asserting the running aggregate.
+func TestCurrentQty_AfterStockMovements_Batch8(t *testing.T) {
+	d, repo := openB8InvDB(t)
+	ctx := context.Background()
+
+	locID, err := repo.EnsureStockLocation(ctx)
+	if err != nil {
+		t.Fatalf("ensure location: %v", err)
+	}
+	if locID != "loc_main" {
+		t.Fatalf("EnsureStockLocation must reuse the seeded loc_main, got %q", locID)
+	}
+
+	seedB8Item(t, d, "b8-mv", "sku-mv", "B8 Move", 0, 1)
+
+	// First movement with no prior inventory row: insert-aggregate branch.
+	if _, err := repo.RecordStockMovement(ctx, nil, StockMovementInput{
+		ItemID: "b8-mv", LocationID: locID, Type: "receive", Quantity: 10,
+	}); err != nil {
+		t.Fatalf("receive: %v", err)
+	}
+	// Second movement updates the existing aggregate.
+	if _, err := repo.RecordStockMovement(ctx, nil, StockMovementInput{
+		ItemID: "b8-mv", LocationID: locID, Type: "sale", Quantity: -3,
+	}); err != nil {
+		t.Fatalf("sale: %v", err)
+	}
+
+	qty, found, err := repo.CurrentQty(ctx, nil, locID, "b8-mv", "")
+	if err != nil || !found || qty != 7 {
+		t.Fatalf("after movements: qty=%v found=%v err=%v, want 7,true", qty, found, err)
+	}
+}

--- a/internal/data/pos_repo_batch8_lookups_test.go
+++ b/internal/data/pos_repo_batch8_lookups_test.go
@@ -1,0 +1,609 @@
+package data
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/universaltill/universal-till/internal/db"
+)
+
+// Coverage batch 8 — POSRepo lookups/ensure/payment/pricing group:
+// LookupCustomer, FindActivePromo, EnsurePaymentMethod, EnsureRegister,
+// EnsureUser, ListActivePluginVersions, ListActivePaymentMethods,
+// ListActiveNonCashPaymentMethods, AppendPriceHistoryItem,
+// AppendPriceHistoryVariant, valueOrDefault.
+
+func newBatch8DB(t *testing.T, name string) *db.DB {
+	t.Helper()
+	dbo, err := db.Open(filepath.Join(t.TempDir(), name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { dbo.Close() })
+	return dbo
+}
+
+func TestPOSRepo_LookupCustomer(t *testing.T) {
+	dbo := newBatch8DB(t, "cust.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(dbo.DB)
+
+	mustExec(t, dbo, `INSERT INTO customers (id, name, phone, loyalty_no)
+VALUES ('cust-b8', 'Dana Vega', '+449900112233', 'LOY-B8-DANA')`)
+
+	// By id, case-insensitively — the scanner emits whatever case the badge
+	// was printed in.
+	id, name, ok := repo.LookupCustomer(ctx, "CUST-B8")
+	if !ok || id != "cust-b8" || name != "Dana Vega" {
+		t.Fatalf("by id: got (%q,%q,%v)", id, name, ok)
+	}
+	// By loyalty number, case-insensitively, with surrounding whitespace.
+	id, name, ok = repo.LookupCustomer(ctx, "  loy-b8-dana  ")
+	if !ok || id != "cust-b8" || name != "Dana Vega" {
+		t.Fatalf("by loyalty: got (%q,%q,%v)", id, name, ok)
+	}
+	// By exact phone.
+	id, _, ok = repo.LookupCustomer(ctx, "+449900112233")
+	if !ok || id != "cust-b8" {
+		t.Fatalf("by phone: got (%q,%v)", id, ok)
+	}
+	// Empty / whitespace-only input must short-circuit to not-found.
+	if _, _, ok := repo.LookupCustomer(ctx, ""); ok {
+		t.Fatal("empty code must not match")
+	}
+	if _, _, ok := repo.LookupCustomer(ctx, "   "); ok {
+		t.Fatal("whitespace-only code must not match")
+	}
+	// Unknown code.
+	if _, _, ok := repo.LookupCustomer(ctx, "no-such-customer"); ok {
+		t.Fatal("unknown code must not match")
+	}
+}
+
+func TestPOSRepo_FindActivePromo(t *testing.T) {
+	dbo := newBatch8DB(t, "promo.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(dbo.DB)
+
+	now := time.Now().UTC()
+	past := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	future := now.Add(2 * time.Hour).Format(time.RFC3339)
+
+	mustExec(t, dbo, `INSERT INTO promotions (code, type, value, starts_at, ends_at, customer_id, is_active) VALUES
+('B8-OPEN',     'amount',  250,  NULL, NULL, NULL, 1),
+('B8-PERCENT',  'percent', 1000, ?,    ?,    NULL, 1),
+('B8-NOTYET',   'amount',  100,  ?,    NULL, NULL, 1),
+('B8-EXPIRED',  'amount',  100,  NULL, ?,    NULL, 1),
+('B8-INACTIVE', 'amount',  100,  NULL, NULL, NULL, 0),
+('B8-ZERO',     'amount',  0,    NULL, NULL, NULL, 1)`,
+		past, future, future, past)
+	mustExec(t, dbo, `INSERT INTO customers (id, name) VALUES ('cust-promo', 'Promo Person')`)
+	mustExec(t, dbo, `INSERT INTO customers (id, name) VALUES ('cust-other', 'Someone Else')`)
+	mustExec(t, dbo, `INSERT INTO promotions (code, type, value, customer_id, is_active)
+VALUES ('B8-TARGETED', 'amount', 500, 'cust-promo', 1)`)
+
+	// Open-ended promo (NULL window), no customer attached.
+	pType, value, ok := repo.FindActivePromo(ctx, "", "B8-OPEN")
+	if !ok || pType != "amount" || value != 250 {
+		t.Fatalf("B8-OPEN: got (%q,%d,%v), want (amount,250,true)", pType, value, ok)
+	}
+	// Inside the active window; percent value is basis points, exact.
+	pType, value, ok = repo.FindActivePromo(ctx, "", "B8-PERCENT")
+	if !ok || pType != "percent" || value != 1000 {
+		t.Fatalf("B8-PERCENT: got (%q,%d,%v), want (percent,1000,true)", pType, value, ok)
+	}
+	// Just outside the window on either side: not yet started / expired.
+	if _, _, ok := repo.FindActivePromo(ctx, "", "B8-NOTYET"); ok {
+		t.Fatal("promo starting in the future must not apply")
+	}
+	if _, _, ok := repo.FindActivePromo(ctx, "", "B8-EXPIRED"); ok {
+		t.Fatal("expired promo must not apply")
+	}
+	// is_active flag beats everything else.
+	if _, _, ok := repo.FindActivePromo(ctx, "", "B8-INACTIVE"); ok {
+		t.Fatal("inactive promo must not apply")
+	}
+	// Non-positive value is rejected post-scan (defensive: a 0-value discount
+	// is meaningless and could mask data errors).
+	if _, _, ok := repo.FindActivePromo(ctx, "", "B8-ZERO"); ok {
+		t.Fatal("zero-value promo must not apply")
+	}
+	// Customer targeting: only the targeted customer gets it.
+	pType, value, ok = repo.FindActivePromo(ctx, "cust-promo", "B8-TARGETED")
+	if !ok || pType != "amount" || value != 500 {
+		t.Fatalf("B8-TARGETED for its customer: got (%q,%d,%v)", pType, value, ok)
+	}
+	if _, _, ok := repo.FindActivePromo(ctx, "cust-other", "B8-TARGETED"); ok {
+		t.Fatal("targeted promo must not apply to a different customer")
+	}
+	if _, _, ok := repo.FindActivePromo(ctx, "", "B8-TARGETED"); ok {
+		t.Fatal("targeted promo must not apply with no customer attached")
+	}
+	// Code is trimmed before matching.
+	if _, _, ok := repo.FindActivePromo(ctx, "", "  B8-OPEN  "); !ok {
+		t.Fatal("promo code must be matched after trimming whitespace")
+	}
+	// Unknown code.
+	if _, _, ok := repo.FindActivePromo(ctx, "", "B8-NOPE"); ok {
+		t.Fatal("unknown promo code must not apply")
+	}
+}
+
+func TestPOSRepo_EnsurePaymentMethod(t *testing.T) {
+	dbo := newBatch8DB(t, "epm.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(dbo.DB)
+
+	// New id: creates a minimal row (name=id, type=cash, active).
+	if err := repo.EnsurePaymentMethod(ctx, "b8-tender"); err != nil {
+		t.Fatalf("EnsurePaymentMethod(new): %v", err)
+	}
+	var name, typ string
+	var active int
+	if err := dbo.DB.QueryRow(`SELECT name, type, is_active FROM payment_methods WHERE id = 'b8-tender'`).
+		Scan(&name, &typ, &active); err != nil {
+		t.Fatalf("row not created: %v", err)
+	}
+	if name != "b8-tender" || typ != "cash" || active != 1 {
+		t.Fatalf("created row wrong: name=%q type=%q active=%d", name, typ, active)
+	}
+
+	// Idempotent: second call leaves exactly one row.
+	if err := repo.EnsurePaymentMethod(ctx, "b8-tender"); err != nil {
+		t.Fatalf("EnsurePaymentMethod(repeat): %v", err)
+	}
+	var n int
+	if err := dbo.DB.QueryRow(`SELECT COUNT(*) FROM payment_methods WHERE id = 'b8-tender'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("repeat call must not duplicate, got %d rows", n)
+	}
+
+	// Migration-seeded 'card' is active with type='card' — Ensure must NOT
+	// rewrite it to type='cash' (that would leak card tenders into the cash
+	// drawer expectation at shift close).
+	if err := repo.EnsurePaymentMethod(ctx, "card"); err != nil {
+		t.Fatalf("EnsurePaymentMethod(existing active): %v", err)
+	}
+	if err := dbo.DB.QueryRow(`SELECT type FROM payment_methods WHERE id = 'card'`).Scan(&typ); err != nil {
+		t.Fatal(err)
+	}
+	if typ != "card" {
+		t.Fatalf("existing method's type must be untouched, got %q", typ)
+	}
+
+	// Existing but INACTIVE row: the FK it exists to satisfy is already
+	// satisfied; Ensure must neither error, nor duplicate, nor force it
+	// active behind the back-office's deactivation.
+	mustExec(t, dbo, `INSERT INTO payment_methods (id, name, type, is_active) VALUES ('b8-retired', 'Retired', 'card', 0)`)
+	if err := repo.EnsurePaymentMethod(ctx, "b8-retired"); err != nil {
+		t.Fatalf("EnsurePaymentMethod(inactive existing): %v", err)
+	}
+	if err := dbo.DB.QueryRow(`SELECT COUNT(*), MIN(is_active) FROM payment_methods WHERE id = 'b8-retired'`).Scan(&n, &active); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 || active != 0 {
+		t.Fatalf("inactive method must stay a single inactive row, got n=%d active=%d", n, active)
+	}
+}
+
+func TestPOSRepo_EnsureRegister(t *testing.T) {
+	dbo := newBatch8DB(t, "reg.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(dbo.DB)
+
+	// Migrations seed no registers: first call creates the default.
+	id, err := repo.EnsureRegister(ctx)
+	if err != nil {
+		t.Fatalf("EnsureRegister(empty): %v", err)
+	}
+	if id != "reg-default" {
+		t.Fatalf("expected reg-default, got %q", id)
+	}
+	// Idempotent: second call returns the same id and there is still one row.
+	id2, err := repo.EnsureRegister(ctx)
+	if err != nil || id2 != id {
+		t.Fatalf("EnsureRegister(repeat): id=%q err=%v", id2, err)
+	}
+	var n int
+	if err := dbo.DB.QueryRow(`SELECT COUNT(*) FROM registers`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("repeat call must not create another register, got %d", n)
+	}
+
+	// With an earlier-sorting active register present, that one wins.
+	mustExec(t, dbo, `INSERT INTO registers (id, name, is_active) VALUES ('reg-a-front', 'Front Till', 1)`)
+	id3, err := repo.EnsureRegister(ctx)
+	if err != nil || id3 != "reg-a-front" {
+		t.Fatalf("expected existing active register reg-a-front, got %q err=%v", id3, err)
+	}
+
+	// Inactive registers are ignored.
+	mustExec(t, dbo, `DELETE FROM registers`)
+	mustExec(t, dbo, `INSERT INTO registers (id, name, is_active) VALUES ('reg-a-dead', 'Old Till', 0)`)
+	id4, err := repo.EnsureRegister(ctx)
+	if err != nil || id4 != "reg-default" {
+		t.Fatalf("inactive register must not satisfy Ensure: got %q err=%v", id4, err)
+	}
+}
+
+func TestPOSRepo_EnsureUser(t *testing.T) {
+	dbo := newBatch8DB(t, "usr.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(dbo.DB)
+
+	// Migrations seed active users ('kiosk' from 018, 'system' from 003);
+	// EnsureUser returns the first active one by id — it must NOT create a
+	// new user when one exists.
+	id, err := repo.EnsureUser(ctx)
+	if err != nil {
+		t.Fatalf("EnsureUser(seeded): %v", err)
+	}
+	if id != "kiosk" {
+		t.Fatalf("expected first seeded active user 'kiosk', got %q", id)
+	}
+	var n int
+	if err := dbo.DB.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	seeded := n
+
+	// With every user deactivated, a default cashier is created.
+	mustExec(t, dbo, `UPDATE users SET is_active = 0`)
+	id, err = repo.EnsureUser(ctx)
+	if err != nil {
+		t.Fatalf("EnsureUser(none active): %v", err)
+	}
+	if id != "cashier-default" {
+		t.Fatalf("expected cashier-default, got %q", id)
+	}
+	var role string
+	var active int
+	if err := dbo.DB.QueryRow(`SELECT role, is_active FROM users WHERE id = 'cashier-default'`).Scan(&role, &active); err != nil {
+		t.Fatalf("created user missing: %v", err)
+	}
+	if role != "cashier" || active != 1 {
+		t.Fatalf("default user must be an active cashier, got role=%q active=%d", role, active)
+	}
+	// Idempotent: repeat returns the same id, no extra rows.
+	id2, err := repo.EnsureUser(ctx)
+	if err != nil || id2 != "cashier-default" {
+		t.Fatalf("EnsureUser(repeat): id=%q err=%v", id2, err)
+	}
+	if err := dbo.DB.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != seeded+1 {
+		t.Fatalf("repeat call must not add users: want %d, got %d", seeded+1, n)
+	}
+}
+
+func TestPOSRepo_ListActivePluginVersions(t *testing.T) {
+	dbo := newBatch8DB(t, "plug.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(dbo.DB)
+
+	// Fresh DB seeds no plugins.
+	rows, err := repo.ListActivePluginVersions(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListActivePluginVersions(empty): %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("expected no plugins on a fresh DB, got %#v", rows)
+	}
+
+	// plugins has an FK to plugin_catalog(id,version) and foreign_keys=ON.
+	for _, p := range [][2]string{{"com.example.zeta", "2.0.0"}, {"com.example.alpha", "1.1.0"}, {"com.example.off", "0.9.0"}} {
+		mustExec(t, dbo, `INSERT INTO plugin_catalog
+(id, version, name, runtime, entrypoint, package_url, sha256, min_pos_version, api_version, published_at)
+VALUES (?, ?, 'P', 'wasm', 'main.wasm', 'https://example.com/p', 'cafe', '0.1.0', '1', datetime('now'))`, p[0], p[1])
+	}
+	mustExec(t, dbo, `INSERT INTO plugins (id, name, version, entrypoint, is_active) VALUES ('com.example.zeta', 'Zeta', '2.0.0', 'main.wasm', 1)`)
+	mustExec(t, dbo, `INSERT INTO plugins (id, name, version, entrypoint, is_active) VALUES ('com.example.alpha', 'Alpha', '1.1.0', 'main.wasm', 1)`)
+	mustExec(t, dbo, `INSERT INTO plugins (id, name, version, entrypoint, is_active) VALUES ('com.example.off', 'Off', '0.9.0', 'main.wasm', 0)`)
+
+	// Active only, ordered by id (alpha before zeta), inactive excluded —
+	// this list stamps sale_plugin_versions on every completed sale.
+	rows, err = repo.ListActivePluginVersions(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListActivePluginVersions: %v", err)
+	}
+	if len(rows) != 2 ||
+		rows[0].ID != "com.example.alpha" || rows[0].Version != "1.1.0" ||
+		rows[1].ID != "com.example.zeta" || rows[1].Version != "2.0.0" {
+		t.Fatalf("wrong rows: %#v", rows)
+	}
+
+	// Same result through an explicit transaction (the sale-completion path).
+	tx, err := dbo.DB.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	txRows, err := repo.ListActivePluginVersions(ctx, tx)
+	if err != nil {
+		t.Fatalf("ListActivePluginVersions(tx): %v", err)
+	}
+	if len(txRows) != 2 || txRows[0] != rows[0] || txRows[1] != rows[1] {
+		t.Fatalf("tx path diverged: %#v vs %#v", txRows, rows)
+	}
+}
+
+func TestPOSRepo_ListActivePaymentMethods(t *testing.T) {
+	dbo := newBatch8DB(t, "lpm.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(dbo.DB)
+
+	// Replace the migration-seeded methods with a controlled set.
+	mustExec(t, dbo, `DELETE FROM payment_methods`)
+	mustExec(t, dbo, `INSERT INTO payment_methods (id, name, type, is_active, sort_order, plugin_id) VALUES
+('cash',   'Cash',        'cash', 1, 1, NULL),
+('card',   'Card',        'card', 1, 2, NULL),
+('stripe', 'Stripe',      'card', 1, 9, 'com.example.stripe'),
+('gift',   'Gift Card',   'voucher', 0, 3, NULL)`)
+
+	got, err := repo.ListActivePaymentMethods(ctx)
+	if err != nil {
+		t.Fatalf("ListActivePaymentMethods: %v", err)
+	}
+	want := []PaymentMethod{
+		{ID: "cash", Name: "Cash", PluginID: ""},
+		{ID: "card", Name: "Card", PluginID: ""},
+		{ID: "stripe", Name: "Stripe", PluginID: "com.example.stripe"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d methods, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("method[%d]: got %+v, want %+v", i, got[i], want[i])
+		}
+	}
+
+	// sort_order beats id: bump cash after card and the order flips.
+	mustExec(t, dbo, `UPDATE payment_methods SET sort_order = 5 WHERE id = 'cash'`)
+	got, err = repo.ListActivePaymentMethods(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 || got[0].ID != "card" || got[1].ID != "cash" || got[2].ID != "stripe" {
+		t.Fatalf("sort_order not respected: %#v", got)
+	}
+}
+
+func TestPOSRepo_ListActiveNonCashPaymentMethods(t *testing.T) {
+	dbo := newBatch8DB(t, "kiosk.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(dbo.DB)
+
+	mustExec(t, dbo, `DELETE FROM payment_methods`)
+	mustExec(t, dbo, `INSERT INTO payment_methods (id, name, type, is_active, sort_order, plugin_id) VALUES
+('cash',      'Cash',          'cash',    1, 1, NULL),
+('cash2',     'Petty Cash',    'cash',    1, 2, NULL),
+('card',      'Card',          'card',    1, 3, NULL),
+('deadcard',  'Broken Reader', 'card',    0, 4, NULL),
+('stripe',    'Stripe',        'card',    1, 5, 'com.example.stripe'),
+('gift',      'Gift Card',     'voucher', 1, 6, NULL)`)
+
+	got, err := repo.ListActiveNonCashPaymentMethods(ctx)
+	if err != nil {
+		t.Fatalf("ListActiveNonCashPaymentMethods: %v", err)
+	}
+	// The kiosk has no cash drawer (ADR-0020): EVERY type='cash' row must be
+	// excluded no matter how many there are, and inactive methods must not
+	// resurface. Non-cash, non-card types (voucher) are allowed through.
+	want := []PaymentMethod{
+		{ID: "card", Name: "Card", PluginID: ""},
+		{ID: "stripe", Name: "Stripe", PluginID: "com.example.stripe"},
+		{ID: "gift", Name: "Gift Card", PluginID: ""},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d methods, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("method[%d]: got %+v, want %+v", i, got[i], want[i])
+		}
+	}
+	for _, m := range got {
+		if m.ID == "cash" || m.ID == "cash2" {
+			t.Fatalf("cash tender leaked into the kiosk list: %+v", m)
+		}
+		if m.ID == "deadcard" {
+			t.Fatalf("inactive tender leaked into the kiosk list: %+v", m)
+		}
+	}
+
+	// All-cash shop: the kiosk list is empty (the page must handle that),
+	// while the staffed-till list still shows the cash tenders.
+	mustExec(t, dbo, `DELETE FROM payment_methods WHERE type != 'cash'`)
+	got, err = repo.ListActiveNonCashPaymentMethods(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("all-cash shop must yield an empty kiosk list, got %#v", got)
+	}
+	staffed, err := repo.ListActivePaymentMethods(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(staffed) != 2 {
+		t.Fatalf("staffed list must still include the cash tenders, got %#v", staffed)
+	}
+}
+
+func TestPOSRepo_AppendPriceHistoryItem(t *testing.T) {
+	dbo := newBatch8DB(t, "phi.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(dbo.DB)
+
+	mustExec(t, dbo, `INSERT INTO items (id, sku, name, base_price, is_active) VALUES ('itm-b8', 'SKU-B8', 'Batch8 Widget', 500, 1)`)
+
+	if err := repo.AppendPriceHistoryItem(ctx, "", 500, time.Now()); err == nil {
+		t.Fatal("empty itemID must error")
+	}
+
+	t1 := time.Date(2026, 3, 1, 9, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+	if err := repo.AppendPriceHistoryItem(ctx, "itm-b8", 500, t1); err != nil {
+		t.Fatalf("first append: %v", err)
+	}
+	if err := repo.AppendPriceHistoryItem(ctx, "itm-b8", 725, t2); err != nil {
+		t.Fatalf("second append: %v", err)
+	}
+
+	type ph struct {
+		price  int64
+		starts string
+		ends   *string
+	}
+	var rows []ph
+	res, err := dbo.DB.Query(`SELECT price, starts_at, ends_at FROM price_history WHERE item_id = 'itm-b8' ORDER BY starts_at`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Close()
+	for res.Next() {
+		var r ph
+		if err := res.Scan(&r.price, &r.starts, &r.ends); err != nil {
+			t.Fatal(err)
+		}
+		rows = append(rows, r)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 price rows, got %d", len(rows))
+	}
+	// The first price was closed exactly when the second started — the
+	// history has no gap and no overlap, in exact minor units.
+	if rows[0].price != 500 || rows[0].starts != t1.Format(time.RFC3339) {
+		t.Fatalf("first row wrong: %+v", rows[0])
+	}
+	if rows[0].ends == nil || *rows[0].ends != t2.Format(time.RFC3339) {
+		t.Fatalf("first row must be closed at t2: %+v", rows[0])
+	}
+	if rows[1].price != 725 || rows[1].starts != t2.Format(time.RFC3339) || rows[1].ends != nil {
+		t.Fatalf("second row must be the open price: %+v", rows[1])
+	}
+}
+
+func TestPOSRepo_AppendPriceHistoryVariant(t *testing.T) {
+	dbo := newBatch8DB(t, "phv.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(dbo.DB)
+
+	mustExec(t, dbo, `INSERT INTO items (id, sku, name, base_price, is_active) VALUES ('itm-b8v', 'SKU-B8V', 'Batch8 Drink', 300, 1)`)
+	mustExec(t, dbo, `INSERT INTO item_variants (id, item_id, sku, name, price, is_active) VALUES ('var-b8', 'itm-b8v', 'SKU-B8V-L', 'Large', 350, 1)`)
+
+	if err := repo.AppendPriceHistoryVariant(ctx, "", 350, time.Now()); err == nil {
+		t.Fatal("empty variantID must error")
+	}
+
+	// An open ITEM price for the parent must not be closed by a VARIANT
+	// price change — they are separate price streams (CHECK: exactly one of
+	// item_id/variant_id is set).
+	t0 := time.Date(2026, 2, 1, 9, 0, 0, 0, time.UTC)
+	if err := repo.AppendPriceHistoryItem(ctx, "itm-b8v", 300, t0); err != nil {
+		t.Fatal(err)
+	}
+
+	t1 := time.Date(2026, 3, 1, 9, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+	if err := repo.AppendPriceHistoryVariant(ctx, "var-b8", 350, t1); err != nil {
+		t.Fatalf("first append: %v", err)
+	}
+	if err := repo.AppendPriceHistoryVariant(ctx, "var-b8", 395, t2); err != nil {
+		t.Fatalf("second append: %v", err)
+	}
+
+	var price int64
+	var starts string
+	var ends *string
+	if err := dbo.DB.QueryRow(`SELECT price, starts_at, ends_at FROM price_history WHERE variant_id = 'var-b8' AND ends_at IS NOT NULL`).
+		Scan(&price, &starts, &ends); err != nil {
+		t.Fatalf("closed variant row: %v", err)
+	}
+	if price != 350 || starts != t1.Format(time.RFC3339) || ends == nil || *ends != t2.Format(time.RFC3339) {
+		t.Fatalf("closed variant row wrong: price=%d starts=%q ends=%v", price, starts, ends)
+	}
+	if err := dbo.DB.QueryRow(`SELECT price, starts_at FROM price_history WHERE variant_id = 'var-b8' AND ends_at IS NULL`).
+		Scan(&price, &starts); err != nil {
+		t.Fatalf("open variant row: %v", err)
+	}
+	if price != 395 || starts != t2.Format(time.RFC3339) {
+		t.Fatalf("open variant row wrong: price=%d starts=%q", price, starts)
+	}
+
+	// The parent item's own price row is untouched and still open.
+	var n int
+	if err := dbo.DB.QueryRow(`SELECT COUNT(*) FROM price_history WHERE item_id = 'itm-b8v' AND ends_at IS NULL AND price = 300`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("variant price change must not close the parent item's open price, got %d open item rows", n)
+	}
+}
+
+func TestPOSRepo_Batch8Lookups_ClosedDBErrorPaths(t *testing.T) {
+	dbo := newBatch8DB(t, "closed.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(dbo.DB)
+	dbo.Close()
+
+	// Lookup-style calls swallow the error into a not-found — the scan
+	// handler treats any failure as "no match", never a 500 mid-sale.
+	if _, _, ok := repo.LookupCustomer(ctx, "cust-b8"); ok {
+		t.Fatal("LookupCustomer on a closed DB must be not-found")
+	}
+	if _, _, ok := repo.FindActivePromo(ctx, "", "B8-OPEN"); ok {
+		t.Fatal("FindActivePromo on a closed DB must be not-found")
+	}
+	// Everything else must surface the error, not fake success.
+	if err := repo.EnsurePaymentMethod(ctx, "x"); err == nil {
+		t.Fatal("EnsurePaymentMethod on a closed DB must error")
+	}
+	if _, err := repo.EnsureRegister(ctx); err == nil {
+		t.Fatal("EnsureRegister on a closed DB must error")
+	}
+	if _, err := repo.EnsureUser(ctx); err == nil {
+		t.Fatal("EnsureUser on a closed DB must error")
+	}
+	if _, err := repo.ListActivePluginVersions(ctx, nil); err == nil {
+		t.Fatal("ListActivePluginVersions on a closed DB must error")
+	}
+	if _, err := repo.ListActivePaymentMethods(ctx); err == nil {
+		t.Fatal("ListActivePaymentMethods on a closed DB must error")
+	}
+	if _, err := repo.ListActiveNonCashPaymentMethods(ctx); err == nil {
+		t.Fatal("ListActiveNonCashPaymentMethods on a closed DB must error")
+	}
+	if err := repo.AppendPriceHistoryItem(ctx, "itm-x", 100, time.Now()); err == nil {
+		t.Fatal("AppendPriceHistoryItem on a closed DB must error")
+	}
+	if err := repo.AppendPriceHistoryVariant(ctx, "var-x", 100, time.Now()); err == nil {
+		t.Fatal("AppendPriceHistoryVariant on a closed DB must error")
+	}
+}
+
+func TestValueOrDefault(t *testing.T) {
+	cases := []struct {
+		val, fallback, want string
+	}{
+		{"itm-1", "var-1", "itm-1"},
+		{"", "var-1", "var-1"},
+		{"   ", "var-1", "var-1"}, // blank-only val falls through
+		{"", "", ""},
+		// Non-blank val is returned as-is (not trimmed).
+		{"  itm-1  ", "var-1", "  itm-1  "},
+	}
+	for _, c := range cases {
+		if got := valueOrDefault(c.val, c.fallback); got != c.want {
+			t.Fatalf("valueOrDefault(%q,%q) = %q, want %q", c.val, c.fallback, got, c.want)
+		}
+	}
+}

--- a/internal/data/pos_repo_batch8_reports_test.go
+++ b/internal/data/pos_repo_batch8_reports_test.go
@@ -1,0 +1,658 @@
+package data
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/universaltill/universal-till/internal/db"
+)
+
+// Coverage batch 8: the owner-intelligence/report group in POSRepo —
+// SalesByDay, SlowItems, DeadStock, TaxSummary, MarginByItem, DayTotal,
+// SeasonalUpcoming, SalesByWeekday/SalesByHour (busyBuckets), and
+// ItemDailySellRates. Real DB, real migrations, exact minor-unit assertions.
+
+// b8OpenDB opens a fresh migrated DB in a temp dir.
+func b8OpenDB(t *testing.T, name string) *db.DB {
+	t.Helper()
+	d, err := db.Open(filepath.Join(t.TempDir(), name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	return d
+}
+
+// b8At renders a time in the RFC3339 format production writes to created_at.
+func b8At(tm time.Time) string { return tm.UTC().Format("2006-01-02T15:04:05Z") }
+
+// b8Sale inserts a sale row. subtotal mirrors total (discounts irrelevant here).
+func b8Sale(t *testing.T, d *db.DB, id, createdAt, status, saleType string, taxTotal, total int64) {
+	t.Helper()
+	mustExec(t, d, `INSERT INTO sales (id, receipt_no, status, sale_type, currency, subtotal, discount_total, tax_total, total, created_at)
+VALUES (?, ?, ?, ?, 'GBP', ?, 0, ?, ?, ?)`, id, "R-"+id, status, saleType, total, taxTotal, total, createdAt)
+}
+
+// b8Line inserts a sale line. Exactly one of itemID/variantID must be
+// non-empty (schema CHECK); the empty one persists as NULL.
+func b8Line(t *testing.T, d *db.DB, saleID string, lineNo int, itemID, variantID, name string, qty float64, rateBP, taxAmt, before, after int64) {
+	t.Helper()
+	var iid, vid any
+	if itemID != "" {
+		iid = itemID
+	}
+	if variantID != "" {
+		vid = variantID
+	}
+	mustExec(t, d, `INSERT INTO sale_lines (id, sale_id, line_no, item_id, variant_id, name_snapshot, quantity, unit_price, line_discount, tax_rate_bp, tax_amount, total_before_tax, total_after_tax)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?)`,
+		fmt.Sprintf("%s-l%d", saleID, lineNo), saleID, lineNo, iid, vid, name, qty, after, rateBP, taxAmt, before, after)
+}
+
+func b8Item(t *testing.T, d *db.DB, id string, basePrice int64, costPrice any, active int) {
+	t.Helper()
+	mustExec(t, d, `INSERT INTO items (id, sku, name, base_price, cost_price, is_active) VALUES (?, ?, ?, ?, ?, ?)`,
+		id, "SKU-"+id, "Name "+id, basePrice, costPrice, active)
+}
+
+func b8Stock(t *testing.T, d *db.DB, invID, itemID, locID string, qty float64) {
+	t.Helper()
+	mustExec(t, d, `INSERT INTO inventory (id, item_id, location_id, quantity) VALUES (?, ?, ?, ?)`,
+		invID, itemID, locID, qty)
+}
+
+func TestPOSRepo_SalesByDay_AggregatesFiltersOrders(t *testing.T) {
+	d := b8OpenDB(t, "salesbyday.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	tNew := time.Now().Add(-2 * time.Hour)
+	tOld := time.Now().Add(-72 * time.Hour)
+	dayNew := tNew.UTC().Format("2006-01-02") // query groups by date() of the stored UTC string
+	dayOld := tOld.UTC().Format("2006-01-02")
+
+	// Two completed sales on the recent day: totals 1000+250, tax 100+25.
+	b8Sale(t, d, "s1", b8At(tNew), "completed", "sale", 100, 1000)
+	b8Sale(t, d, "s2", b8At(tNew), "completed", "sale", 25, 250)
+	// One on the older day.
+	b8Sale(t, d, "s3", b8At(tOld), "completed", "sale", 70, 700)
+	// Voided same day: must not count.
+	b8Sale(t, d, "s4", b8At(tNew), "voided", "sale", 999, 9999)
+	// Outside the 7-day window: must not appear.
+	b8Sale(t, d, "s5", b8At(time.Now().Add(-9*24*time.Hour)), "completed", "sale", 0, 55555)
+
+	rows, err := repo.SalesByDay(ctx, 7)
+	if err != nil {
+		t.Fatalf("SalesByDay: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 day buckets, got %d: %+v", len(rows), rows)
+	}
+	// Ordered day DESC: newest first.
+	if rows[0].Day != dayNew || rows[1].Day != dayOld {
+		t.Fatalf("wrong day order: got [%s, %s], want [%s, %s]", rows[0].Day, rows[1].Day, dayNew, dayOld)
+	}
+	if rows[0].Count != 2 || rows[0].Total != 1250 || rows[0].TaxTotal != 125 {
+		t.Fatalf("new day = %+v, want count 2 total 1250 tax 125", rows[0])
+	}
+	if rows[1].Count != 1 || rows[1].Total != 700 || rows[1].TaxTotal != 70 {
+		t.Fatalf("old day = %+v, want count 1 total 700 tax 70", rows[1])
+	}
+}
+
+func TestPOSRepo_SlowItems_AscendingWithFiltersAndLimit(t *testing.T) {
+	d := b8OpenDB(t, "slowitems.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	b8Item(t, d, "itm", 100, nil, 1) // shared FK target; grouping is by name_snapshot
+	now := b8At(time.Now().Add(-2 * time.Hour))
+
+	b8Sale(t, d, "s1", now, "completed", "sale", 0, 5400)
+	b8Line(t, d, "s1", 1, "itm", "", "Widget", 1, 0, 0, 100, 100)
+	b8Line(t, d, "s1", 2, "itm", "", "Gadget", 2, 0, 0, 5000, 5000)
+	b8Line(t, d, "s1", 3, "itm", "", "Gizmo", 1, 0, 0, 300, 300)
+	// Return-type completed sale: SlowItems is sale-only, must not appear.
+	b8Sale(t, d, "s2", now, "completed", "return", 0, 40)
+	b8Line(t, d, "s2", 1, "itm", "", "ReturnOnly", 1, 0, 0, 40, 40)
+	// Voided: excluded by status.
+	b8Sale(t, d, "s3", now, "voided", "sale", 0, 10)
+	b8Line(t, d, "s3", 1, "itm", "", "VoidOnly", 1, 0, 0, 10, 10)
+	// Outside the 30-day window.
+	b8Sale(t, d, "s4", b8At(time.Now().Add(-40*24*time.Hour)), "completed", "sale", 0, 5)
+	b8Line(t, d, "s4", 1, "itm", "", "OldOnly", 1, 0, 0, 5, 5)
+
+	rows, err := repo.SlowItems(ctx, 30, 2)
+	if err != nil {
+		t.Fatalf("SlowItems: %v", err)
+	}
+	// Ascending by revenue, LIMIT 2 drops the best seller (Gadget).
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows (limit), got %d: %+v", len(rows), rows)
+	}
+	if rows[0].Name != "Widget" || rows[0].Qty != 1 || rows[0].Revenue != 100 {
+		t.Fatalf("worst seller = %+v, want Widget qty 1 revenue 100", rows[0])
+	}
+	if rows[1].Name != "Gizmo" || rows[1].Qty != 1 || rows[1].Revenue != 300 {
+		t.Fatalf("second slowest = %+v, want Gizmo qty 1 revenue 300", rows[1])
+	}
+}
+
+func TestPOSRepo_DeadStock_ValueMathAndExclusions(t *testing.T) {
+	d := b8OpenDB(t, "deadstock.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	// 001_init.sql seeds a demo catalog with stock; clear inventory so only
+	// this test's holdings count (same convention as batch 7's settings test).
+	mustExec(t, d, `DELETE FROM inventory`)
+	mustExec(t, d, `INSERT INTO stock_locations (id, name) VALUES ('loc1', 'Shop'), ('loc2', 'Back room')`)
+
+	// Dead across two locations: qty 3+2=5 × 500 = 2500.
+	b8Item(t, d, "dead1", 500, nil, 1)
+	b8Stock(t, d, "inv1", "dead1", "loc1", 3)
+	b8Stock(t, d, "inv2", "dead1", "loc2", 2)
+	// Dead, highest value: 1 × 10000.
+	b8Item(t, d, "dead2", 10000, nil, 1)
+	b8Stock(t, d, "inv3", "dead2", "loc1", 1)
+	// Sold directly in the window: not dead.
+	b8Item(t, d, "sold", 200, nil, 1)
+	b8Stock(t, d, "inv4", "sold", "loc1", 4)
+	// Sold via a VARIANT line in the window: must resolve to the parent item.
+	b8Item(t, d, "variantsold", 300, nil, 1)
+	mustExec(t, d, `INSERT INTO item_variants (id, item_id, name, price) VALUES ('v1', 'variantsold', 'Large', 350)`)
+	b8Stock(t, d, "inv5", "variantsold", "loc1", 2)
+	// Inactive item with stock: excluded.
+	b8Item(t, d, "inactive", 400, nil, 0)
+	b8Stock(t, d, "inv6", "inactive", "loc1", 5)
+	// Active but zero stock: excluded.
+	b8Item(t, d, "nostock", 600, nil, 1)
+	b8Stock(t, d, "inv7", "nostock", "loc1", 0)
+	// Only sale is OUTSIDE the window: still dead. 1 × 100.
+	b8Item(t, d, "oldsale", 100, nil, 1)
+	b8Stock(t, d, "inv8", "oldsale", "loc1", 1)
+	// Only sale in-window is VOIDED: still dead. 1 × 700.
+	b8Item(t, d, "voidsold", 700, nil, 1)
+	b8Stock(t, d, "inv9", "voidsold", "loc1", 1)
+
+	now := b8At(time.Now().Add(-2 * time.Hour))
+	b8Sale(t, d, "s1", now, "completed", "sale", 0, 200)
+	b8Line(t, d, "s1", 1, "sold", "", "Sold thing", 1, 0, 0, 200, 200)
+	b8Sale(t, d, "s2", now, "completed", "sale", 0, 350)
+	b8Line(t, d, "s2", 1, "", "v1", "Variant thing L", 1, 0, 0, 350, 350)
+	b8Sale(t, d, "s3", b8At(time.Now().Add(-40*24*time.Hour)), "completed", "sale", 0, 100)
+	b8Line(t, d, "s3", 1, "oldsale", "", "Old thing", 1, 0, 0, 100, 100)
+	b8Sale(t, d, "s4", now, "voided", "sale", 0, 700)
+	b8Line(t, d, "s4", 1, "voidsold", "", "Void thing", 1, 0, 0, 700, 700)
+
+	rows, err := repo.DeadStock(ctx, 30, 10)
+	if err != nil {
+		t.Fatalf("DeadStock: %v", err)
+	}
+	if len(rows) != 4 {
+		t.Fatalf("expected 4 dead items, got %d: %+v", len(rows), rows)
+	}
+	// Ordered by tied-up value DESC.
+	wantOrder := []struct {
+		name  string
+		sku   string
+		qty   float64
+		value int64
+	}{
+		{"Name dead2", "SKU-dead2", 1, 10000},
+		{"Name dead1", "SKU-dead1", 5, 2500},
+		{"Name voidsold", "SKU-voidsold", 1, 700},
+		{"Name oldsale", "SKU-oldsale", 1, 100},
+	}
+	for i, w := range wantOrder {
+		got := rows[i]
+		if got.Name != w.name || got.SKU != w.sku || got.Qty != w.qty || got.StockValue != w.value {
+			t.Fatalf("row %d = %+v, want %+v", i, got, w)
+		}
+	}
+
+	// LIMIT applies after the value ordering.
+	top, err := repo.DeadStock(ctx, 30, 1)
+	if err != nil {
+		t.Fatalf("DeadStock(limit 1): %v", err)
+	}
+	if len(top) != 1 || top[0].Name != "Name dead2" {
+		t.Fatalf("limit 1 must return only the most tied-up item, got %+v", top)
+	}
+}
+
+func TestPOSRepo_TaxSummary_BandsReturnsSubtract(t *testing.T) {
+	d := b8OpenDB(t, "taxsummary.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	b8Item(t, d, "itm", 100, nil, 1)
+	now := b8At(time.Now().Add(-2 * time.Hour))
+
+	// Sale: 20% band net 1000 tax 200; zero band net 500 tax 0.
+	b8Sale(t, d, "s1", now, "completed", "sale", 200, 1700)
+	b8Line(t, d, "s1", 1, "itm", "", "Taxed", 1, 2000, 200, 1000, 1200)
+	b8Line(t, d, "s1", 2, "itm", "", "ZeroRated", 1, 0, 0, 500, 500)
+	// Return in the 20% band: subtracts net 300 tax 60.
+	b8Sale(t, d, "s2", now, "completed", "return", 60, 360)
+	b8Line(t, d, "s2", 1, "itm", "", "Taxed", 1, 2000, 60, 300, 360)
+	// Voided: ignored entirely.
+	b8Sale(t, d, "s3", now, "voided", "sale", 999, 999)
+	b8Line(t, d, "s3", 1, "itm", "", "Voided", 1, 2000, 999, 999, 999)
+	// Outside the 30-day window: ignored.
+	b8Sale(t, d, "s4", b8At(time.Now().Add(-40*24*time.Hour)), "completed", "sale", 111, 666)
+	b8Line(t, d, "s4", 1, "itm", "", "Ancient", 1, 2000, 111, 555, 666)
+
+	bands, err := repo.TaxSummary(ctx, 30)
+	if err != nil {
+		t.Fatalf("TaxSummary: %v", err)
+	}
+	if len(bands) != 2 {
+		t.Fatalf("expected 2 tax bands, got %d: %+v", len(bands), bands)
+	}
+	// Ordered by rate DESC: 20% band first, net 1000-300, tax 200-60.
+	if bands[0].RateBP != 2000 || bands[0].Net != 700 || bands[0].Tax != 140 {
+		t.Fatalf("20%% band = %+v, want rate 2000 net 700 tax 140", bands[0])
+	}
+	if bands[1].RateBP != 0 || bands[1].Net != 500 || bands[1].Tax != 0 {
+		t.Fatalf("zero band = %+v, want rate 0 net 500 tax 0", bands[1])
+	}
+}
+
+func TestPOSRepo_MarginByItem_CostSourcesOrderingLimit(t *testing.T) {
+	d := b8OpenDB(t, "margins.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	b8Item(t, d, "coffee", 300, int64(100), 1) // item-level cost
+	b8Item(t, d, "nocost", 300, nil, 1)        // no cost anywhere: excluded
+	b8Item(t, d, "shirt", 900, int64(200), 1)
+	// Variant with its OWN cost — must win over the parent item's.
+	mustExec(t, d, `INSERT INTO item_variants (id, item_id, name, price, cost_price) VALUES ('v-shirt', 'shirt', 'L', 1000, 250)`)
+
+	now := b8At(time.Now().Add(-2 * time.Hour))
+	b8Sale(t, d, "s1", now, "completed", "sale", 0, 1900)
+	// Coffee: qty 3, revenue 900, cost 3×100=300, margin 600.
+	b8Line(t, d, "s1", 1, "coffee", "", "Coffee", 3, 0, 0, 900, 900)
+	// Shirt via variant: qty 2, revenue 1000, cost 2×250=500, margin 500.
+	b8Line(t, d, "s1", 2, "", "v-shirt", "Shirt L", 2, 0, 0, 1000, 1000)
+	// No cost price: excluded even though revenue is the highest.
+	b8Line(t, d, "s1", 3, "nocost", "", "Mystery", 1, 0, 0, 99999, 99999)
+	// Return-type completed sale of coffee: MarginByItem is sale-only, ignored.
+	b8Sale(t, d, "s2", now, "completed", "return", 0, 300)
+	b8Line(t, d, "s2", 1, "coffee", "", "Coffee", 1, 0, 0, 300, 300)
+	// Outside the window.
+	b8Sale(t, d, "s3", b8At(time.Now().Add(-40*24*time.Hour)), "completed", "sale", 0, 300)
+	b8Line(t, d, "s3", 1, "coffee", "", "Coffee", 1, 0, 0, 300, 300)
+
+	rows, err := repo.MarginByItem(ctx, 30, 10)
+	if err != nil {
+		t.Fatalf("MarginByItem: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 margin rows, got %d: %+v", len(rows), rows)
+	}
+	// Ordered by margin DESC.
+	if rows[0].Name != "Coffee" || rows[0].Revenue != 900 || rows[0].Cost != 300 || rows[0].Margin != 600 {
+		t.Fatalf("coffee = %+v, want revenue 900 cost 300 margin 600", rows[0])
+	}
+	if rows[1].Name != "Shirt L" || rows[1].Revenue != 1000 || rows[1].Cost != 500 || rows[1].Margin != 500 {
+		t.Fatalf("shirt = %+v, want revenue 1000 cost 500 (variant cost) margin 500", rows[1])
+	}
+
+	top, err := repo.MarginByItem(ctx, 30, 1)
+	if err != nil {
+		t.Fatalf("MarginByItem(limit 1): %v", err)
+	}
+	if len(top) != 1 || top[0].Name != "Coffee" {
+		t.Fatalf("limit 1 must keep the best margin only, got %+v", top)
+	}
+}
+
+func TestPOSRepo_DayTotal_LocalCalendarDays(t *testing.T) {
+	d := b8OpenDB(t, "daytotal.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	today := b8At(time.Now())
+	yesterday := b8At(time.Now().AddDate(0, 0, -1))
+
+	b8Sale(t, d, "t1", today, "completed", "sale", 0, 300)
+	b8Sale(t, d, "t2", today, "completed", "sale", 0, 200)
+	b8Sale(t, d, "y1", yesterday, "completed", "sale", 0, 700)
+	// Yesterday's return and voided sale: both excluded.
+	b8Sale(t, d, "y2", yesterday, "completed", "return", 0, 400)
+	b8Sale(t, d, "y3", yesterday, "voided", "sale", 0, 999)
+
+	total, count, err := repo.DayTotal(ctx, 0)
+	if err != nil {
+		t.Fatalf("DayTotal(0): %v", err)
+	}
+	if total != 500 || count != 2 {
+		t.Fatalf("today = (%d, %d), want (500, 2)", total, count)
+	}
+	total, count, err = repo.DayTotal(ctx, 1)
+	if err != nil {
+		t.Fatalf("DayTotal(1): %v", err)
+	}
+	if total != 700 || count != 1 {
+		t.Fatalf("yesterday = (%d, %d), want (700, 1)", total, count)
+	}
+	// A day with no sales reports zeros, not an error.
+	total, count, err = repo.DayTotal(ctx, 5)
+	if err != nil || total != 0 || count != 0 {
+		t.Fatalf("empty day = (%d, %d, %v), want (0, 0, nil)", total, count, err)
+	}
+}
+
+func TestPOSRepo_SeasonalUpcoming_YearAgoWindowAndSuggestions(t *testing.T) {
+	d := b8OpenDB(t, "seasonal.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	mustExec(t, d, `INSERT INTO stock_locations (id, name) VALUES ('loc1', 'Shop')`)
+	b8Item(t, d, "pumpkin", 250, nil, 1)
+	b8Stock(t, d, "inv1", "pumpkin", "loc1", 2)
+	b8Item(t, d, "covered", 250, nil, 1)
+	b8Stock(t, d, "inv2", "covered", "loc1", 10)
+	b8Item(t, d, "scarf", 800, nil, 1) // sold via variant, no stock on hand
+	mustExec(t, d, `INSERT INTO item_variants (id, item_id, name, price) VALUES ('v2', 'scarf', 'Red', 800)`)
+	b8Item(t, d, "berry", 300, nil, 1) // fractional (weighed) quantities
+	b8Stock(t, d, "inv3", "berry", "loc1", 1)
+	b8Item(t, d, "middle", 100, nil, 1) // pins the days<=0 default at 28, not less
+	b8Item(t, d, "retired", 100, nil, 0) // inactive: excluded
+	b8Item(t, d, "tooOld", 100, nil, 1)
+	b8Item(t, d, "tooRecent", 100, nil, 1)
+
+	// Window with days=28 is [now-365d, now-337d). -364d and -360d are inside;
+	// -366d (before) and -330d (after) are out.
+	at := func(daysAgo int) string { return b8At(time.Now().AddDate(0, 0, -daysAgo)) }
+	seed := func(saleID, itemID, variantID, name string, qty float64, when string) {
+		b8Sale(t, d, saleID, when, "completed", "sale", 0, 100)
+		b8Line(t, d, saleID, 1, itemID, variantID, name, qty, 0, 0, 100, 100)
+	}
+	seed("s1", "pumpkin", "", "Pumpkin", 5, at(364))
+	seed("s2", "covered", "", "Covered", 2, at(360))
+	seed("s3", "", "v2", "Scarf Red", 4, at(364))
+	seed("s4", "retired", "", "Retired", 9, at(364))
+	seed("s5", "tooOld", "", "Too old", 9, at(366))
+	seed("s6", "tooRecent", "", "Too recent", 9, at(330))
+	// Weighed stock: 2.5 sold last year, 1 on hand -> need 1.5, and only
+	// Ceil (per the doc comment) suggests 2; Floor would say 1.
+	seed("s7", "berry", "", "Berry", 2.5, at(362))
+	// Inside the default 28-day window [-365d,-337d) but OUTSIDE a 14-day
+	// one [-365d,-351d): only visible when days<=0 really defaults to 28.
+	seed("s8", "middle", "", "Middle", 1, at(340))
+
+	rows, err := repo.SeasonalUpcoming(ctx, 28, 10)
+	if err != nil {
+		t.Fatalf("SeasonalUpcoming: %v", err)
+	}
+	if len(rows) != 5 {
+		t.Fatalf("expected 5 seasonal items, got %d: %+v", len(rows), rows)
+	}
+	// Ordered by last-year units DESC.
+	if rows[0].Name != "Name pumpkin" || rows[0].LastYear != 5 || rows[0].OnHand != 2 || rows[0].SuggestQty != 3 {
+		t.Fatalf("pumpkin = %+v, want lastYear 5 onHand 2 suggest 3", rows[0])
+	}
+	if rows[1].Name != "Name scarf" || rows[1].LastYear != 4 || rows[1].OnHand != 0 || rows[1].SuggestQty != 4 {
+		t.Fatalf("scarf (variant path) = %+v, want lastYear 4 onHand 0 suggest 4", rows[1])
+	}
+	// Fractional need rounds UP: ceil(2.5 - 1) = 2 (Floor would give 1).
+	if rows[2].Name != "Name berry" || rows[2].LastYear != 2.5 || rows[2].OnHand != 1 || rows[2].SuggestQty != 2 {
+		t.Fatalf("berry = %+v, want lastYear 2.5 onHand 1 suggest 2", rows[2])
+	}
+	// Fully covered: suggestion clamps to 0, never negative.
+	if rows[3].Name != "Name covered" || rows[3].LastYear != 2 || rows[3].OnHand != 10 || rows[3].SuggestQty != 0 {
+		t.Fatalf("covered = %+v, want lastYear 2 onHand 10 suggest 0", rows[3])
+	}
+	if rows[4].Name != "Name middle" || rows[4].LastYear != 1 || rows[4].SuggestQty != 1 {
+		t.Fatalf("middle = %+v, want lastYear 1 suggest 1", rows[4])
+	}
+
+	// days <= 0 falls back to the 28-day default: identical result,
+	// INCLUDING "middle" (sold -340d), which a shorter default would drop.
+	def, err := repo.SeasonalUpcoming(ctx, 0, 10)
+	if err != nil {
+		t.Fatalf("SeasonalUpcoming(0): %v", err)
+	}
+	if len(def) != 5 || def[0].Name != rows[0].Name || def[0].SuggestQty != rows[0].SuggestQty || def[4].Name != "Name middle" {
+		t.Fatalf("days<=0 must default to 28 (incl. the -340d sale): got %+v", def)
+	}
+
+	// LIMIT trims from the bottom of the units ordering.
+	top, err := repo.SeasonalUpcoming(ctx, 28, 1)
+	if err != nil {
+		t.Fatalf("SeasonalUpcoming(limit 1): %v", err)
+	}
+	if len(top) != 1 || top[0].Name != "Name pumpkin" {
+		t.Fatalf("limit 1 must keep the biggest seasonal seller, got %+v", top)
+	}
+}
+
+func TestPOSRepo_SalesByWeekdayAndHour_BucketsLocalTime(t *testing.T) {
+	d := b8OpenDB(t, "busy.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	// Two sales a couple of hours ago, one ~27h ago (guaranteed different
+	// local hour AND different local weekday from t1).
+	t1 := time.Now().Add(-2 * time.Hour)
+	t2 := time.Now().Add(-27 * time.Hour)
+	b8Sale(t, d, "s1", b8At(t1), "completed", "sale", 0, 400)
+	b8Sale(t, d, "s2", b8At(t1), "completed", "sale", 0, 600)
+	b8Sale(t, d, "s3", b8At(t2), "completed", "sale", 0, 500)
+	// Excluded: return-type, voided, and out-of-window rows.
+	b8Sale(t, d, "s4", b8At(t1), "completed", "return", 0, 77777)
+	b8Sale(t, d, "s5", b8At(t1), "voided", "sale", 0, 88888)
+	b8Sale(t, d, "s6", b8At(time.Now().Add(-40*24*time.Hour)), "completed", "sale", 0, 99999)
+
+	type agg struct {
+		count int
+		total int64
+	}
+	// Expected buckets computed by SQLite itself from the same stored
+	// strings, through the same strftime(...,'localtime') conversion the
+	// production query uses — this pins the %w weekday numbering (0=Sun,
+	// not ISO %u) and SQLite-vs-Go local-clock agreement in EVERY
+	// timezone, including CI's UTC. Honest residual (independent review,
+	// batch 8): under TZ=UTC a production query that dropped 'localtime'
+	// is behaviorally invisible — local time IS UTC there — so that one
+	// regression is only catchable on non-UTC machines.
+	ctrlSlot := func(format string, tm time.Time, goSlot int) int {
+		var slot int
+		if err := d.DB.QueryRow(`SELECT CAST(strftime(?, ?, 'localtime') AS INTEGER)`,
+			format, b8At(tm)).Scan(&slot); err != nil {
+			t.Fatalf("control slot query: %v", err)
+		}
+		if slot != goSlot {
+			t.Fatalf("sqlite localtime %s=%d disagrees with Go local %d for %s — driver drift", format, slot, goSlot, b8At(tm))
+		}
+		return slot
+	}
+	expect := func(format string, goSlotOf func(time.Time) int) map[int]agg {
+		exp := map[int]agg{}
+		add := func(tm time.Time, total int64) {
+			s := ctrlSlot(format, tm, goSlotOf(tm))
+			a := exp[s]
+			a.count++
+			a.total += total
+			exp[s] = a
+		}
+		add(t1, 400)
+		add(t1, 600)
+		add(t2, 500)
+		return exp
+	}
+	check := func(name string, got []BusySlot, exp map[int]agg) {
+		t.Helper()
+		if len(got) != len(exp) {
+			t.Fatalf("%s: expected %d buckets, got %d: %+v", name, len(exp), len(got), got)
+		}
+		for i, b := range got {
+			w, ok := exp[b.Slot]
+			if !ok || b.Count != w.count || b.Total != w.total {
+				t.Fatalf("%s bucket %d = %+v, want %+v (known slot %v)", name, i, b, w, ok)
+			}
+			if i > 0 && got[i-1].Slot >= b.Slot {
+				t.Fatalf("%s buckets must be ordered by slot ascending: %+v", name, got)
+			}
+		}
+	}
+
+	byHour, err := repo.SalesByHour(ctx, 7)
+	if err != nil {
+		t.Fatalf("SalesByHour: %v", err)
+	}
+	check("SalesByHour", byHour, expect("%H", func(tm time.Time) int { return tm.Local().Hour() }))
+
+	byWeekday, err := repo.SalesByWeekday(ctx, 7)
+	if err != nil {
+		t.Fatalf("SalesByWeekday: %v", err)
+	}
+	check("SalesByWeekday", byWeekday, expect("%w", func(tm time.Time) int { return int(tm.Local().Weekday()) }))
+}
+
+func TestPOSRepo_ItemDailySellRates_NetOfReturnsPerDay(t *testing.T) {
+	d := b8OpenDB(t, "sellrates.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	b8Item(t, d, "apple", 50, nil, 1)
+	b8Item(t, d, "banana", 30, nil, 1)
+	b8Item(t, d, "cherry", 20, nil, 1)
+	b8Item(t, d, "pear", 80, nil, 1)
+	b8Item(t, d, "melon", 200, nil, 1)
+	mustExec(t, d, `INSERT INTO item_variants (id, item_id, name, price) VALUES ('v-pear', 'pear', 'Conference', 80)`)
+
+	now := b8At(time.Now().Add(-2 * time.Hour))
+	seed := func(saleID, status, saleType, itemID, variantID string, qty float64, when string) {
+		b8Sale(t, d, saleID, when, status, saleType, 0, 100)
+		b8Line(t, d, saleID, 1, itemID, variantID, "n-"+saleID, qty, 0, 0, 100, 100)
+	}
+	// Apple: 10 + 4 sold in-window → 14 / 7 days = 2.0.
+	seed("s1", "completed", "sale", "apple", "", 10, now)
+	seed("s2", "completed", "sale", "apple", "", 4, now)
+	// Banana: 7 sold, 7 returned → net 0 → absent.
+	seed("s3", "completed", "sale", "banana", "", 7, now)
+	seed("s4", "completed", "return", "banana", "", 7, now)
+	// Cherry: 3 sold, 1 returned → net 2 → 2/7.
+	seed("s5", "completed", "sale", "cherry", "", 3, now)
+	seed("s6", "completed", "return", "cherry", "", 1, now)
+	// Pear: sold via variant → resolves to the parent item id. 7/7 = 1.0.
+	seed("s7", "completed", "sale", "", "v-pear", 7, now)
+	// Melon: only outside the window → absent.
+	seed("s8", "completed", "sale", "melon", "", 9, b8At(time.Now().Add(-10*24*time.Hour)))
+	// Voided apple sale: never counted.
+	seed("s9", "voided", "sale", "apple", "", 100, now)
+
+	rates, err := repo.ItemDailySellRates(ctx, 7)
+	if err != nil {
+		t.Fatalf("ItemDailySellRates: %v", err)
+	}
+	if len(rates) != 3 {
+		t.Fatalf("expected 3 items with movement, got %#v", rates)
+	}
+	if rates["apple"] != 2.0 {
+		t.Fatalf("apple rate = %v, want 2.0", rates["apple"])
+	}
+	if rates["cherry"] != 2.0/7.0 {
+		t.Fatalf("cherry rate = %v, want %v", rates["cherry"], 2.0/7.0)
+	}
+	if rates["pear"] != 1.0 {
+		t.Fatalf("pear (variant path) rate = %v, want 1.0", rates["pear"])
+	}
+	if _, ok := rates["banana"]; ok {
+		t.Fatalf("banana netted to zero and must be absent: %#v", rates)
+	}
+	if _, ok := rates["melon"]; ok {
+		t.Fatalf("melon sold outside the window and must be absent: %#v", rates)
+	}
+
+	// days <= 0 defaults the window AND the divisor to 28.
+	def, err := repo.ItemDailySellRates(ctx, 0)
+	if err != nil {
+		t.Fatalf("ItemDailySellRates(0): %v", err)
+	}
+	if def["apple"] != 14.0/28.0 {
+		t.Fatalf("apple rate with default window = %v, want 0.5", def["apple"])
+	}
+}
+
+func TestPOSRepo_Reports_EmptyDB(t *testing.T) {
+	d := b8OpenDB(t, "empty.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	// A fresh DB is NOT empty: 001_init.sql seeds a demo catalog with stock
+	// (but no sales). Clear inventory so DeadStock's empty path is real.
+	mustExec(t, d, `DELETE FROM inventory`)
+
+	if rows, err := repo.SalesByDay(ctx, 7); err != nil || len(rows) != 0 {
+		t.Fatalf("SalesByDay empty = (%v, %v)", rows, err)
+	}
+	if rows, err := repo.SlowItems(ctx, 7, 5); err != nil || len(rows) != 0 {
+		t.Fatalf("SlowItems empty = (%v, %v)", rows, err)
+	}
+	if rows, err := repo.DeadStock(ctx, 7, 5); err != nil || len(rows) != 0 {
+		t.Fatalf("DeadStock empty = (%v, %v)", rows, err)
+	}
+	if rows, err := repo.TaxSummary(ctx, 7); err != nil || len(rows) != 0 {
+		t.Fatalf("TaxSummary empty = (%v, %v)", rows, err)
+	}
+	if rows, err := repo.MarginByItem(ctx, 7, 5); err != nil || len(rows) != 0 {
+		t.Fatalf("MarginByItem empty = (%v, %v)", rows, err)
+	}
+	if total, count, err := repo.DayTotal(ctx, 0); err != nil || total != 0 || count != 0 {
+		t.Fatalf("DayTotal empty = (%d, %d, %v)", total, count, err)
+	}
+	if rows, err := repo.SeasonalUpcoming(ctx, 28, 5); err != nil || len(rows) != 0 {
+		t.Fatalf("SeasonalUpcoming empty = (%v, %v)", rows, err)
+	}
+	if rows, err := repo.SalesByWeekday(ctx, 7); err != nil || len(rows) != 0 {
+		t.Fatalf("SalesByWeekday empty = (%v, %v)", rows, err)
+	}
+	if rows, err := repo.SalesByHour(ctx, 7); err != nil || len(rows) != 0 {
+		t.Fatalf("SalesByHour empty = (%v, %v)", rows, err)
+	}
+	if rates, err := repo.ItemDailySellRates(ctx, 7); err != nil || len(rates) != 0 {
+		t.Fatalf("ItemDailySellRates empty = (%#v, %v)", rates, err)
+	}
+
+	// A closed DB must surface an error from every report, never a silent
+	// empty result (batch-7 convention; also exercises the query-error wraps).
+	_ = d.Close()
+	if _, err := repo.SalesByDay(ctx, 7); err == nil {
+		t.Fatal("SalesByDay on a closed DB must error")
+	}
+	if _, err := repo.SlowItems(ctx, 7, 5); err == nil {
+		t.Fatal("SlowItems on a closed DB must error")
+	}
+	if _, err := repo.DeadStock(ctx, 7, 5); err == nil {
+		t.Fatal("DeadStock on a closed DB must error")
+	}
+	if _, err := repo.TaxSummary(ctx, 7); err == nil {
+		t.Fatal("TaxSummary on a closed DB must error")
+	}
+	if _, err := repo.MarginByItem(ctx, 7, 5); err == nil {
+		t.Fatal("MarginByItem on a closed DB must error")
+	}
+	if _, _, err := repo.DayTotal(ctx, 0); err == nil {
+		t.Fatal("DayTotal on a closed DB must error")
+	}
+	if _, err := repo.SeasonalUpcoming(ctx, 28, 5); err == nil {
+		t.Fatal("SeasonalUpcoming on a closed DB must error")
+	}
+	if _, err := repo.SalesByWeekday(ctx, 7); err == nil {
+		t.Fatal("SalesByWeekday on a closed DB must error")
+	}
+	if _, err := repo.SalesByHour(ctx, 7); err == nil {
+		t.Fatal("SalesByHour on a closed DB must error")
+	}
+	if _, err := repo.ItemDailySellRates(ctx, 7); err == nil {
+		t.Fatal("ItemDailySellRates on a closed DB must error")
+	}
+}

--- a/internal/data/pos_repo_batch8_sales_test.go
+++ b/internal/data/pos_repo_batch8_sales_test.go
@@ -1,0 +1,471 @@
+package data
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/universaltill/universal-till/internal/db"
+)
+
+// Coverage batch 8: the POSRepo sale-lifecycle group — receipt sequencing,
+// sale/line persistence, status transitions, payment-failure audit, and the
+// read-back lookups the journal/refund/invoice pages rely on.
+
+func openBatch8DB(t *testing.T, name string) *db.DB {
+	t.Helper()
+	d, err := db.Open(filepath.Join(t.TempDir(), name))
+	if err != nil {
+		t.Fatalf("open %s: %v", name, err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+// seedBatch8Sale writes a complete sale (header + 2 lines + 1 payment)
+// through the same repo writers checkout uses, so every read-back test
+// exercises the real InsertSale/InsertSaleLine roundtrip.
+func seedBatch8Sale(t *testing.T, d *db.DB, repo *POSRepo, saleID, receiptNo, createdAt string) {
+	t.Helper()
+	ctx := context.Background()
+	mustExec(t, d, `INSERT OR IGNORE INTO items (id, sku, name, base_price, is_active)
+VALUES ('itm-b8', 'B8-SKU', 'Batch8 Item', 500, 1)`)
+	mustExec(t, d, `INSERT OR IGNORE INTO payment_methods (id, name, type, is_active)
+VALUES ('cash', 'Cash', 'cash', 1)`)
+
+	// subtotal 1000, discount 100, tax 180, total 1080 — exact minor units.
+	if err := repo.InsertSale(ctx, nil, saleID, receiptNo, "sale", "", "", "", "GBP",
+		1000, 100, 180, 1080, "batch8 note", createdAt, "cash", true, "queued", 2, "", ""); err != nil {
+		t.Fatalf("InsertSale: %v", err)
+	}
+	// Insert line 2 first: ListSaleLineSnapshots/GetSaleDetail must order by line_no,
+	// not insertion order.
+	if err := repo.InsertSaleLine(ctx, nil, saleID+"-l2", saleID, 2, "itm-b8", "",
+		"Batch8 Item", "B8-SKU", "5012345678900", 1, 200, 0, 2000, 40, 200, 240); err != nil {
+		t.Fatalf("InsertSaleLine l2: %v", err)
+	}
+	if err := repo.InsertSaleLine(ctx, nil, saleID+"-l1", saleID, 1, "itm-b8", "",
+		"Batch8 Item", "B8-SKU", "5012345678900", 2, 400, 100, 2000, 140, 700, 840); err != nil {
+		t.Fatalf("InsertSaleLine l1: %v", err)
+	}
+	if err := repo.InsertPayment(ctx, nil, saleID+"-p1", saleID, "cash",
+		1080, "GBP", "ref-b8", 20, 50, createdAt); err != nil {
+		t.Fatalf("InsertPayment: %v", err)
+	}
+}
+
+func TestPOSRepo_LookupUserRole(t *testing.T) {
+	d := openBatch8DB(t, "roles.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	mustExec(t, d, `INSERT INTO users (id, username, display_name, role, is_active)
+VALUES ('u-mgr', 'mgr', 'Manager', 'manager', 1)`)
+
+	role, ok, err := repo.LookupUserRole(ctx, "u-mgr")
+	if err != nil || !ok || role != "manager" {
+		t.Fatalf("LookupUserRole(u-mgr) = (%q,%v,%v), want (manager,true,nil)", role, ok, err)
+	}
+	// Migration 003 seeds the 'system' admin actor — the refund override path
+	// (internal/pages/inventory_api.go) depends on its role resolving.
+	role, ok, err = repo.LookupUserRole(ctx, "system")
+	if err != nil || !ok || role != "admin" {
+		t.Fatalf("LookupUserRole(system) = (%q,%v,%v), want (admin,true,nil)", role, ok, err)
+	}
+	role, ok, err = repo.LookupUserRole(ctx, "nobody")
+	if err != nil || ok || role != "" {
+		t.Fatalf("LookupUserRole(unknown) = (%q,%v,%v), want (\"\",false,nil)", role, ok, err)
+	}
+}
+
+func TestPOSRepo_NextReceiptNo_Sequencing(t *testing.T) {
+	d := openBatch8DB(t, "receipts.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	// Empty DB, no prefix configured: sequence starts at 1, zero-padded to 9.
+	got, err := repo.NextReceiptNo(ctx, nil)
+	if err != nil || got != "000000001" {
+		t.Fatalf("NextReceiptNo(empty) = (%q,%v), want (000000001,nil)", got, err)
+	}
+
+	// Using the issued number advances the sequence — monotonic, no reuse.
+	seedBatch8Sale(t, d, repo, "sale-b8-1", got, "2026-07-30T10:00:00Z")
+	got, err = repo.NextReceiptNo(ctx, nil)
+	if err != nil || got != "000000002" {
+		t.Fatalf("NextReceiptNo(after 1 sale) = (%q,%v), want (000000002,nil)", got, err)
+	}
+
+	// Non-numeric legacy receipt casts to 0 and must not break the counter.
+	mustExec(t, d, `INSERT INTO sales (id, receipt_no, status, sale_type, currency, subtotal, total, created_at)
+VALUES ('sale-legacy', 'R-0099', 'completed', 'sale', 'GBP', 100, 100, '2026-07-30T10:01:00Z')`)
+	got, err = repo.NextReceiptNo(ctx, nil)
+	if err != nil || got != "000000002" {
+		t.Fatalf("NextReceiptNo(with legacy receipt) = (%q,%v), want (000000002,nil)", got, err)
+	}
+
+	// ADR-0011 synced replica: the till prefix namespaces the counter, and
+	// another till's receipts (different prefix) never bleed into this max.
+	mustExec(t, d, `INSERT INTO settings (key, value) VALUES ('sync.receipt_prefix', 'T2-')`)
+	mustExec(t, d, `INSERT INTO sales (id, receipt_no, status, sale_type, currency, subtotal, total, created_at)
+VALUES ('sale-t2', 'T2-000000007', 'completed', 'sale', 'GBP', 100, 100, '2026-07-30T10:02:00Z')`)
+	mustExec(t, d, `INSERT INTO sales (id, receipt_no, status, sale_type, currency, subtotal, total, created_at)
+VALUES ('sale-t9', 'T9-000000042', 'completed', 'sale', 'GBP', 100, 100, '2026-07-30T10:03:00Z')`)
+	got, err = repo.NextReceiptNo(ctx, nil)
+	if err != nil || got != "T2-000000008" {
+		t.Fatalf("NextReceiptNo(prefixed) = (%q,%v), want (T2-000000008,nil)", got, err)
+	}
+
+	// The checkout path calls it inside a transaction (internal/pos/sales.go:75).
+	tx, err := d.DB.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	got, err = repo.NextReceiptNo(ctx, tx)
+	if err != nil || got != "T2-000000008" {
+		t.Fatalf("NextReceiptNo(in tx) = (%q,%v), want (T2-000000008,nil)", got, err)
+	}
+}
+
+func TestPOSRepo_InsertSale_ReadBackRoundtrip(t *testing.T) {
+	d := openBatch8DB(t, "roundtrip.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+	created := "2026-07-30T09:30:00Z"
+	seedBatch8Sale(t, d, repo, "sale-rt", "000000001", created)
+
+	// SaleTotals: exact integer minor units, straight off the header row.
+	receipt, subtotal, tax, total, err := repo.SaleTotals(ctx, "sale-rt")
+	if err != nil {
+		t.Fatalf("SaleTotals: %v", err)
+	}
+	if receipt != "000000001" || subtotal != 1000 || tax != 180 || total != 1080 {
+		t.Fatalf("SaleTotals = (%q,%d,%d,%d), want (000000001,1000,180,1080)", receipt, subtotal, tax, total)
+	}
+
+	receipt, ok, err := repo.GetReceiptNo(ctx, "sale-rt")
+	if err != nil || !ok || receipt != "000000001" {
+		t.Fatalf("GetReceiptNo = (%q,%v,%v), want (000000001,true,nil)", receipt, ok, err)
+	}
+
+	id, ok, err := repo.FindSaleIDByReceipt(ctx, "000000001")
+	if err != nil || !ok || id != "sale-rt" {
+		t.Fatalf("FindSaleIDByReceipt = (%q,%v,%v), want (sale-rt,true,nil)", id, ok, err)
+	}
+
+	// InsertSale stamps completed_at = created_at; the refund-window check
+	// (internal/pages/pos_api.go:616) parses it as RFC3339.
+	ts, ok, err := repo.SaleCompletedAt(ctx, "sale-rt")
+	if err != nil || !ok {
+		t.Fatalf("SaleCompletedAt: ok=%v err=%v", ok, err)
+	}
+	want, _ := time.Parse(time.RFC3339, created)
+	if !ts.Equal(want) {
+		t.Fatalf("SaleCompletedAt = %v, want %v", ts, want)
+	}
+
+	// ListSaleLineSnapshots: ordered by line_no (l2 was inserted first), with
+	// the snapshot fields the refund flow re-prices from.
+	snaps, err := repo.ListSaleLineSnapshots(ctx, "sale-rt")
+	if err != nil {
+		t.Fatalf("ListSaleLineSnapshots: %v", err)
+	}
+	if len(snaps) != 2 {
+		t.Fatalf("want 2 snapshots, got %d: %+v", len(snaps), snaps)
+	}
+	l1 := snaps[0]
+	if l1.ID != "sale-rt-l1" || l1.ItemID != "itm-b8" || l1.VariantID != "" ||
+		l1.Name != "Batch8 Item" || l1.SKU != "B8-SKU" || l1.Barcode != "5012345678900" ||
+		l1.Qty != 2 || l1.UnitPrice != 400 || l1.TaxRateBP != 2000 {
+		t.Fatalf("snapshot line 1 mismatch: %+v", l1)
+	}
+	if snaps[1].ID != "sale-rt-l2" || snaps[1].Qty != 1 || snaps[1].UnitPrice != 200 {
+		t.Fatalf("snapshot line 2 mismatch: %+v", snaps[1])
+	}
+
+	// GetSaleDetailByID (invoice page path) resolves id -> receipt -> full detail.
+	detail, ok, err := repo.GetSaleDetailByID(ctx, "sale-rt")
+	if err != nil || !ok {
+		t.Fatalf("GetSaleDetailByID: ok=%v err=%v", ok, err)
+	}
+	if detail.ID != "sale-rt" || detail.ReceiptNo != "000000001" || detail.Status != "completed" ||
+		detail.SaleType != "sale" || detail.TenderType != "cash" || !detail.Offline ||
+		detail.SyncStatus != "queued" || detail.Currency != "GBP" ||
+		detail.Subtotal != 1000 || detail.DiscountTotal != 100 || detail.TaxTotal != 180 ||
+		detail.Total != 1080 || detail.CreatedAt != created || detail.CashierID != "" {
+		t.Fatalf("GetSaleDetailByID header mismatch: %+v", detail)
+	}
+	if len(detail.Lines) != 2 {
+		t.Fatalf("want 2 detail lines, got %d", len(detail.Lines))
+	}
+	dl := detail.Lines[0]
+	if dl.Name != "Batch8 Item" || dl.SKU != "B8-SKU" || dl.ItemID != "itm-b8" ||
+		dl.TaxRateBP != 2000 || dl.Qty != 2 || dl.UnitPrice != 400 ||
+		dl.LineDiscount != 100 || dl.TaxAmount != 140 || dl.LineTotal != 840 {
+		t.Fatalf("detail line 1 mismatch: %+v", dl)
+	}
+	if len(detail.Payments) != 1 {
+		t.Fatalf("want 1 payment, got %d", len(detail.Payments))
+	}
+	p := detail.Payments[0]
+	if p.Method != "cash" || p.Amount != 1080 || p.ChangeGiven != 20 ||
+		p.TipAmount != 50 || p.Reference != "ref-b8" || p.PaidAt != created {
+		t.Fatalf("detail payment mismatch: %+v", p)
+	}
+
+	// Duplicate receipt_no violates the sales UNIQUE constraint — checkout
+	// relies on this to make receipt reuse impossible.
+	err = repo.InsertSale(ctx, nil, "sale-dup", "000000001", "sale", "", "", "", "GBP",
+		1, 0, 0, 1, "", created, "cash", false, "queued", 0, "", "")
+	if err == nil {
+		t.Fatal("InsertSale with duplicate receipt_no must fail")
+	}
+
+	// A line with neither item nor variant violates the schema CHECK.
+	err = repo.InsertSaleLine(ctx, nil, "bad-line", "sale-rt", 3, "", "",
+		"Ghost", "", "", 1, 100, 0, 0, 0, 100, 100)
+	if err == nil {
+		t.Fatal("InsertSaleLine with no item_id and no variant_id must fail")
+	}
+}
+
+func TestPOSRepo_SaleLookups_NotFound(t *testing.T) {
+	d := openBatch8DB(t, "notfound.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	if id, ok, err := repo.FindSaleIDByReceipt(ctx, "999999999"); err != nil || ok || id != "" {
+		t.Fatalf("FindSaleIDByReceipt(unknown) = (%q,%v,%v)", id, ok, err)
+	}
+	if rc, ok, err := repo.GetReceiptNo(ctx, "no-sale"); err != nil || ok || rc != "" {
+		t.Fatalf("GetReceiptNo(unknown) = (%q,%v,%v)", rc, ok, err)
+	}
+	if snaps, err := repo.ListSaleLineSnapshots(ctx, "no-sale"); err != nil || len(snaps) != 0 {
+		t.Fatalf("ListSaleLineSnapshots(unknown) = (%+v,%v), want empty", snaps, err)
+	}
+	// SaleTotals surfaces the raw ErrNoRows — callers must treat it as an error.
+	if _, _, _, _, err := repo.SaleTotals(ctx, "no-sale"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("SaleTotals(unknown) err = %v, want sql.ErrNoRows", err)
+	}
+	if _, ok, err := repo.SaleCompletedAt(ctx, "no-sale"); err != nil || ok {
+		t.Fatalf("SaleCompletedAt(unknown) = ok=%v err=%v, want (false,nil)", ok, err)
+	}
+	if _, ok, err := repo.GetSaleDetailByID(ctx, "no-sale"); err != nil || ok {
+		t.Fatalf("GetSaleDetailByID(unknown) = ok=%v err=%v, want (false,nil)", ok, err)
+	}
+	if entries, err := repo.ListRecentSales(ctx, 5); err != nil || len(entries) != 0 {
+		t.Fatalf("ListRecentSales(empty db) = (%+v,%v), want empty", entries, err)
+	}
+}
+
+func TestPOSRepo_SaleCompletedAt_EmptyAndNull(t *testing.T) {
+	d := openBatch8DB(t, "completedat.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	// Blank completed_at reads back as "not completed", not an error.
+	mustExec(t, d, `INSERT INTO sales (id, receipt_no, status, sale_type, currency, subtotal, total, created_at, completed_at)
+VALUES ('sale-blank', '000000010', 'completed', 'sale', 'GBP', 100, 100, '2026-07-30T10:00:00Z', '')`)
+	if _, ok, err := repo.SaleCompletedAt(ctx, "sale-blank"); err != nil || ok {
+		t.Fatalf("SaleCompletedAt(blank) = ok=%v err=%v, want (false,nil)", ok, err)
+	}
+
+	// NULL completed_at is a Scan error today (string dest), not (false,nil) —
+	// pin the current behavior so a change here is a conscious one.
+	mustExec(t, d, `INSERT INTO sales (id, receipt_no, status, sale_type, currency, subtotal, total, created_at, completed_at)
+VALUES ('sale-null', '000000011', 'completed', 'sale', 'GBP', 100, 100, '2026-07-30T10:00:00Z', NULL)`)
+	if _, ok, err := repo.SaleCompletedAt(ctx, "sale-null"); err == nil || ok {
+		t.Fatalf("SaleCompletedAt(NULL) = ok=%v err=%v, expected the current scan-error behavior", ok, err)
+	}
+
+	// Unparseable timestamp is an explicit error.
+	mustExec(t, d, `INSERT INTO sales (id, receipt_no, status, sale_type, currency, subtotal, total, created_at, completed_at)
+VALUES ('sale-badts', '000000012', 'completed', 'sale', 'GBP', 100, 100, '2026-07-30T10:00:00Z', 'not-a-time')`)
+	if _, ok, err := repo.SaleCompletedAt(ctx, "sale-badts"); err == nil || ok {
+		t.Fatalf("SaleCompletedAt(bad ts) = ok=%v err=%v, want parse error", ok, err)
+	}
+}
+
+func TestPOSRepo_UpdateSaleStatus(t *testing.T) {
+	d := openBatch8DB(t, "status.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+	seedBatch8Sale(t, d, repo, "sale-st", "000000001", "2026-07-30T11:00:00Z")
+
+	readStatus := func() (status string, voidedAt sql.NullString) {
+		t.Helper()
+		if err := d.DB.QueryRow(`SELECT status, voided_at FROM sales WHERE id = 'sale-st'`).
+			Scan(&status, &voidedAt); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+
+	// Non-void transition: status changes, voided_at stays NULL.
+	if err := repo.UpdateSaleStatus(ctx, nil, "sale-st", "refunded"); err != nil {
+		t.Fatalf("UpdateSaleStatus(refunded): %v", err)
+	}
+	status, voidedAt := readStatus()
+	if status != "refunded" || voidedAt.Valid {
+		t.Fatalf("after refunded: status=%q voided_at=%+v, want (refunded, NULL)", status, voidedAt)
+	}
+
+	// Voiding stamps voided_at with a parseable UTC timestamp.
+	before := time.Now().UTC().Add(-2 * time.Second)
+	if err := repo.UpdateSaleStatus(ctx, nil, "sale-st", "voided"); err != nil {
+		t.Fatalf("UpdateSaleStatus(voided): %v", err)
+	}
+	status, voidedAt = readStatus()
+	if status != "voided" || !voidedAt.Valid {
+		t.Fatalf("after voided: status=%q voided_at=%+v", status, voidedAt)
+	}
+	stamp, err := time.Parse(time.RFC3339, voidedAt.String)
+	if err != nil {
+		t.Fatalf("voided_at %q not RFC3339: %v", voidedAt.String, err)
+	}
+	if stamp.Before(before) || stamp.After(time.Now().UTC().Add(2*time.Second)) {
+		t.Fatalf("voided_at %v not within test window", stamp)
+	}
+
+	// Later non-void status keeps the original voided_at (CASE keeps old value).
+	if err := repo.UpdateSaleStatus(ctx, nil, "sale-st", "completed"); err != nil {
+		t.Fatal(err)
+	}
+	status, voidedAt2 := readStatus()
+	if status != "completed" || voidedAt2.String != voidedAt.String {
+		t.Fatalf("voided_at must survive later transitions: %q -> %q", voidedAt.String, voidedAt2.String)
+	}
+
+	// Unknown sale id: silent no-op, no error — callers get no signal.
+	// This pins CURRENT behavior (no RowsAffected check), not documented
+	// intent; a QUEUE follow-up exists to surface the no-op to callers,
+	// and fixing it must consciously update this assertion.
+	if err := repo.UpdateSaleStatus(ctx, nil, "no-such-sale", "voided"); err != nil {
+		t.Fatalf("UpdateSaleStatus(unknown) = %v, want nil (current silent no-op)", err)
+	}
+
+	// Transactional path: a rollback discards the status change.
+	tx, err := d.DB.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.UpdateSaleStatus(ctx, tx, "sale-st", "parked"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+	if status, _ = readStatus(); status != "completed" {
+		t.Fatalf("rollback must discard status change, got %q", status)
+	}
+}
+
+func TestPOSRepo_RecordPaymentFailure(t *testing.T) {
+	d := openBatch8DB(t, "payfail.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	gotID, err := repo.RecordPaymentFailure(ctx, PaymentFailure{
+		SaleID:   "sale-pf",
+		ActorID:  "system", // seeded by migration 003; audit_log.actor_id has an FK
+		Reason:   "card declined",
+		Payments: []any{map[string]any{"method": "card", "amount": 1080}},
+		Lines:    []any{map[string]any{"item_id": "itm-b8", "qty": 1}},
+		Total:    1080,
+		Currency: "GBP",
+	})
+	if err != nil || gotID != "sale-pf" {
+		t.Fatalf("RecordPaymentFailure = (%q,%v), want (sale-pf,nil)", gotID, err)
+	}
+
+	var actorID, entityType, action, dataJSON string
+	if err := d.DB.QueryRow(`SELECT actor_id, entity_type, action, data_json
+FROM audit_log WHERE entity_id = 'sale-pf'`).Scan(&actorID, &entityType, &action, &dataJSON); err != nil {
+		t.Fatalf("read audit row: %v", err)
+	}
+	if actorID != "system" || entityType != "sale" || action != "payment_failed" {
+		t.Fatalf("audit row = (%q,%q,%q), want (system,sale,payment_failed)", actorID, entityType, action)
+	}
+	var payload struct {
+		Reason   string `json:"reason"`
+		Total    int64  `json:"total"`
+		Currency string `json:"currency"`
+		Payments []any  `json:"payments"`
+		Lines    []any  `json:"lines"`
+		TS       string `json:"ts"`
+	}
+	if err := json.Unmarshal([]byte(dataJSON), &payload); err != nil {
+		t.Fatalf("data_json not JSON: %v (%s)", err, dataJSON)
+	}
+	if payload.Reason != "card declined" || payload.Total != 1080 || payload.Currency != "GBP" ||
+		len(payload.Payments) != 1 || len(payload.Lines) != 1 {
+		t.Fatalf("audit payload mismatch: %+v", payload)
+	}
+	if _, err := time.Parse(time.RFC3339, payload.TS); err != nil {
+		t.Fatalf("payload ts %q not RFC3339: %v", payload.TS, err)
+	}
+
+	// No sale id yet (failure before the sale row exists): a fresh uuid is
+	// generated and used as the audit entity id.
+	genID, err := repo.RecordPaymentFailure(ctx, PaymentFailure{
+		Reason: "terminal offline", Total: 500, Currency: "GBP",
+	})
+	if err != nil || genID == "" || genID == "sale-pf" {
+		t.Fatalf("RecordPaymentFailure(no sale id) = (%q,%v)", genID, err)
+	}
+	var n int
+	if err := d.DB.QueryRow(`SELECT COUNT(*) FROM audit_log
+WHERE entity_id = ? AND action = 'payment_failed' AND actor_id IS NULL`, genID).Scan(&n); err != nil || n != 1 {
+		t.Fatalf("generated-id audit row count = %d err=%v, want 1", n, err)
+	}
+}
+
+func TestPOSRepo_ListRecentSales(t *testing.T) {
+	d := openBatch8DB(t, "recent.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	for i, ts := range []string{
+		"2026-07-30T09:00:00Z", // oldest
+		"2026-07-30T09:05:00Z",
+		"2026-07-30T09:10:00Z",
+		"2026-07-30T09:15:00Z",
+		"2026-07-30T09:20:00Z",
+		"2026-07-30T09:25:00Z", // newest
+	} {
+		mustExec(t, d, `INSERT INTO sales (id, receipt_no, status, sale_type, tender_type, sync_status, currency, subtotal, total, created_at)
+VALUES (?, ?, 'completed', 'sale', 'cash', 'synced', 'GBP', ?, ?, ?)`,
+			// receipt R1..R6, totals 101..106 minor units
+			"sale-r"+string(rune('1'+i)), "R"+string(rune('1'+i)), 100+int64(i)+1, 100+int64(i)+1, ts)
+	}
+
+	entries, err := repo.ListRecentSales(ctx, 2)
+	if err != nil {
+		t.Fatalf("ListRecentSales(2): %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(entries))
+	}
+	if entries[0].ReceiptNo != "R6" || entries[0].Total != 106 ||
+		entries[0].TenderType != "cash" || entries[0].SyncStatus != "synced" ||
+		entries[0].CreatedAt != "2026-07-30T09:25:00Z" {
+		t.Fatalf("newest entry mismatch: %+v", entries[0])
+	}
+	if entries[1].ReceiptNo != "R5" || entries[1].Total != 105 {
+		t.Fatalf("second entry mismatch: %+v", entries[1])
+	}
+
+	// limit <= 0 falls back to 5 (the journal page default).
+	entries, err = repo.ListRecentSales(ctx, 0)
+	if err != nil || len(entries) != 5 {
+		t.Fatalf("ListRecentSales(0) = %d entries err=%v, want 5", len(entries), err)
+	}
+	if entries[0].ReceiptNo != "R6" || entries[4].ReceiptNo != "R2" {
+		t.Fatalf("default-limit ordering mismatch: first=%+v last=%+v", entries[0], entries[4])
+	}
+}


### PR DESCRIPTION
Coverage batch 8 of the test-coverage push (ut-docs/QUEUE.md): all 42 previously-zero-coverage `internal/data/pos_repo.go` functions under real sqlite-backed tests — reports/owner-intelligence, inventory/stock, sale lifecycle, and lookups/ensure/payments/price-history groups. Package: **63.6% → 76.2%**.

Two real bugs surfaced by the new tests, fixed failing-first (production diff is 2 lines):
- **GetLowStockItems**: a never-stocked item with a reorder level poisoned the whole query (NULL `location_id` scan) and the back-office caller drops errors — owners silently lost ALL low-stock alerts.
- **MarginByItem**: variant lines without their own `cost_price` never fell back to the parent item's cost and vanished from the margin report (doc-comment intent; join now mirrors `SeasonalUpcoming`'s resolution pattern).

Verification: 5 pipeline mutation probes + independent different-model (opus) review with 17 fresh probes at different sites; every surviving probe led to a hardened test, re-run to a kill. Full `go test ./...`, both CI guards green. Review record: `docs/code-reviews/2026-07-30-coverage-data-batch8.md`.

Deferred (queued in ut-docs/QUEUE.md, per the review's ranking): SalesByDay counts returns as positive revenue; UpdateSaleStatus silent no-op + empty-actor voids (audit poisoning); DeadStock/TopItems missing sale_type filters; location-filtered low-stock can't show never-stocked items; SaleCompletedAt NULL scan (effectively unreachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PC7bUiXcj47ztWSZnNNG8V