### PR TITLE
fix: returns no longer count as sales across window reports; phantom voids error + get attributed

### DIFF
--- a/docs/code-reviews/2026-07-30-report-sale-status-correctness.md
+++ b/docs/code-reviews/2026-07-30-report-sale-status-correctness.md
@@ -1,0 +1,131 @@
+# Code review — owner-report & sale-status correctness fixes
+
+- **Date**: 2026-07-30
+- **Branch**: `fix/report-sale-status-correctness`
+- **Scope**: the four deferred correctness gaps from coverage batch 8's
+  independent review (see `2026-07-30-coverage-data-batch8.md` and the
+  QUEUE item), fixed TDD-style — every fix written failing-first with the
+  exact predicted failure, then fixed, then passing.
+- **Independent review**: different-model (opus) subagent, findings below.
+
+## The semantic decision (documented, deliberate)
+
+Sales reports **exclude** completed returns rather than netting them.
+Rationale: `DayTotal` (the "today/yesterday" cards) already excludes
+returns and renders on the SAME back-office dashboard as `SalesByDay`'s
+7-day chart — after this change the chart's today-row equals the today
+card by construction. `SlowItems` and `busyBuckets` also already
+excluded returns; `SalesByDay`, `TopItems`, and `DeadStock`'s has-sold
+subquery were the stragglers. `TaxSummary` deliberately KEEPS netting
+returns — that is the fiscal view, where a return genuinely reduces tax
+owed. `EndOfDay` reports sales and returns as separate columns, also
+unchanged.
+
+## What changed (six production hunks)
+
+1. `SalesByDay` + `AND sale_type = 'sale'` — a completed return no
+   longer counts as positive daily revenue on the reports page, back
+   office, or the AI Q&A tool (`ask_api.go`), and no longer disagrees
+   with `TaxSummary` on the same page.
+2. `TopItems` + `AND s.sale_type = 'sale'` — a returned item's line no
+   longer inflates its "top seller" revenue (aligns with `SlowItems`).
+3. `DeadStock` has-sold subquery + `AND s.sale_type = 'sale'` — a
+   customer bringing an item back no longer counts as it "selling"; the
+   capital-on-the-shelf report shows it again.
+4. `data.UpdateSaleStatus` now checks `RowsAffected` and returns
+   "sale not found" for unknown ids. Because `pos.UpdateSaleStatus` runs
+   the repo update FIRST inside `WithTx`, the transaction now rolls back
+   before the audit insert — a void of a nonexistent sale no longer
+   returns 204 while writing a "voided" audit row for a sale that was
+   never voided (audit-log poisoning).
+5. `/api/pos/sale/status` now records the logged-in operator
+   (`getSessionUserID`) as the audit actor instead of a hardcoded `""` —
+   voids/parks/refund-status changes are attributable again.
+6. `GetLowStockItems` with a location filter now includes never-stocked
+   items (`OR inv.location_id IS NULL` — safe because the column is
+   `NOT NULL`, so NULL can only mean "no inventory row"); and
+   `SaleCompletedAt` scans `sql.NullString`, so a NULL `completed_at`
+   reads as "not completed" like blank, instead of a scan error the
+   refund-window caller silently swallowed.
+
+Two batch-8 pinned-behavior assertions were consciously flipped, as
+those tests' own comments demanded (`UpdateSaleStatus` unknown-id no-op;
+`SaleCompletedAt` NULL scan error).
+
+## Verification
+
+- Nine tests written/flipped first, all confirmed failing against the
+  unfixed code, all passing after — the failing-first runs double as
+  revert-mutation evidence for these one-line fixes:
+  - `internal/data/pos_repo_report_semantics_test.go` (new):
+    SalesByDay/TopItems/DeadStock return-exclusion, location-filtered
+    never-stocked low stock.
+  - `pos_repo_batch8_sales_test.go`: the two conscious flips.
+  - `internal/pos/sales_test.go`: phantom void errors AND leaves zero
+    audit rows.
+  - `internal/pages/pos_status_test.go` (real mux, `auth.WithUser`):
+    actor attribution end-to-end; unknown sale → error status + no
+    audit row.
+- Full `go build ./...`, `go vet ./...`, `go test ./...`,
+  `guard-data-access.sh`, `guard-i18n.sh` — all green (no user-facing
+  template strings added; the new error is API-level).
+
+## Independent (opus) review findings
+
+**No blockers.** The reviewer revert-probed every production hunk
+individually (7/7): each revert failed exactly the matching test with the
+predicted message — every line proven load-bearing. It also verified: the
+repo-update-before-audit ordering claim in `internal/pos/sales.go`
+empirically; `data.UpdateSaleStatus` has exactly one caller so the new
+error breaks nothing else; re-voiding an already-voided sale still
+succeeds (SQLite counts same-value updates as affected — no idempotency
+regression); no OTHER endpoint passes a hardcoded `""` actor for
+audit-relevant actions (the remaining `""` actors are pre-auth login
+events, and `"kiosk"`/`"cloud"` are deliberate sentinels); and no UI
+label implies netting — the one label promising "returns already
+deducted" sits on `TaxSummary`, which keeps netting. **It endorsed
+exclusion over netting** (the QUEUE item's "netting seems right" hint
+notwithstanding): returns carry positive totals so netting would be a
+different, bigger change; `COUNT(*)` can't be netted coherently; and
+`TopItems` mirrors `SlowItems` which already excludes.
+
+**Its main catch — fixed before commit (failing-first, 700→500):** fixing
+`SalesByDay` alone made `/reports` SELF-contradictory — `SalesByDepartment`,
+`SalesByTill`, `PaymentBreakdown` and `DepartmentsForDay` still counted
+returns (headline £5.00 next to breakdowns showing £7.00), and `EndOfDay`
+was internally inconsistent (its till query filtered `sale_type`, its
+departments call didn't). All four got the same one-line filter, covered
+by `TestWindowReports_ExcludeReturns_DeptTillPayments` (confirmed failing
+pre-fix: `Revenue:700, want 500`).
+
+**Other findings fixed before commit:**
+- Low-stock location-filter test had no negative case — now also pins
+  that another location's row stays excluded.
+- Unknown-sale voids now return **404** via a `data.ErrSaleNotFound`
+  sentinel (was 400 like validation errors); handler test asserts 404.
+- The AI Q&A tool descriptions (`ask_api.go`) now say returns are
+  excluded, so the self-hosted model doesn't present gross-of-refunds
+  figures as complete (Go string, no i18n obligation — confirmed).
+- `RowsAffected` error no longer shadows `err`; the two "writes no
+  audit" tests no longer ignore their count query's error.
+
+**Accepted as-is / queued:**
+- Refunds now appear NOWHERE on the window reports (only `EndOfDay`
+  shows Gross/Refund/Net) — queued: a Refunds/Net pair for `/reports`.
+- Per-location low-stock still hides an item stocked only at another
+  location (qty 0 here) — genuine product-semantics question (could
+  flood branch lists in warehouse-pattern shops); queued for a decision,
+  reviewer's view (show it) recorded.
+- `SaleCompletedAt`'s only caller discards `ok`/`err`, so the NULL fix
+  is a repo-contract fix with no behavior change at that caller —
+  correct framing, noted.
+- `setupStatusDB`'s hand-rolled schema lacks the `audit_log.actor_id`
+  FK; reviewer chased the chain and confirmed no live risk
+  (`nullIfEmpty` + seeded `system` user). Pre-existing helper weakness.
+- The endpoint has no role gate on voiding — pre-existing, out of scope.
+
+## Final gate (after review fixes)
+
+`go build`, `go vet`, full `go test ./...`, both CI guards — green.
+`git diff main --stat` = exactly the intended change set; the three
+pre-existing untracked planning docs stay uncommitted (own QUEUE item).

--- a/internal/data/pos_repo.go
+++ b/internal/data/pos_repo.go
@@ -511,7 +511,11 @@ WHERE i.reorder_level > 0
 `
 	args := []any{}
 	if locationID != "" {
-		query += ` AND inv.location_id = ?`
+		// inv.location_id IS NULL = never stocked anywhere (LEFT JOIN
+		// missed; the column itself is NOT NULL so this can't over-match)
+		// — a new item awaiting its first delivery belongs on every
+		// location's reorder list.
+		query += ` AND (inv.location_id = ? OR inv.location_id IS NULL)`
 		args = append(args, locationID)
 	}
 	query += ` ORDER BY i.name`
@@ -591,7 +595,7 @@ JOIN sales s ON s.id = sl.sale_id
 LEFT JOIN item_variants iv ON iv.id = sl.variant_id
 LEFT JOIN items it ON it.id = COALESCE(sl.item_id, iv.item_id)
 LEFT JOIN dept_roots dr ON dr.id = it.category_id
-WHERE s.status = 'completed' AND s.created_at >= datetime('now', ?)
+WHERE s.status = 'completed' AND s.sale_type = 'sale' AND s.created_at >= datetime('now', ?)
 GROUP BY department
 ORDER BY revenue DESC`, fmt.Sprintf("-%d days", days))
 	if err != nil {
@@ -629,7 +633,7 @@ SELECT s.till_id, COALESCE(t.name, '') AS name,
        COUNT(*) AS cnt, COALESCE(SUM(s.total), 0) AS revenue
 FROM sales s
 LEFT JOIN tills t ON t.id = s.till_id
-WHERE s.status = 'completed' AND s.created_at >= datetime('now', ?)
+WHERE s.status = 'completed' AND s.sale_type = 'sale' AND s.created_at >= datetime('now', ?)
 GROUP BY s.till_id
 ORDER BY revenue DESC`, fmt.Sprintf("-%d days", days))
 	if err != nil {
@@ -659,7 +663,7 @@ JOIN sales s ON s.id = sl.sale_id
 LEFT JOIN item_variants iv ON iv.id = sl.variant_id
 LEFT JOIN items it ON it.id = COALESCE(sl.item_id, iv.item_id)
 LEFT JOIN dept_roots dr ON dr.id = it.category_id
-WHERE s.status = 'completed' AND date(s.created_at) = date(?)
+WHERE s.status = 'completed' AND s.sale_type = 'sale' AND date(s.created_at) = date(?)
 GROUP BY department
 ORDER BY revenue DESC`, day)
 	if err != nil {
@@ -678,11 +682,13 @@ ORDER BY revenue DESC`, day)
 }
 
 // SalesByDay aggregates completed sales per day for the last N days.
+// Returns are excluded, matching DayTotal on the same dashboard (and
+// SlowItems/busyBuckets); TaxSummary is the fiscal view and nets them.
 func (r *POSRepo) SalesByDay(ctx context.Context, days int) ([]DailySales, error) {
 	rows, err := r.db.QueryContext(ctx, `
 SELECT date(created_at) AS day, COUNT(*), COALESCE(SUM(total), 0), COALESCE(SUM(tax_total), 0)
 FROM sales
-WHERE status = 'completed' AND created_at >= datetime('now', ?)
+WHERE status = 'completed' AND sale_type = 'sale' AND created_at >= datetime('now', ?)
 GROUP BY day ORDER BY day DESC`, fmt.Sprintf("-%d days", days))
 	if err != nil {
 		return nil, fmt.Errorf("sales by day: %w", err)
@@ -705,7 +711,7 @@ func (r *POSRepo) TopItems(ctx context.Context, days, limit int) ([]TopItem, err
 SELECT sl.name_snapshot, SUM(sl.quantity), COALESCE(SUM(sl.total_after_tax), 0) AS revenue
 FROM sale_lines sl
 JOIN sales s ON s.id = sl.sale_id
-WHERE s.status = 'completed' AND s.created_at >= datetime('now', ?)
+WHERE s.status = 'completed' AND s.sale_type = 'sale' AND s.created_at >= datetime('now', ?)
 GROUP BY sl.name_snapshot ORDER BY revenue DESC LIMIT ?`, fmt.Sprintf("-%d days", days), limit)
 	if err != nil {
 		return nil, fmt.Errorf("top items: %w", err)
@@ -768,7 +774,7 @@ WHERE i.is_active = 1 AND inv.quantity > 0
     SELECT DISTINCT COALESCE(NULLIF(sl.item_id, ''), v.item_id) FROM sale_lines sl
     JOIN sales s ON s.id = sl.sale_id
     LEFT JOIN item_variants v ON v.id = sl.variant_id
-    WHERE s.status = 'completed'
+    WHERE s.status = 'completed' AND s.sale_type = 'sale'
       AND COALESCE(NULLIF(sl.item_id, ''), v.item_id) IS NOT NULL
       AND s.created_at >= datetime('now', ?)
   )
@@ -1005,7 +1011,7 @@ func (r *POSRepo) PaymentBreakdown(ctx context.Context, days int) ([]MethodTotal
 SELECT p.method_id, COUNT(*), COALESCE(SUM(p.amount - p.change_given), 0) AS applied
 FROM payments p
 JOIN sales s ON s.id = p.sale_id
-WHERE s.status = 'completed' AND s.created_at >= datetime('now', ?)
+WHERE s.status = 'completed' AND s.sale_type = 'sale' AND s.created_at >= datetime('now', ?)
 GROUP BY p.method_id ORDER BY applied DESC`, fmt.Sprintf("-%d days", days))
 	if err != nil {
 		return nil, fmt.Errorf("payment breakdown: %w", err)
@@ -2031,15 +2037,22 @@ func (r *POSRepo) CleanupObsoleteItems(ctx context.Context, actorID string) (int
 }
 
 // UpdateSaleStatus updates sale status (and optionally voided_at when voided).
+// ErrSaleNotFound reports a status update against a sale id that doesn't
+// exist — callers distinguish it (404) from validation failures (400).
+var ErrSaleNotFound = errors.New("sale not found")
+
 func (r *POSRepo) UpdateSaleStatus(ctx context.Context, tx *sql.Tx, saleID, status string) error {
 	now := time.Now().UTC().Format(time.RFC3339)
-	_, err := r.exec(tx).ExecContext(ctx, `
+	res, err := r.exec(tx).ExecContext(ctx, `
 UPDATE sales
 SET status = ?, voided_at = CASE WHEN ? = 'voided' THEN ? ELSE voided_at END
 WHERE id = ?
 `, status, status, now, saleID)
 	if err != nil {
 		return fmt.Errorf("update sale status: %w", err)
+	}
+	if n, rerr := res.RowsAffected(); rerr == nil && n == 0 {
+		return fmt.Errorf("update sale status: %w: %s", ErrSaleNotFound, saleID)
 	}
 	return nil
 }
@@ -2333,14 +2346,15 @@ func (r *POSRepo) SaleTotals(ctx context.Context, saleID string) (string, int64,
 
 // SaleCompletedAt returns the completed_at timestamp for a sale.
 func (r *POSRepo) SaleCompletedAt(ctx context.Context, saleID string) (time.Time, bool, error) {
-	var completed string
-	err := r.db.QueryRowContext(ctx, `SELECT completed_at FROM sales WHERE id = ?`, saleID).Scan(&completed)
+	var completedNS sql.NullString
+	err := r.db.QueryRowContext(ctx, `SELECT completed_at FROM sales WHERE id = ?`, saleID).Scan(&completedNS)
 	if err == sql.ErrNoRows {
 		return time.Time{}, false, nil
 	}
 	if err != nil {
 		return time.Time{}, false, fmt.Errorf("sale completed_at: %w", err)
 	}
+	completed := completedNS.String
 	if strings.TrimSpace(completed) == "" {
 		return time.Time{}, false, nil
 	}

--- a/internal/data/pos_repo_batch8_sales_test.go
+++ b/internal/data/pos_repo_batch8_sales_test.go
@@ -275,12 +275,13 @@ VALUES ('sale-blank', '000000010', 'completed', 'sale', 'GBP', 100, 100, '2026-0
 		t.Fatalf("SaleCompletedAt(blank) = ok=%v err=%v, want (false,nil)", ok, err)
 	}
 
-	// NULL completed_at is a Scan error today (string dest), not (false,nil) —
-	// pin the current behavior so a change here is a conscious one.
+	// NULL completed_at reads back as "not completed", same contract as
+	// blank — fixed 2026-07-30 (was a scan error into a string dest;
+	// pos_api.go:616 swallowed it and proceeded with a zero time).
 	mustExec(t, d, `INSERT INTO sales (id, receipt_no, status, sale_type, currency, subtotal, total, created_at, completed_at)
 VALUES ('sale-null', '000000011', 'completed', 'sale', 'GBP', 100, 100, '2026-07-30T10:00:00Z', NULL)`)
-	if _, ok, err := repo.SaleCompletedAt(ctx, "sale-null"); err == nil || ok {
-		t.Fatalf("SaleCompletedAt(NULL) = ok=%v err=%v, expected the current scan-error behavior", ok, err)
+	if _, ok, err := repo.SaleCompletedAt(ctx, "sale-null"); err != nil || ok {
+		t.Fatalf("SaleCompletedAt(NULL) = ok=%v err=%v, want (false,nil)", ok, err)
 	}
 
 	// Unparseable timestamp is an explicit error.
@@ -341,12 +342,11 @@ func TestPOSRepo_UpdateSaleStatus(t *testing.T) {
 		t.Fatalf("voided_at must survive later transitions: %q -> %q", voidedAt.String, voidedAt2.String)
 	}
 
-	// Unknown sale id: silent no-op, no error — callers get no signal.
-	// This pins CURRENT behavior (no RowsAffected check), not documented
-	// intent; a QUEUE follow-up exists to surface the no-op to callers,
-	// and fixing it must consciously update this assertion.
-	if err := repo.UpdateSaleStatus(ctx, nil, "no-such-sale", "voided"); err != nil {
-		t.Fatalf("UpdateSaleStatus(unknown) = %v, want nil (current silent no-op)", err)
+	// Unknown sale id: an explicit error — fixed 2026-07-30 (was a silent
+	// no-op with no RowsAffected check, so voids of nonexistent sales
+	// "succeeded" and still left an audit row via internal/pos).
+	if err := repo.UpdateSaleStatus(ctx, nil, "no-such-sale", "voided"); err == nil {
+		t.Fatal("UpdateSaleStatus(unknown) = nil, want a not-found error")
 	}
 
 	// Transactional path: a rollback discards the status change.

--- a/internal/data/pos_repo_report_semantics_test.go
+++ b/internal/data/pos_repo_report_semantics_test.go
@@ -1,0 +1,182 @@
+package data
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Report/sale-status correctness fixes (2026-07-30, from coverage batch 8's
+// independent review): sales reports must not count completed RETURNS as
+// sales. The file's established semantics are exclusion (DayTotal, SlowItems,
+// busyBuckets all filter sale_type='sale'); SalesByDay, TopItems and
+// DeadStock's has-sold subquery were the stragglers. TaxSummary deliberately
+// keeps NETTING returns — that's the fiscal view, asserted elsewhere.
+// Written failing-first against the unfixed queries.
+
+func TestSalesByDay_ExcludesReturns(t *testing.T) {
+	d := b8OpenDB(t, "salesbyday-returns.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	now := b8At(time.Now().Add(-2 * time.Hour))
+	b8Sale(t, d, "rs1", now, "completed", "sale", 100, 1000)
+	b8Sale(t, d, "rs2", now, "completed", "return", 30, 300) // must not appear
+	b8Sale(t, d, "rs3", now, "voided", "sale", 0, 99999)     // must not appear
+
+	daily, err := repo.SalesByDay(ctx, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(daily) != 1 {
+		t.Fatalf("want 1 day row, got %+v", daily)
+	}
+	got := daily[0]
+	if got.Count != 1 || got.Total != 1000 || got.TaxTotal != 100 {
+		t.Fatalf("day = %+v, want count 1 / total 1000 / tax 100 (returns excluded, matching DayTotal on the same dashboard)", got)
+	}
+}
+
+func TestTopItems_ExcludesReturns(t *testing.T) {
+	d := b8OpenDB(t, "topitems-returns.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	now := b8At(time.Now().Add(-2 * time.Hour))
+	b8Item(t, d, "ri-a", 500, nil, 1)
+	b8Sale(t, d, "rt1", now, "completed", "sale", 0, 500)
+	b8Line(t, d, "rt1", 1, "ri-a", "", "Widget", 1, 0, 0, 500, 500)
+	b8Sale(t, d, "rt2", now, "completed", "return", 0, 200)
+	b8Line(t, d, "rt2", 1, "ri-a", "", "Widget", 1, 0, 0, 200, 200)
+
+	top, err := repo.TopItems(ctx, 7, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(top) != 1 || top[0].Name != "Widget" {
+		t.Fatalf("want just Widget, got %+v", top)
+	}
+	if top[0].Qty != 1 || top[0].Revenue != 500 {
+		t.Fatalf("Widget = %+v, want qty 1 / revenue 500 (the return's line must not inflate it)", top[0])
+	}
+}
+
+func TestDeadStock_ReturnDoesNotCountAsSold(t *testing.T) {
+	d := b8OpenDB(t, "deadstock-returns.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	// Neutralize the demo seed inventory so the assertion set is exact.
+	mustExec(t, d, `DELETE FROM inventory`)
+
+	mustExec(t, d, `INSERT INTO stock_locations (id, name) VALUES ('loc_rd', 'Dead Shop')`)
+	b8Item(t, d, "rd-a", 400, nil, 1)
+	b8Stock(t, d, "rdinv1", "rd-a", "loc_rd", 5)
+	// Its ONLY window activity is a completed RETURN — customers bringing
+	// an item back is not it "selling"; it must still count as dead stock.
+	now := b8At(time.Now().Add(-24 * time.Hour))
+	b8Sale(t, d, "rd1", now, "completed", "return", 0, 400)
+	b8Line(t, d, "rd1", 1, "rd-a", "", "Name rd-a", 1, 0, 0, 400, 400)
+
+	dead, err := repo.DeadStock(ctx, 30, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, row := range dead {
+		if row.Name == "Name rd-a" {
+			found = true
+			if row.Qty != 5 || row.StockValue != 2000 {
+				t.Fatalf("rd-a = %+v, want qty 5 / value 2000", row)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("item whose only activity is a return must still be dead stock, got %+v", dead)
+	}
+}
+
+// The /reports page renders SalesByDay's headline NEXT TO the department,
+// till and payment breakdowns — if the breakdowns keep counting returns,
+// the page contradicts itself (batch: headline 500 vs breakdowns 700).
+// DepartmentsForDay feeds the Z-report, whose own till query already
+// filtered sale_type='sale' — this also makes EndOfDay internally coherent.
+func TestWindowReports_ExcludeReturns_DeptTillPayments(t *testing.T) {
+	d := b8OpenDB(t, "window-reports-returns.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	tm := time.Now().Add(-2 * time.Hour)
+	when := b8At(tm)
+	b8Item(t, d, "ri-b", 500, nil, 1)
+	b8Sale(t, d, "wr1", when, "completed", "sale", 0, 500)
+	b8Line(t, d, "wr1", 1, "ri-b", "", "Gadget", 1, 0, 0, 500, 500)
+	mustExec(t, d, `INSERT INTO payments(id, sale_id, method_id, amount, currency, change_given, paid_at) VALUES('wrp1','wr1','cash',500,'GBP',0,?)`, when)
+	// The completed return that must not inflate any breakdown.
+	b8Sale(t, d, "wr2", when, "completed", "return", 0, 200)
+	b8Line(t, d, "wr2", 1, "ri-b", "", "Gadget", 1, 0, 0, 200, 200)
+	mustExec(t, d, `INSERT INTO payments(id, sale_id, method_id, amount, currency, change_given, paid_at) VALUES('wrp2','wr2','cash',200,'GBP',0,?)`, when)
+
+	dept, err := repo.SalesByDepartment(ctx, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dept) != 1 || dept[0].Qty != 1 || dept[0].Revenue != 500 {
+		t.Fatalf("SalesByDepartment = %+v, want one row qty 1 / revenue 500", dept)
+	}
+
+	tills, err := repo.SalesByTill(ctx, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tills) != 1 || tills[0].Count != 1 || tills[0].Revenue != 500 {
+		t.Fatalf("SalesByTill = %+v, want one row count 1 / revenue 500", tills)
+	}
+
+	day, err := repo.DepartmentsForDay(ctx, when[:10])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(day) != 1 || day[0].Qty != 1 || day[0].Revenue != 500 {
+		t.Fatalf("DepartmentsForDay = %+v, want one row qty 1 / revenue 500", day)
+	}
+
+	pay, err := repo.PaymentBreakdown(ctx, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pay) != 1 || pay[0].Method != "cash" || pay[0].Count != 1 || pay[0].Amount != 500 {
+		t.Fatalf("PaymentBreakdown = %+v, want cash count 1 / applied 500", pay)
+	}
+}
+
+func TestGetLowStockItems_LocationFilterIncludesNeverStocked(t *testing.T) {
+	d := b8OpenDB(t, "lowstock-locfilter.db")
+	ctx := context.Background()
+	repo := NewPOSRepo(d.DB)
+
+	mustExec(t, d, `DELETE FROM inventory`)
+	mustExec(t, d, `UPDATE items SET reorder_level = 0`)
+	mustExec(t, d, `INSERT INTO stock_locations (id, name) VALUES ('loc_lf', 'Filter Main')`)
+
+	b8Item(t, d, "lf-never", 500, nil, 1)
+	mustExec(t, d, `UPDATE items SET reorder_level = 5 WHERE id = 'lf-never'`)
+
+	// An item stocked (and low) at a DIFFERENT location must stay out of
+	// this location's filtered list — the IS NULL widening must not
+	// over-match rows that belong elsewhere.
+	mustExec(t, d, `INSERT INTO stock_locations (id, name) VALUES ('loc_other', 'Elsewhere')`)
+	b8Item(t, d, "lf-elsewhere", 500, nil, 1)
+	mustExec(t, d, `UPDATE items SET reorder_level = 5 WHERE id = 'lf-elsewhere'`)
+	mustExec(t, d, `INSERT INTO inventory (id, item_id, location_id, quantity) VALUES ('inv-lf-o', 'lf-elsewhere', 'loc_other', 1)`)
+
+	// "New item, reorder level set, never received" is exactly what a
+	// per-location reorder list exists to surface (batch 8 review).
+	items, err := repo.GetLowStockItems(ctx, "loc_lf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || items[0].ItemID != "lf-never" || items[0].CurrentQty != 0 {
+		t.Fatalf("location-filtered report must include ONLY the never-stocked item (not other locations' rows), got %+v", items)
+	}
+}

--- a/internal/pages/ask_api.go
+++ b/internal/pages/ask_api.go
@@ -39,7 +39,7 @@ func askTools(repo *data.POSRepo) []ai.AskTool {
 	return []ai.AskTool{
 		{
 			Name:        "sales_by_day",
-			Description: "Daily sales totals: per day the number of completed sales, revenue total and tax total (minor units).",
+			Description: "Daily sales totals: per day the number of completed sales, revenue total and tax total (minor units). Returns/refunds are excluded, not netted.",
 			Params:      days,
 			Run: func(ctx context.Context, args map[string]any) (any, error) {
 				return repo.SalesByDay(ctx, intArg(args, "days", 14, 1, 365))
@@ -47,7 +47,7 @@ func askTools(repo *data.POSRepo) []ai.AskTool {
 		},
 		{
 			Name:        "top_items",
-			Description: "Best-selling items over a period: name, quantity sold, revenue (minor units).",
+			Description: "Best-selling items over a period: name, quantity sold, revenue (minor units). Returns/refunds are excluded.",
 			Params: map[string]any{
 				"type": "object",
 				"properties": map[string]any{

--- a/internal/pages/pos_api.go
+++ b/internal/pages/pos_api.go
@@ -665,8 +665,12 @@ func registerPOSAPI(mux *http.ServeMux, d *common.Deps) {
 			http.Error(w, "saleId and status required", http.StatusBadRequest)
 			return
 		}
-		if err := pos.UpdateSaleStatus(r.Context(), d.Db, in.SaleID, in.Status, "", in.Reason); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+		if err := pos.UpdateSaleStatus(r.Context(), d.Db, in.SaleID, in.Status, getSessionUserID(r), in.Reason); err != nil {
+			code := http.StatusBadRequest
+			if errors.Is(err, data.ErrSaleNotFound) {
+				code = http.StatusNotFound
+			}
+			http.Error(w, err.Error(), code)
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)

--- a/internal/pages/pos_status_test.go
+++ b/internal/pages/pos_status_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/universaltill/universal-till/internal/auth"
 	"github.com/universaltill/universal-till/internal/pages/common"
 	_ "modernc.org/sqlite"
 )
@@ -72,5 +73,56 @@ func TestStatusEndpoint_ParkAndVoid(t *testing.T) {
 	_ = db.QueryRow(`SELECT COUNT(*) FROM audit_log WHERE entity_id='sale1' AND action='voided'`).Scan(&count)
 	if count == 0 {
 		t.Fatalf("expected audit log for void")
+	}
+}
+
+func TestStatusEndpoint_RecordsSessionOperatorAsActor(t *testing.T) {
+	db := setupStatusDB(t)
+	defer db.Close()
+	dp := &common.Deps{Db: db, State: common.RuntimeState{Currency: "GBP", TaxRatePct: 20}}
+	mux := http.NewServeMux()
+	registerPOSAPI(mux, dp)
+
+	b, _ := json.Marshal(map[string]string{"saleId": "sale1", "status": "voided", "reason": "who did this"})
+	req := httptest.NewRequest(http.MethodPost, "/api/pos/sale/status", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	req = auth.WithUser(req, auth.User{ID: "op7", Role: "manager"})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("void failed: %d %s", rec.Code, rec.Body.String())
+	}
+	// The void must be attributed to the logged-in operator, not recorded
+	// actor-less (batch 8 review: pos_api passed "" as actorID).
+	var actor string
+	if err := db.QueryRow(`SELECT COALESCE(actor_id,'') FROM audit_log WHERE entity_id='sale1' AND action='voided'`).Scan(&actor); err != nil {
+		t.Fatalf("read audit actor: %v", err)
+	}
+	if actor != "op7" {
+		t.Fatalf("audit actor_id = %q, want op7", actor)
+	}
+}
+
+func TestStatusEndpoint_UnknownSaleFailsAndWritesNoAudit(t *testing.T) {
+	db := setupStatusDB(t)
+	defer db.Close()
+	dp := &common.Deps{Db: db, State: common.RuntimeState{Currency: "GBP", TaxRatePct: 20}}
+	mux := http.NewServeMux()
+	registerPOSAPI(mux, dp)
+
+	b, _ := json.Marshal(map[string]string{"saleId": "ghost", "status": "voided"})
+	req := httptest.NewRequest(http.MethodPost, "/api/pos/sale/status", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("voiding a nonexistent sale returned %d, want 404", rec.Code)
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM audit_log WHERE entity_id='ghost'`).Scan(&count); err != nil {
+		t.Fatalf("count audit rows: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("phantom void left %d audit row(s), want 0", count)
 	}
 }

--- a/internal/pos/sales_test.go
+++ b/internal/pos/sales_test.go
@@ -458,6 +458,27 @@ func TestUpdateSaleStatus_Void(t *testing.T) {
 	}
 }
 
+func TestUpdateSaleStatus_UnknownSaleErrorsAndWritesNoAudit(t *testing.T) {
+	ctx := context.Background()
+	db := setupSaleDB(t)
+	defer db.Close()
+
+	// Voiding a sale that doesn't exist must fail loudly — and the whole
+	// transaction must roll back, leaving NO "voided" audit row for a sale
+	// that was never voided (audit-log poisoning, batch 8 review).
+	err := UpdateSaleStatus(ctx, db, "no-such-sale", "voided", "actor1", "phantom")
+	if err == nil {
+		t.Fatal("UpdateSaleStatus(unknown sale) = nil, want error")
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM audit_log WHERE entity_id='no-such-sale'`).Scan(&count); err != nil {
+		t.Fatalf("count audit rows: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("phantom void left %d audit row(s), want 0", count)
+	}
+}
+
 func TestCompleteSale_AllowsChangeAcrossPayments(t *testing.T) {
 	ctx := context.Background()
 	db := setupSaleDB(t)


### PR DESCRIPTION
The 'owner-report & sale-status correctness' queue item (from coverage batch 8's independent review, ut-docs/QUEUE.md).

**Report semantics** — completed returns no longer count as positive sales anywhere on the window reports: `SalesByDay`, `TopItems`, `DeadStock`'s has-sold subquery, **and** (per the independent review's catch that fixing SalesByDay alone left `/reports` contradicting itself — headline £5.00 next to £7.00 breakdowns) `SalesByDepartment`, `SalesByTill`, `PaymentBreakdown`, `DepartmentsForDay`. Exclusion (not netting) matches `DayTotal` on the same dashboard and `SlowItems`/`busyBuckets`; `TaxSummary` deliberately keeps netting as the fiscal view (its label already says "returns already deducted"). Also makes `EndOfDay` internally coherent.

**Sale-status hardening** — voiding a nonexistent sale used to return 204 AND write a "voided" audit row for a sale that was never voided (audit poisoning), attributed to nobody. Now: `data.UpdateSaleStatus` checks `RowsAffected` → `ErrSaleNotFound` → 404, transaction rolls back before the audit insert, and `/api/pos/sale/status` records the logged-in operator as actor.

**Smaller fixes**: location-filtered low-stock includes never-stocked items (with a negative case pinning other locations' rows stay excluded); `SaleCompletedAt` treats NULL as not-completed; AI Q&A tool descriptions state returns are excluded.

Every fix written failing-first; independent (opus) review revert-probed all 7 hunks individually — each revert failed exactly its matching test — and its findings were fixed and re-verified. Review record: `docs/code-reviews/2026-07-30-report-sale-status-correctness.md`.

Queued follow-ups: refunds now appear nowhere on `/reports` (only EndOfDay shows Gross/Refund/Net) — add a Refunds/Net pair; per-location low-stock for items stocked only elsewhere needs a product decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PC7bUiXcj47ztWSZnNNG8V