### PR TITLE
fix: app.Run joins its background services before returning

### DIFF
--- a/docs/code-reviews/2026-07-30-app-run-shutdown-join.md
+++ b/docs/code-reviews/2026-07-30-app-run-shutdown-join.md
@@ -1,0 +1,172 @@
+# Code review — `app.Run` joins its background services before returning
+
+- **Date:** 2026-07-30
+- **Branch/PR:** `fix/app-run-shutdown-join`
+- **Author:** pipeline (sonnet)
+- **Independent reviewer:** opus subagent (different model)
+- **Scope:** `internal/app`, `internal/server`, `internal/updates`,
+  `internal/alerts`, `internal/enroll`, `mobile/mobile_test.go`
+
+## The bug
+
+`internal/app/app.go`'s `Run(ctx)` starts several background goroutines —
+`updates.Start`, `alerts.Start`, `enroll.Init`'s conditional registration
+loop, and (via `server.Start`) a `BackgroundJobs` scheduler, a daily
+local-DB-backup ticker, a related-items-rebuild ticker, and `server.Start`'s
+own graceful-shutdown goroutine (`srv.Shutdown` → `supervisor.Shutdown`) —
+all fire-and-forget. `Run` returned (running its deferred `database.Close()`)
+without ever waiting for any of them to actually exit. A straggler could
+still be reading/writing the DB, or writing sqlite `-wal`/`-shm` files in the
+data directory, for a moment after `Run` had already returned and the DB
+handle was closed.
+
+Found via a `mobile/mobile_test.go` CI flake (main run 30531313594,
+`TempDir RemoveAll cleanup: directory not empty`) — `PR #97` (merged
+2026-07-30) diagnosed the real root cause correctly but deliberately only
+mitigated the *test's* symptom (a manually-owned dir + 5s-retry `RemoveAll`),
+leaving "drain before returning" as this queued follow-up. This PR is that
+fix.
+
+Also relevant and independently confirmed during review: `net/http`'s
+`Server.Shutdown` docs guarantee `Serve` returns as soon as `Shutdown`
+*begins* (listeners close), not after it fully completes — so
+`server.Start`'s original shutdown goroutine could leave `supervisor.Shutdown`
+still running after `server.Start` itself had already returned. A second,
+related race this fix also had to close.
+
+## What shipped
+
+A `*sync.WaitGroup` threads from `app.Run` into `updates.Start`,
+`alerts.Start`, `enroll.Init`, and `server.Start` (which threads it into
+`BackgroundJobs.Start` and its own three internal goroutines, including the
+shutdown goroutine). Every spawn site does `wg.Add(1)` synchronously before
+the `go` statement and `defer wg.Done()` as the goroutine's first statement.
+
+`app.Run` derives an independently-cancellable `bgCtx` from the caller's
+`ctx` and passes `bgCtx` (not `ctx`) to every one of those calls; a single
+deferred cleanup (`stopBg(); drainBackgroundServices(&wg, log,
+backgroundDrainTimeout)`) runs on **every** return path from `Run`, not just
+the normal caller-driven shutdown. `drainBackgroundServices` waits on the
+group with a bounded, loudly-logged timeout (10s in production) before
+giving up and returning anyway — a wedged service must not hang shutdown
+forever.
+
+`mobile/mobile_test.go`'s manually-owned-dir + 5s-retry `RemoveAll`
+workaround from PR #97 is gone; plain `t.TempDir()` is safe again.
+
+## Independent review — two real rounds
+
+**Round 1 verdict: SAFE TO MERGE WITH FIXES.** The reviewer verified the core
+`wg.Add`/`wg.Done` mechanics were race-correct (every `Add` before its `go`
+statement, every `Done` deferred first-line) and that the Serve/Shutdown race
+was genuinely closed on the *normal* cancel path — but found two real gaps by
+actually running mutation probes, not just reading the diff:
+
+- **F1/F2 (should-fix, correctness):** `Run`'s early error returns
+  (`plugins.Init`, `marketplace.NewCatalogRepository`, and — proven with a
+  temporary probe test — `server.Start`'s own listen failure) all bypassed
+  the drain entirely, because at that point nothing had told the
+  already-started background goroutines (e.g. enroll's registration loop) to
+  stop. The reviewer's probe showed this meant a **guaranteed** 10s stall (a
+  spurious "still running" error log) followed by closing the DB with
+  goroutines still live — the exact bug this PR exists to fix, still present
+  on every non-happy-path return.
+- **F3 (should-fix, test-integrity):** all three `internal/server` join
+  assertions were **vacuous** — one-directional ("wg drains within N
+  seconds of cancel"), which an empty/never-`Add`-ed `WaitGroup` satisfies
+  instantly. The reviewer proved this by deleting all six `wg.Add`/`wg.Done`
+  pairs from `server.go` and showing the three tests still passed — meaning
+  the package that owns the Serge/Shutdown-race fix (the whole point of this
+  diff) had zero real test protection.
+- **F4 (should-fix, comment accuracy):** the `mobile_test.go` comment
+  overclaimed that a clean local run "proves the join works" — the reviewer
+  showed 40 clean `-race -count=40` runs *with the fix removed*, since the
+  original bug was a rare, timing-dependent flake, not a guaranteed
+  reproduction.
+- **F5 (should-fix, scope accuracy):** the `wg` doc comment's "every
+  background goroutine" was not literally true — `internal/plugins.Supervisor`'s
+  `monitorProcess` goroutines were already an acknowledged gap, but the
+  reviewer also found the wasm runtime's per-plugin event-channel drainer
+  (`internal/plugins/wasm_runtime.go`, `for ev := range ch`) has no
+  shutdown-triggered exit at all (its channel only closes on the next
+  `Sync`/reload) — independently confirmed by reading `ipc.go`'s
+  `ResetSubscribers` and its only two call sites before accepting the claim.
+- F6–F8: nitpicks (QUEUE.md wording, a slow test-failure path, a
+  leaked-but-harmless goroutine on the timeout branch).
+
+**All five should-fixes applied, re-verified with the reviewer's own method
+(deliberately reintroduce each bug, confirm the specific test now fails with
+the exact predicted message, restore the fix, confirm green again) before
+this record was written — not taken on the reviewer's word:**
+
+- F1/F2: `Run` now derives `bgCtx` and defers `stopBg()`+drain on every
+  return path. New test `TestRun_JoinsBackgroundGoroutinesOnEarlyServerError`
+  drives a real `Run()` (never cancelling its own ctx) into an unbindable
+  `UT_LISTEN_ADDR`, with `enroll.Init`'s background loop genuinely live
+  (config's default marketplace endpoint), and asserts `Run` returns in
+  well under 3s. Reverted to the pre-fix shape → the test failed exactly as
+  the reviewer's probe predicted: `Run took 10.145339385s ... apparently
+  only stopped by the 10s drain timeout`. Restored → passes in 0.69s.
+- F3: added the missing "must NOT return before cancel" half to all three
+  `internal/server` join assertions. Reintroduced the reviewer's exact
+  mutation (stripped all 6 `wg.Add`/`wg.Done` pairs) → all three tests now
+  fail with the expected "not tracked" messages. Restored → green.
+- F4: comment reworded to state plainly that a clean run is a regression
+  canary, not proof by itself.
+- F5: `app.go`'s doc comment now names both excluded gaps
+  (`monitorProcess`, the wasm event drainer) and why each is excluded;
+  logged as its own `ut-docs/QUEUE.md` follow-up rather than silently
+  dropped.
+- F7/F8 (nitpicks): `enroll`'s join test now calls
+  `srv.CloseClientConnections()` ahead of `srv.Close()` so a regression
+  fails fast instead of stalling ~15s; `drainBackgroundServices`'s doc notes
+  the intentionally-leaked, harmless `wg.Wait()` goroutine on timeout.
+
+## Verified beyond the reviewer's own probes
+
+- `go build ./... && go vet ./...` clean.
+- `go test -race` green across `internal/app`, `internal/server`,
+  `internal/updates`, `internal/alerts`, `internal/enroll`, `mobile`.
+- `go test ./mobile/... -race -count=15` clean (reviewer independently ran
+  `-count=10` and `-count=40`, also clean).
+- Full `go test ./...`: one failure, `internal/issuereport`'s
+  `TestSaveCleansUpDirectoryOnWriteFailure` ("expected Save to fail on a
+  read-only bundle directory") — confirmed pre-existing and unrelated by
+  running it against unmodified `main` in this same container (root can
+  write through a `0500` dir, so the permission-based test can't fail the
+  way it expects here regardless of this diff). This branch does not touch
+  `internal/issuereport`.
+- `bash scripts/ci/guard-data-access.sh`, `guard-i18n.sh`,
+  `guard-emoji-font.sh`, `guard-kiosk-launch-flags.sh`,
+  `guard-webkit-version.sh` — all green (none of this diff's surface is
+  relevant to the latter three, run anyway for completeness).
+- Full Playwright e2e suite (`e2e/`, both projects, 20 specs): 19/20 green;
+  the one failure (`catalog-image-to-till.spec.ts`, a thumbnail
+  `naturalWidth`/`complete` image-decode timing assertion) reproduces
+  identically against unmodified `main` in this container — pre-existing,
+  unrelated to this diff (confirmed via `git stash`).
+- No SQL/money/i18n/plugin-signing surface touched (`guard-data-access.sh`
+  passing plus a manual diff read confirms); no new file writes anywhere in
+  the diff, so neither of this pipeline's two recurring bug classes
+  (missing `os.MkdirAll`, cwd-relative path instead of `paths.Data`) apply.
+  No real client/shop name, no secret-shaped literal anywhere in the diff.
+
+## Explicitly out of scope, logged as follow-ups (`ut-docs/QUEUE.md`)
+
+- `internal/plugins.Supervisor`'s `monitorProcess` goroutines: `Shutdown`
+  cancels the process context but doesn't join the corresponding
+  `cmd.Wait()` goroutine. Architecturally separate (native plugin-process
+  supervision, ADR-0001), a bigger diff on its own.
+- The wasm runtime's per-plugin event-channel drainer
+  (`internal/plugins/wasm_runtime.go`): its channel is only closed by the
+  next `Sync`/reload, never by shutdown/ctx-cancel — confirmed by reading
+  `ipc.go`. Registering it on the same `wg` today would make every drain
+  time out, so it's correctly excluded rather than silently ignored.
+
+## Verdict
+
+**SAFE TO MERGE.** All should-fix findings applied and independently
+re-verified via mutation (break it, confirm the specific test fails with the
+predicted message, fix it, confirm green) rather than taken on either
+party's word. Full gate green modulo two confirmed-pre-existing,
+unrelated-to-this-diff environment issues.

--- a/internal/alerts/alerts.go
+++ b/internal/alerts/alerts.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/universaltill/universal-till/internal/config"
@@ -130,9 +131,13 @@ func unusualSales(ctx context.Context, db *sql.DB) (float64, int64, bool) {
 }
 
 // Start runs the daily digest loop: first push shortly after boot (give
-// enrolment a moment), then every 24h. Ctx-cancelled with the server.
-func Start(ctx context.Context, cfg *config.Config, db *sql.DB) {
+// enrolment a moment), then every 24h. Ctx-cancelled with the server. wg is
+// marked Done once the loop goroutine has fully exited, so callers can wait
+// out shutdown instead of returning while it still runs.
+func Start(ctx context.Context, cfg *config.Config, db *sql.DB, wg *sync.WaitGroup) {
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		first := time.NewTimer(2 * time.Minute)
 		defer first.Stop()
 		select {

--- a/internal/alerts/alerts_test.go
+++ b/internal/alerts/alerts_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/universaltill/universal-till/internal/config"
 	"github.com/universaltill/universal-till/internal/db"
@@ -116,5 +118,49 @@ func TestPushDigest(t *testing.T) {
 	}
 	if auth != "Bearer tok-1" {
 		t.Fatalf("auth = %q", auth)
+	}
+}
+
+// Start's digest loop must be genuinely joinable: wg.Wait() must NOT return
+// while the loop is still running (a missing wg.Add would let Wait return
+// immediately, vacuously "passing" without ever tracking the goroutine), and
+// MUST return promptly once ctx is cancelled (a missing wg.Done would hang it
+// forever) — this is what lets app.Run safely close the DB right after Wait
+// returns. The loop's first action is a 2-minute wait-or-cancel select, so
+// cancelling well inside that window proves the goroutine is genuinely
+// parked there, not already finished on its own.
+func TestStart_JoinsOnCancel(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "join.db")
+	database, err := db.Open(f)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	Start(ctx, &config.Config{}, database.DB, &wg)
+
+	if waitWithin(&wg, 150*time.Millisecond) {
+		t.Fatal("wg.Wait() returned before ctx was even cancelled — digest goroutine not tracked")
+	}
+	cancel()
+	if !waitWithin(&wg, 2*time.Second) {
+		t.Fatal("Start's digest goroutine did not join wg within 2s of ctx cancel")
+	}
+}
+
+// waitWithin reports whether wg.Wait() returns within d.
+func waitWithin(wg *sync.WaitGroup, d time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(d):
+		return false
 	}
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -86,14 +86,33 @@ func Run(ctx context.Context) error {
 	settingsStore.LoadRuntimeConfig(ctx, cfg)
 	_ = settingsStore.SaveRuntimeConfig(ctx, cfg)
 
-	// wg tracks every background goroutine this boot sequence starts —
-	// directly or via server.Start — so Run can wait for all of them to
-	// actually exit before its deferred database.Close() above runs. Without
-	// this, "Run returned" didn't mean "nothing is still writing to the data
-	// dir" (found 2026-07-30 via a mobile-shutdown CI flake).
+	// wg tracks every background goroutine this boot sequence starts directly
+	// (enroll/updates/alerts) or via server.Start, so Run can wait for all of
+	// them to actually exit before its deferred database.Close() above runs.
+	// Without this, "Run returned" didn't mean "nothing is still writing to
+	// the data dir" (found 2026-07-30 via a mobile-shutdown CI flake). NOT
+	// covered, deliberately: internal/plugins.Supervisor's monitorProcess
+	// goroutines (native plugin processes — separate, larger fix, logged in
+	// ut-docs/QUEUE.md) and the wasm runtime's per-plugin event-channel
+	// drainer (internal/plugins/wasm_runtime.go — its channel is only closed
+	// on the next Sync/reload, never on shutdown, so tracking it here would
+	// make every drain time out; also logged).
+	//
+	// bgCtx is independently cancellable from ctx: an early startup error
+	// below (plugins.Init, marketplace.NewCatalogRepository, server.Start's
+	// own listen failure) returns before the caller ever cancels ctx, and
+	// without this, the background goroutines already started (e.g. enroll's
+	// registration loop) would never be told to stop — drainBackgroundServices
+	// would then always time out waiting on goroutines nothing signalled.
+	// stopBg() is deferred so it (and the drain) run on every return path.
 	var wg sync.WaitGroup
+	bgCtx, stopBg := context.WithCancel(ctx)
+	defer func() {
+		stopBg()
+		drainBackgroundServices(&wg, log, backgroundDrainTimeout)
+	}()
 
-	enroll.Init(ctx, cfg, settingsStore, &wg)
+	enroll.Init(bgCtx, cfg, settingsStore, &wg)
 
 	pluginManager, err := plugins.Init(ctx, cfg, database.DB)
 	if err != nil {
@@ -113,8 +132,8 @@ func Run(ctx context.Context) error {
 		log.Warnf("Marketplace not configured (UT_MARKETPLACE_ENDPOINT_URL not set)")
 	}
 
-	updates.Start(ctx, &wg)
-	alerts.Start(ctx, cfg, database.DB, &wg)
+	updates.Start(bgCtx, &wg)
+	alerts.Start(bgCtx, cfg, database.DB, &wg)
 
 	mux := pages.Init(ctx, cfg, pluginManager, database.DB, catalogRepo)
 
@@ -123,9 +142,7 @@ func Run(ctx context.Context) error {
 		log.Warnf("plugin auto-start failed: %v", err)
 	}
 
-	runErr := server.Start(ctx, cfg, mux, catalogRepo, database.DB, supervisor, &wg)
-	drainBackgroundServices(&wg, log, backgroundDrainTimeout)
-	return runErr
+	return server.Start(bgCtx, cfg, mux, catalogRepo, database.DB, supervisor, &wg)
 }
 
 // backgroundDrainTimeout bounds how long Run waits for background goroutines
@@ -139,7 +156,10 @@ const backgroundDrainTimeout = 10 * time.Second
 // anyway, closing the database regardless (a wedged service is a bug to fix,
 // not a reason to never shut down). timeout is a parameter (rather than using
 // the backgroundDrainTimeout constant directly) so tests can exercise the
-// timeout branch without a real 10-second wait.
+// timeout branch without a real 10-second wait. On timeout the internal
+// wg.Wait() goroutine above is intentionally leaked — harmless (it only
+// blocks on Wait, touching nothing) — and exits whenever the wedged service
+// eventually does.
 func drainBackgroundServices(wg *sync.WaitGroup, log *logging.Logger, timeout time.Duration) {
 	done := make(chan struct{})
 	go func() {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -12,6 +12,8 @@ package app
 import (
 	"context"
 	"os"
+	"sync"
+	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/universaltill/universal-till/internal/alerts"
@@ -84,7 +86,14 @@ func Run(ctx context.Context) error {
 	settingsStore.LoadRuntimeConfig(ctx, cfg)
 	_ = settingsStore.SaveRuntimeConfig(ctx, cfg)
 
-	enroll.Init(ctx, cfg, settingsStore)
+	// wg tracks every background goroutine this boot sequence starts —
+	// directly or via server.Start — so Run can wait for all of them to
+	// actually exit before its deferred database.Close() above runs. Without
+	// this, "Run returned" didn't mean "nothing is still writing to the data
+	// dir" (found 2026-07-30 via a mobile-shutdown CI flake).
+	var wg sync.WaitGroup
+
+	enroll.Init(ctx, cfg, settingsStore, &wg)
 
 	pluginManager, err := plugins.Init(ctx, cfg, database.DB)
 	if err != nil {
@@ -104,8 +113,8 @@ func Run(ctx context.Context) error {
 		log.Warnf("Marketplace not configured (UT_MARKETPLACE_ENDPOINT_URL not set)")
 	}
 
-	updates.Start(ctx)
-	alerts.Start(ctx, cfg, database.DB)
+	updates.Start(ctx, &wg)
+	alerts.Start(ctx, cfg, database.DB, &wg)
 
 	mux := pages.Init(ctx, cfg, pluginManager, database.DB, catalogRepo)
 
@@ -114,7 +123,34 @@ func Run(ctx context.Context) error {
 		log.Warnf("plugin auto-start failed: %v", err)
 	}
 
-	return server.Start(ctx, cfg, mux, catalogRepo, database.DB, supervisor)
+	runErr := server.Start(ctx, cfg, mux, catalogRepo, database.DB, supervisor, &wg)
+	drainBackgroundServices(&wg, log, backgroundDrainTimeout)
+	return runErr
+}
+
+// backgroundDrainTimeout bounds how long Run waits for background goroutines
+// to exit before giving up and closing the database anyway.
+const backgroundDrainTimeout = 10 * time.Second
+
+// drainBackgroundServices blocks until every goroutine registered on wg has
+// exited, so the caller's subsequent database.Close() never races a
+// straggler. Bounded: a service that ignores ctx cancellation must not hang
+// shutdown forever — after timeout elapses this logs loudly and returns
+// anyway, closing the database regardless (a wedged service is a bug to fix,
+// not a reason to never shut down). timeout is a parameter (rather than using
+// the backgroundDrainTimeout constant directly) so tests can exercise the
+// timeout branch without a real 10-second wait.
+func drainBackgroundServices(wg *sync.WaitGroup, log *logging.Logger, timeout time.Duration) {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		wg.Wait()
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		log.Errorf("shutdown: background services still running %s after cancel — closing database anyway", timeout)
+	}
 }
 
 // bootstrapPluginDirectories creates required plugin cache directories

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"context"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -55,5 +57,41 @@ func TestDrainBackgroundServices_TimesOutAndLogsWhenWgNeverCompletes(t *testing.
 	}
 	if !found {
 		t.Fatal("expected an ERROR log noting background services were still running after timeout")
+	}
+}
+
+// Run must join its background goroutines on EVERY return path, not just a
+// caller-driven ctx cancel. This drives a real boot all the way through
+// enroll.Init (config.Init's default marketplace endpoint means a fresh,
+// unenrolled till always starts enroll's background registration/signing-key
+// loop) and then fails at server.Start's listen step on a deliberately
+// unbindable address — an early startup error, with the caller's ctx (never
+// cancelled here) still fully live. Before the fix, nothing told enroll's
+// loop to stop in this case, so Run's drain would always hit its full 10s
+// timeout waiting on a goroutine nothing had cancelled. Asserting Run returns
+// in well under that bound is what proves the internally-derived bgCtx (not
+// the caller's ctx) is what actually stops it.
+func TestRun_JoinsBackgroundGoroutinesOnEarlyServerError(t *testing.T) {
+	t.Setenv("UT_DATA_DIR", t.TempDir())
+	t.Setenv("UT_ENV_FILE", filepath.Join(t.TempDir(), "does-not-exist.env"))
+	t.Setenv("UT_AUTH", "off")
+	t.Setenv("UT_OPEN_BROWSER", "false")
+	t.Setenv("UT_LISTEN_ADDR", "not-a-valid-listen-address") // server.Start fails fast at bind
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() { done <- Run(context.Background()) }() // ctx never cancelled by this test
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Run succeeded despite an unbindable UT_LISTEN_ADDR")
+		}
+		if elapsed := time.Since(start); elapsed > 3*time.Second {
+			t.Fatalf("Run took %s to return a startup error — background goroutines were "+
+				"apparently only stopped by the 10s drain timeout, not a real cancel", elapsed)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("Run did not return within 15s of an unbindable listen address")
 	}
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/universaltill/universal-till/internal/logging"
+)
+
+// drainBackgroundServices must not block past wg reaching zero: a fast
+// goroutine finishing well inside the timeout must let Run proceed promptly,
+// not wait out the whole bound every time.
+func TestDrainBackgroundServices_ReturnsAsSoonAsWgIsDone(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		wg.Done()
+	}()
+
+	start := time.Now()
+	drainBackgroundServices(&wg, logging.L(), 5*time.Second)
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("drainBackgroundServices took %s, want well under the 5s timeout", elapsed)
+	}
+}
+
+// A service that never joins (ignores ctx cancellation, or a real bug in a
+// Start function) must not hang shutdown forever: drainBackgroundServices
+// must return once its bound elapses, and log loudly that it gave up rather
+// than closing the database silently as if nothing were still running.
+func TestDrainBackgroundServices_TimesOutAndLogsWhenWgNeverCompletes(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)          // deliberately never Done() — simulates a wedged background service
+	t.Cleanup(wg.Done) // let the real goroutine this spawns eventually finish after the test
+
+	start := time.Now()
+	drainBackgroundServices(&wg, logging.L(), 100*time.Millisecond)
+	elapsed := time.Since(start)
+	if elapsed < 100*time.Millisecond {
+		t.Fatalf("drainBackgroundServices returned after %s, before its own 100ms timeout elapsed", elapsed)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("drainBackgroundServices took %s, want close to its 100ms timeout", elapsed)
+	}
+
+	found := false
+	for _, p := range logging.Recent() {
+		if p.Level == "ERROR" && strings.Contains(p.Msg, "background services still running") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected an ERROR log noting background services were still running after timeout")
+	}
+}

--- a/internal/enroll/enroll.go
+++ b/internal/enroll/enroll.go
@@ -143,8 +143,10 @@ func RegisterNow(ctx context.Context, cfg *config.Config, kv Settings) (Status, 
 // Init loads (or creates) this till's marketplace identity, fills the empty
 // cfg.Marketplace fields from it, and — when the till is not yet enrolled and
 // not explicitly configured — starts a background registration loop. Call once
-// at startup, after LoadRuntimeConfig and before the server starts.
-func Init(ctx context.Context, cfg *config.Config, kv Settings) {
+// at startup, after LoadRuntimeConfig and before the server starts. wg is
+// marked Done once that background loop (if started) has fully exited, so
+// callers can wait out shutdown instead of returning while it still runs.
+func Init(ctx context.Context, cfg *config.Config, kv Settings, wg *sync.WaitGroup) {
 	log := logging.L()
 	storeIDExplicit = os.Getenv("UT_MARKETPLACE_STORE_ID") != ""
 	// At this point cfg.Marketplace.ClientID can only have come from the
@@ -220,7 +222,11 @@ func Init(ctx context.Context, cfg *config.Config, kv Settings) {
 	if !needKey && !needDevice {
 		return
 	}
-	go run(ctx, *m, deviceName, kv, needKey, needDevice)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		run(ctx, *m, deviceName, kv, needKey, needDevice)
+	}()
 }
 
 // EnsureRegistered returns the effective config, first enrolling the till

--- a/internal/enroll/enroll_test.go
+++ b/internal/enroll/enroll_test.go
@@ -120,7 +120,7 @@ func TestInitFreshTillDoesNotRegisterStore(t *testing.T) {
 	kv := newFakeKV()
 	cfg := freshConfig(srv.URL)
 
-	Init(context.Background(), cfg, kv)
+	Init(context.Background(), cfg, kv, &sync.WaitGroup{})
 
 	deviceID := kv.get(keyDeviceID)
 	if !strings.HasPrefix(deviceID, "till-") {
@@ -243,7 +243,7 @@ func TestInitAlreadyEnrolledSkipsRegistration(t *testing.T) {
 	}
 	cfg := freshConfig(srv.URL)
 
-	Init(context.Background(), cfg, kv)
+	Init(context.Background(), cfg, kv, &sync.WaitGroup{})
 
 	if cfg.Marketplace.ClientID != "store-old" || cfg.Marketplace.StoreID != "store-old" {
 		t.Fatalf("cfg not filled from persisted enrolment: %q/%q", cfg.Marketplace.ClientID, cfg.Marketplace.StoreID)
@@ -268,7 +268,7 @@ func TestInitExplicitConfigWinsAndSkipsEnrolment(t *testing.T) {
 	cfg.Marketplace.PublicKey = strings.Repeat("ef", 32)
 	t.Setenv("UT_MARKETPLACE_STORE_ID", "store-1")
 
-	Init(context.Background(), cfg, kv)
+	Init(context.Background(), cfg, kv, &sync.WaitGroup{})
 
 	time.Sleep(50 * time.Millisecond)
 	if *calls != 0 {
@@ -291,7 +291,7 @@ func TestEnsureRegisteredRetriesAcrossAttempts(t *testing.T) {
 	srv, calls := testMarketplace(t, 2) // first two register calls fail
 	kv := newFakeKV()
 	cfg := freshConfig(srv.URL)
-	Init(context.Background(), cfg, kv)
+	Init(context.Background(), cfg, kv, &sync.WaitGroup{})
 
 	for i := 1; i <= 3; i++ {
 		eff := EnsureRegistered(context.Background(), cfg, kv)
@@ -314,7 +314,7 @@ func TestInitKeylessExplicitTillStillFetchesSigningKey(t *testing.T) {
 	cfg := freshConfig(srv.URL)
 	cfg.Marketplace.ClientID = "merchant-1" // explicit merchant, but no public key
 
-	Init(context.Background(), cfg, kv)
+	Init(context.Background(), cfg, kv, &sync.WaitGroup{})
 
 	waitFor(t, "signing key", func() bool { return kv.get(keyPublicKey) != "" })
 	time.Sleep(50 * time.Millisecond)
@@ -323,6 +323,62 @@ func TestInitKeylessExplicitTillStillFetchesSigningKey(t *testing.T) {
 	}
 	if eff := Effective(cfg); eff.Marketplace.PublicKey != strings.Repeat("ab", 32) {
 		t.Fatalf("effective public key = %q", eff.Marketplace.PublicKey)
+	}
+}
+
+// Init's background registration loop must be genuinely joinable: wg.Wait()
+// must NOT return while the loop is still in flight (a missing wg.Add would
+// let Wait return immediately, vacuously "passing" without ever tracking the
+// goroutine), and MUST return promptly once ctx is cancelled (a missing
+// wg.Done, or a goroutine that ignores cancellation, would hang it forever).
+// Both directions matter: this is what lets a caller (app.Run, at shutdown)
+// safely assume nothing this goroutine touches is still live once Wait
+// returns. Uses a handler that blocks until the request's own context is
+// cancelled, so the fetch is provably still in flight until then, and a
+// channel the handler closes on entry so the test knows the goroutine has
+// genuinely reached the blocked call before asserting anything.
+func TestInit_BackgroundLoopJoinsOnCancel(t *testing.T) {
+	resetState()
+	reqReceived := make(chan struct{})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ui/api/signing-key", func(w http.ResponseWriter, r *http.Request) {
+		close(reqReceived)
+		<-r.Context().Done() // never respond on its own — only ctx cancel ends this
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	kv := newFakeKV()
+	cfg := freshConfig(srv.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+
+	Init(ctx, cfg, kv, &wg)
+
+	select {
+	case <-reqReceived:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background loop never reached the signing-key request")
+	}
+
+	waitDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(waitDone)
+	}()
+
+	// The request is still blocked server-side — wg.Wait() must NOT be done yet.
+	select {
+	case <-waitDone:
+		t.Fatal("wg.Wait() returned while the background loop was still in flight — goroutine not tracked")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case <-waitDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Init's background loop did not exit within 2s of ctx cancel")
 	}
 }
 

--- a/internal/enroll/enroll_test.go
+++ b/internal/enroll/enroll_test.go
@@ -346,7 +346,14 @@ func TestInit_BackgroundLoopJoinsOnCancel(t *testing.T) {
 		<-r.Context().Done() // never respond on its own — only ctx cancel ends this
 	})
 	srv := httptest.NewServer(mux)
+	// CloseClientConnections before Close: the handler goroutine above is
+	// parked on <-r.Context().Done(), which only fires once the underlying
+	// connection is force-closed — without this, a FAILING run of this test
+	// (e.g. the join regressing) leaves that handler blocked until the
+	// client's own timeout, and srv.Close alone waits it out (~15s stall
+	// before reporting the actual failure).
 	t.Cleanup(srv.Close)
+	t.Cleanup(srv.CloseClientConnections)
 
 	kv := newFakeKV()
 	cfg := freshConfig(srv.URL)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/universaltill/universal-till/internal/config"
@@ -56,11 +57,15 @@ func NewBackgroundJobs(catalogRepo *marketplace.CatalogRepository, db *sql.DB, s
 	}
 }
 
-// Start begins all background jobs
-func (bj *BackgroundJobs) Start(ctx context.Context) {
+// Start begins all background jobs. wg is marked Done once every job's
+// goroutine has fully exited (ctx cancelled), so a caller waiting on wg
+// never returns while one of these could still be mid-sync/mid-write.
+func (bj *BackgroundJobs) Start(ctx context.Context, wg *sync.WaitGroup) {
 	// Catalog sync job (T011) - LOCAL-FIRST: Only sync when cache is stale
 	// User must explicitly refresh via UI to fetch from marketplace
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		ticker := time.NewTicker(bj.catalogSyncInterval)
 		defer ticker.Stop()
 		for {
@@ -81,7 +86,9 @@ func (bj *BackgroundJobs) Start(ctx context.Context) {
 	}()
 
 	// Telemetry reporting job (stub for T024)
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		ticker := time.NewTicker(bj.telemetryInterval)
 		defer ticker.Stop()
 		for {
@@ -97,7 +104,9 @@ func (bj *BackgroundJobs) Start(ctx context.Context) {
 	}()
 
 	// Revocation check job (T030)
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		ticker := time.NewTicker(bj.revocationInterval)
 		defer ticker.Stop()
 		for {
@@ -166,12 +175,21 @@ func (bj *BackgroundJobs) syncCatalog(ctx context.Context) {
 	}
 }
 
-func Start(ctx context.Context, cfg *config.Config, handler http.Handler, catalogRepo *marketplace.CatalogRepository, db *sql.DB, supervisor *plugins.Supervisor) error {
-	// Start background jobs if catalog repository is configured
+// Start boots the HTTP server and every background job it owns. wg is marked
+// Done, per job/goroutine, once each has fully exited (ctx cancelled) —
+// including this function's own graceful-shutdown goroutine — so a caller
+// that both waits on wg AND waits for Start to return (as app.Run does) can
+// safely assume nothing Start ever spawned is still touching db/supervisor
+// once both have happened. wg must not be nil.
+func Start(ctx context.Context, cfg *config.Config, handler http.Handler, catalogRepo *marketplace.CatalogRepository, db *sql.DB, supervisor *plugins.Supervisor, wg *sync.WaitGroup) error {
+	// Start background jobs if catalog repository is configured. Start()
+	// itself only launches goroutines and returns immediately, so it doesn't
+	// need its own wrapping goroutine — jobs' own 3 goroutines register with
+	// wg directly.
 	if catalogRepo != nil {
 		logger := log.New(log.Writer(), "[BackgroundJobs] ", log.LstdFlags)
 		jobs := NewBackgroundJobs(catalogRepo, db, supervisor, cfg, logger)
-		go jobs.Start(ctx)
+		jobs.Start(ctx, wg)
 	}
 
 	// Daily local DB backup (docs: architecture/local-backup.md) — runs
@@ -179,7 +197,9 @@ func Start(ctx context.Context, cfg *config.Config, handler http.Handler, catalo
 	// newest backup is older than 24h; first check shortly after boot so a
 	// till powered off nightly still gets one.
 	if db != nil {
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			run := func() { runDailyBackup(db, cfg.DBPath) }
 			ticker := time.NewTicker(time.Hour)
 			defer ticker.Stop()
@@ -205,7 +225,9 @@ func Start(ctx context.Context, cfg *config.Config, handler http.Handler, catalo
 	// "customers also buy" strip. Runs at startup (tills reboot daily) and
 	// every 24h for always-on installs. Local SQL only — no network.
 	if db != nil {
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			repo := data.NewRelatedItemsRepo(db)
 			rebuild := func() {
 				jobCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
@@ -247,8 +269,15 @@ func Start(ctx context.Context, cfg *config.Config, handler http.Handler, catalo
 	}
 	cfg.ListenAddr = actualAddr
 
-	// Graceful shutdown when context is cancelled
+	// Graceful shutdown when context is cancelled. Registered with wg because
+	// net/http's Shutdown contract only guarantees Serve returns once
+	// listeners are closed — supervisor.Shutdown below can still be running
+	// after Serve (and so this function) has already returned; without this,
+	// a caller waiting on wg alone could race supervisor.Shutdown's own DB
+	// writes (audit_events) against database.Close().
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		<-ctx.Done()
 		log.Printf("shutting down HTTP server...")
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -308,7 +308,7 @@ func TestBackgroundJobsStart_SyncsWhenStaleThenStops(t *testing.T) {
 		revocationInterval:  time.Hour,
 		retryBaseDelay:      time.Millisecond,
 	}
-	bj.Start(ctx)
+	bj.Start(ctx, &sync.WaitGroup{})
 
 	select {
 	case <-archSeen:
@@ -341,7 +341,7 @@ func TestBackgroundJobsStart_SkipsWhenFresh(t *testing.T) {
 		revocationInterval:  time.Hour,
 		retryBaseDelay:      time.Millisecond,
 	}
-	bj.Start(ctx)
+	bj.Start(ctx, &sync.WaitGroup{})
 
 	time.Sleep(200 * time.Millisecond)
 	select {
@@ -367,6 +367,7 @@ func TestBackgroundJobsStart_CancelStopsLoops(t *testing.T) {
 	plantSnapshot(t, cacheDir, time.Now().Add(-time.Hour))
 
 	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
 	bj := &BackgroundJobs{
 		catalogRepo:         newTestCatalogRepoAt(t, srv.URL, cacheDir),
 		cfg:                 &config.Config{DefaultLocale: "en-US"},
@@ -376,7 +377,7 @@ func TestBackgroundJobsStart_CancelStopsLoops(t *testing.T) {
 		revocationInterval:  time.Hour,
 		retryBaseDelay:      time.Millisecond,
 	}
-	bj.Start(ctx)
+	bj.Start(ctx, &wg)
 
 	select {
 	case <-requests:
@@ -384,6 +385,20 @@ func TestBackgroundJobsStart_CancelStopsLoops(t *testing.T) {
 		t.Fatal("scheduler never reached the marketplace")
 	}
 	cancel()
+
+	// Deterministic proof the 3 job goroutines actually exited (not just a
+	// timing-based inference from silence on the requests channel below).
+	waitDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(waitDone)
+	}()
+	select {
+	case <-waitDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("BackgroundJobs goroutines did not join wg within 5s of context cancel")
+	}
+
 	time.Sleep(100 * time.Millisecond) // let in-flight attempts finish
 	for {                              // drain everything that raced the cancel
 		select {
@@ -422,7 +437,7 @@ func TestBackgroundJobsStart_TelemetryFailureIsLoggedNotFatal(t *testing.T) {
 		telemetryInterval:   20 * time.Millisecond,
 		revocationInterval:  time.Hour,
 	}
-	bj.Start(ctx)
+	bj.Start(ctx, &sync.WaitGroup{})
 
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
@@ -458,7 +473,7 @@ func TestBackgroundJobsStart_RevocationTickPollsFeed(t *testing.T) {
 		telemetryInterval:   time.Hour,
 		revocationInterval:  20 * time.Millisecond,
 	}
-	bj.Start(ctx)
+	bj.Start(ctx, &sync.WaitGroup{})
 
 	select {
 	case path := <-requests:
@@ -503,7 +518,8 @@ func TestStart_ServesOpensBrowserAndShutsDown(t *testing.T) {
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
-	go func() { errCh <- Start(ctx, cfg, handler, nil, nil, nil) }()
+	var wg sync.WaitGroup
+	go func() { errCh <- Start(ctx, cfg, handler, nil, nil, nil, &wg) }()
 
 	var url string
 	select {
@@ -531,6 +547,13 @@ func TestStart_ServesOpensBrowserAndShutsDown(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("Start did not return after context cancel")
 	}
+	// Start's own graceful-shutdown goroutine (srv.Shutdown + supervisor.Shutdown)
+	// must have fully finished by now too, not just be "probably done" —
+	// net/http's Shutdown contract only guarantees Serve returns once listeners
+	// close, so without wg tracking that goroutine, this could otherwise race.
+	if !waitWithin(&wg, 2*time.Second) {
+		t.Fatal("wg did not reach zero within 2s of Start returning — shutdown goroutine not joined")
+	}
 	// Safe to read cfg now that Start has returned: it must hold the address
 	// actually bound (an ephemeral port, not the :0 we asked for).
 	if cfg.ListenAddr == "127.0.0.1:0" {
@@ -545,9 +568,24 @@ func TestStart_ServesOpensBrowserAndShutsDown(t *testing.T) {
 func TestStart_ReturnsErrorOnBadAddr(t *testing.T) {
 	t.Setenv("UT_OPEN_BROWSER", "false")
 	cfg := &config.Config{ListenAddr: "not-a-listen-addr"}
-	err := Start(context.Background(), cfg, http.NewServeMux(), nil, nil, nil)
+	err := Start(context.Background(), cfg, http.NewServeMux(), nil, nil, nil, &sync.WaitGroup{})
 	if err == nil {
 		t.Fatal("Start succeeded on an unbindable address")
+	}
+}
+
+// waitWithin reports whether wg.Wait() returns within d.
+func waitWithin(wg *sync.WaitGroup, d time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(d):
+		return false
 	}
 }
 
@@ -570,7 +608,8 @@ func TestStart_WithDBRunsRelatedItemsRebuild(t *testing.T) {
 	cfg := &config.Config{ListenAddr: "127.0.0.1:0", DBPath: dbPath}
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
-	go func() { errCh <- Start(ctx, cfg, http.NewServeMux(), nil, d.DB, nil) }()
+	var wg sync.WaitGroup
+	go func() { errCh <- Start(ctx, cfg, http.NewServeMux(), nil, d.DB, nil, &wg) }()
 
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
@@ -591,6 +630,13 @@ func TestStart_WithDBRunsRelatedItemsRebuild(t *testing.T) {
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("Start did not return after cancel")
+	}
+	// The related-items ticker goroutine (which reads db) must have actually
+	// exited by now — this test's own t.Cleanup closes d right after, and a
+	// straggler reading a closed *sql.DB is exactly the bug class this
+	// wg-joining fix exists to prevent.
+	if !waitWithin(&wg, 2*time.Second) {
+		t.Fatal("wg did not reach zero within 2s of Start returning — a background goroutine was left unjoined")
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -384,18 +384,19 @@ func TestBackgroundJobsStart_CancelStopsLoops(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("scheduler never reached the marketplace")
 	}
+
+	// Before cancel: wg must NOT already be at zero (a missing wg.Add on any
+	// of the 3 job goroutines would let Wait return instantly, vacuously
+	// "passing" the check below without ever tracking them).
+	if waitWithin(&wg, 150*time.Millisecond) {
+		t.Fatal("wg.Wait() returned before ctx was even cancelled — job goroutines not tracked")
+	}
+
 	cancel()
 
 	// Deterministic proof the 3 job goroutines actually exited (not just a
 	// timing-based inference from silence on the requests channel below).
-	waitDone := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(waitDone)
-	}()
-	select {
-	case <-waitDone:
-	case <-time.After(5 * time.Second):
+	if !waitWithin(&wg, 5*time.Second) {
 		t.Fatal("BackgroundJobs goroutines did not join wg within 5s of context cancel")
 	}
 
@@ -538,6 +539,13 @@ func TestStart_ServesOpensBrowserAndShutsDown(t *testing.T) {
 		t.Fatalf("GET %s -> %d %q, want 200 till-ok", url, resp.StatusCode, body)
 	}
 
+	// Before cancel: wg must NOT already be at zero — the shutdown goroutine
+	// is alive but parked on <-ctx.Done(), so a missing wg.Add there would
+	// let this vacuously "pass" without ever tracking it.
+	if waitWithin(&wg, 150*time.Millisecond) {
+		t.Fatal("wg.Wait() returned before ctx was even cancelled — shutdown goroutine not tracked")
+	}
+
 	cancel()
 	select {
 	case err := <-errCh:
@@ -620,6 +628,13 @@ func TestStart_WithDBRunsRelatedItemsRebuild(t *testing.T) {
 	}
 	if !strings.Contains(logBuf.String(), "[RelatedItems] rebuilt") {
 		t.Fatalf("related-items rebuild never ran at startup; log:\n%s", logBuf.String())
+	}
+
+	// Before cancel: wg must NOT already be at zero — the daily-backup and
+	// related-items goroutines are alive, parked on their own tickers, so a
+	// missing wg.Add on either would let this vacuously "pass" below.
+	if waitWithin(&wg, 150*time.Millisecond) {
+		t.Fatal("wg.Wait() returned before ctx was even cancelled — a background goroutine was not tracked")
 	}
 
 	cancel()

--- a/internal/updates/updates.go
+++ b/internal/updates/updates.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -48,12 +49,16 @@ func CheckNow(ctx context.Context) Status {
 }
 
 // Start launches the background checker: once ~30s after boot, then daily.
-// Set UT_UPDATE_CHECK=0 to disable (e.g. air-gapped tills).
-func Start(ctx context.Context) {
+// Set UT_UPDATE_CHECK=0 to disable (e.g. air-gapped tills). wg is marked Done
+// once the checker goroutine has fully exited (ctx cancelled) — callers use
+// it to wait out shutdown instead of returning while the goroutine still runs.
+func Start(ctx context.Context, wg *sync.WaitGroup) {
 	if !enabledFromEnv() {
 		return
 	}
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		select {
 		case <-time.After(30 * time.Second):
 		case <-ctx.Done():

--- a/internal/updates/updates_test.go
+++ b/internal/updates/updates_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/universaltill/universal-till/internal/buildinfo"
 )
@@ -132,18 +134,55 @@ func TestEnabledFromEnv(t *testing.T) {
 	}
 }
 
-// Start with checks disabled must return without spawning the checker; with an
-// already-cancelled context the boot-wait goroutine exits on ctx.Done. Neither
-// timer branch (30s boot wait elapsing, 24h ticker) is exercisable in a unit
-// test without a fake clock — deliberately left uncovered rather than faked.
+// Start with checks disabled must return without spawning the checker (so wg
+// must stay at zero — Wait returns instantly, and that's correct here since
+// no goroutine was ever started). With an already-cancelled context the
+// boot-wait goroutine exits on ctx.Done — and must actually register with wg
+// first, or a caller waiting on wg would never notice it was ever running.
+// Neither timer branch (30s boot wait elapsing, 24h ticker) is exercisable in
+// a unit test without a fake clock — deliberately left uncovered rather than
+// faked.
 func TestStartDisabledAndCancelled(t *testing.T) {
 	t.Setenv("UT_UPDATE_CHECK", "0")
-	Start(context.Background()) // must be a no-op
+	var disabledWG sync.WaitGroup
+	Start(context.Background(), &disabledWG) // must be a no-op
+	if !waitImmediately(&disabledWG) {
+		t.Fatal("disabled Start registered a goroutine it never started")
+	}
 
+	// Not pre-cancelled this time: the goroutine must actually be running
+	// (blocked in its own select) when we check, so a missing wg.Add can't
+	// vacuously pass by racing an already-done ctx.
 	t.Setenv("UT_UPDATE_CHECK", "1")
 	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	Start(ctx, &wg)
+	if waitWithin(&wg, 150*time.Millisecond) {
+		t.Fatal("wg.Wait() returned before ctx was even cancelled — checker goroutine not tracked")
+	}
 	cancel()
-	Start(ctx) // goroutine sees ctx.Done and returns
+	if !waitWithin(&wg, 2*time.Second) {
+		t.Fatal("Start's checker goroutine did not join wg within 2s of ctx cancel")
+	}
+}
+
+// waitImmediately reports whether wg.Wait() returns without blocking at all.
+func waitImmediately(wg *sync.WaitGroup) bool {
+	return waitWithin(wg, 20*time.Millisecond)
+}
+
+func waitWithin(wg *sync.WaitGroup, d time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(d):
+		return false
+	}
 }
 
 func TestNewer(t *testing.T) {

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -5,45 +5,28 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 )
 
 // mobileTestEnv points the till at an isolated temp data dir and disables
 // auth (no PIN session needed to hit /healthz) for every test in this file —
 // mirrors how other live-verification runs in this repo set up a throwaway
 // till instance.
-// It also OWNS the data dir, deliberately NOT via t.TempDir(): app.Run's
-// background services (updates/alerts/enroll, the plugin supervisor) are
-// started as detached goroutines that app.Run does not join on shutdown, so
-// for a moment after Stop() returns a straggler can still write into the
-// data dir (sqlite -wal/-shm and friends). t.TempDir's own RemoveAll cleanup
-// races that and flakes with "TempDir RemoveAll cleanup: directory not
-// empty" (main CI 2026-07-30, run 30531313594). Until app.Run drains its
-// services before returning (queued in ut-docs/QUEUE.md), remove the dir
-// ourselves with a short retry window. Cleanup order (LIFO): Stop runs
-// first, then this retrying removal.
+// Plain t.TempDir() is safe here: app.Run now joins every background
+// goroutine it starts (directly or via server.Start) before returning, so by
+// the time Stop() returns (it blocks on app.Run's return), nothing is still
+// writing into the data dir. Before that fix, a straggler could still be
+// mid-write for a moment after Stop() returned, and t.TempDir()'s own
+// RemoveAll cleanup raced it, flaking with "TempDir RemoveAll cleanup:
+// directory not empty" (main CI 2026-07-30, run 30531313594) — worked around
+// there with a manual dir + retrying removal. That workaround is gone: a
+// single, un-retried RemoveAll succeeding right after Stop() is now the
+// actual proof the join works, not a tolerated flake. Cleanup order (LIFO):
+// Stop runs first, then t.TempDir()'s own (single-attempt) removal.
 func mobileTestEnv(t *testing.T) string {
 	t.Helper()
 	t.Setenv("UT_AUTH", "off")
 	t.Setenv("UT_ENV_FILE", t.TempDir()+"/does-not-exist.env") // don't pick up a stray local pos.env
-	dataDir, err := os.MkdirTemp("", "ut-mobile-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		deadline := time.Now().Add(5 * time.Second)
-		for {
-			err := os.RemoveAll(dataDir)
-			if err == nil {
-				return
-			}
-			if time.Now().After(deadline) {
-				t.Errorf("cleanup data dir: %v", err)
-				return
-			}
-			time.Sleep(100 * time.Millisecond)
-		}
-	})
+	dataDir := t.TempDir()
 	t.Cleanup(Stop)
 	return dataDir
 }

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -18,10 +18,12 @@ import (
 // mid-write for a moment after Stop() returned, and t.TempDir()'s own
 // RemoveAll cleanup raced it, flaking with "TempDir RemoveAll cleanup:
 // directory not empty" (main CI 2026-07-30, run 30531313594) — worked around
-// there with a manual dir + retrying removal. That workaround is gone: a
-// single, un-retried RemoveAll succeeding right after Stop() is now the
-// actual proof the join works, not a tolerated flake. Cleanup order (LIFO):
-// Stop runs first, then t.TempDir()'s own (single-attempt) removal.
+// there with a manual dir + retrying removal. That workaround is gone. NOTE:
+// this is a regression canary, not a proof by itself — it only ever caught
+// the bug as a rare, timing-dependent CI flake (a clean local run here proves
+// nothing on its own; internal/app and internal/server carry the actual
+// deterministic join tests). Cleanup order (LIFO): Stop runs first, then
+// t.TempDir()'s own (single-attempt) removal.
 func mobileTestEnv(t *testing.T) string {
 	t.Helper()
 	t.Setenv("UT_AUTH", "off")


### PR DESCRIPTION
## Summary
- `app.Run` started `updates.Start`/`alerts.Start`/`enroll.Init`'s registration loop and `server.Start`'s internal goroutines (a job scheduler, a daily DB backup ticker, a related-items rebuild ticker, and its own graceful-shutdown goroutine) as fire-and-forget, then ran its deferred `database.Close()` without ever waiting for them to exit — a straggler could still be writing into the data dir for a moment after `Run` returned. Found via a `mobile` CI flake (main run 30531313594); PR #97 mitigated the test symptom only, this is the real fix.
- A `*sync.WaitGroup` now threads through every `Start`/`Init` call (including `server.Start`'s internal goroutines), each registering before spawn and joining on exit. `Run` derives an independently-cancellable `bgCtx` and drains the group with a bounded, loudly-logged timeout on **every** return path — not just the normal caller-driven shutdown.
- Independent review (opus, different model) found two real gaps in round 1 — `Run`'s early error returns bypassed the drain entirely, and `internal/server`'s join tests were vacuous (one-directional, so an empty WaitGroup passed them). Both fixed and reverified via mutation (break it, confirm the exact predicted failure, restore, confirm green) — see the review record.
- `mobile/mobile_test.go`'s 5s-retry `RemoveAll` workaround (PR #97) is gone; plain `t.TempDir()` is safe again.

## Test plan
- [x] `go build ./... && go vet ./...`
- [x] `go test -race ./internal/app/... ./internal/server/... ./internal/updates/... ./internal/alerts/... ./internal/enroll/... ./mobile/...`
- [x] `go test ./mobile/... -race -count=15` (reviewer independently ran `-count=10` and `-count=40`)
- [x] Full `go test ./...` — one pre-existing, unrelated failure (`internal/issuereport`, confirmed reproducing on unmodified `main` too, root-in-container permission bypass)
- [x] `guard-data-access.sh`, `guard-i18n.sh`, `guard-emoji-font.sh`, `guard-kiosk-launch-flags.sh`, `guard-webkit-version.sh` all green
- [x] Full Playwright e2e suite: 19/20 green, the one failure confirmed pre-existing/unrelated on `main`
- [x] Independent review: `docs/code-reviews/2026-07-30-app-run-shutdown-join.md` — SAFE TO MERGE after fixes, both rounds of mutation-probe re-verification done personally, not taken on either party's word

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ld44CLzCveBgbcHtteKvBn)_