### PR TITLE
fix: plugins can no longer hijack built-in tenders via payment-entry keys (ADR-0031)

### DIFF
--- a/docs/code-reviews/2026-07-30-plugin-payment-key-hijack.md
+++ b/docs/code-reviews/2026-07-30-plugin-payment-key-hijack.md
@@ -1,0 +1,123 @@
+# Code review — plugin payment-key hijack: ownership-guarded sync + install validation + repair
+
+- **Date**: 2026-07-30
+- **Branch**: `fix/plugin-payment-key-hijack`
+- **Scope**: the batch-9-review finding that a plugin declaring
+  `{type:"payment", key:"cash"}` captured the built-in cash tender and —
+  once the plugin was disabled — the sync's deactivate step removed cash
+  from checkout entirely. Brushes the offline-first non-negotiable
+  ("checkout must never be blocked").
+- **Decision record**: `ut-docs/adr/0031-plugin-payment-method-identity.md`
+  — bare keys + ownership guard + install-time validation; namespacing
+  (`<plugin_id>:<key>`) was rejected because `payments.method_id` prints
+  verbatim on customer receipts and the reports payment breakdown, and a
+  history remap of `payments.method_id` would ride along — traced in
+  code before deciding, not assumed.
+- **Independent review**: different-model (opus) subagent, findings below.
+
+## What changed
+
+1. **`SyncPluginPaymentMethods` ownership guard**: the upsert's
+   `ON CONFLICT(id) DO UPDATE` now carries
+   `WHERE payment_methods.plugin_id = excluded.plugin_id` and no longer
+   reassigns `plugin_id`. A key colliding with a built-in
+   (`plugin_id IS NULL` — the WHERE is NULL-safe by construction: `NULL =
+   'x'` is never true), a shop-created tender, or another plugin's method
+   leaves the existing row untouched. First owner wins.
+2. **Install-time validation** (`plugins.PersistManifest`, step 0, inside
+   the install transaction): payment entry keys must be non-empty,
+   contain no `:` (reserved), not equal any non-plugin
+   `payment_methods.id`, and not be owned by another plugin
+   (`PluginRepo.FindPaymentKeyConflicts` checks both `payment_methods`
+   and `plugin_entries`). The plugin's own keys never self-conflict —
+   reinstall/upgrade pass. A rejected install rolls back whole.
+3. **Migration `021_payment_method_hijack_repair.sql`**: any
+   already-captured built-in (`cash`/`card`/`gift`) gets `plugin_id`
+   cleared and `is_active = 1` restored. Names deliberately not reset
+   (operators may rename tenders legitimately). Idempotent; only the
+   three seeded ids are touched, so genuine plugin methods are never
+   affected.
+
+## Verification (pipeline side)
+
+Seven tests written failing-first, each seen failing with the exact
+capture it guards against:
+
+- `plugin_repo_payment_guard_test.go` (real migrated DB, real seeds):
+  hijack blocked both halves (capture AND the deactivate-after-disable
+  that actually kills checkout); plugin's own lifecycle still works
+  (materialize → deactivate on disable → reactivate on re-enable);
+  cross-plugin collision leaves the first owner's row untouched;
+  migration 021 re-executed against a hand-hijacked real DB repairs the
+  built-in, is idempotent, and leaves genuine plugin methods alone.
+- `payment_key_validation_test.go`: built-in collision rejected with the
+  key named and no half-installed plugin left behind (tx rollback
+  asserted); cross-plugin collision names the owning plugin; empty and
+  `:` keys rejected; same-plugin upgrade with unchanged key passes.
+
+`go build ./...`, `go vet ./...`, full `go test ./...`, both CI guards —
+green.
+
+## Independent (opus) review findings
+
+The reviewer revert-probed all three original production pieces (each
+revert failed exactly its matching tests), verified the SQL NULL
+semantics (a false `DO UPDATE ... WHERE` is a skip, not an error),
+confirmed no other `Sync*` function materializes `plugin_entries` into
+another table, confirmed no ecosystem plugin declares `cash`/`card`/
+`gift` (demo/qrpay/stripe/sumup all use unique keys), and confirmed
+migration 021 composes with the tx-wrapped migration runner.
+
+**BLOCKER it found — fixed (failing-first, then green):** LAN admin sync
+re-hijacks a repaired replica. `payment_methods` is an admin-synced
+table and `upsertRow` copied every column — including `plugin_id` and
+`is_active` — so a not-yet-upgraded primary re-imported the captured
+state onto a replica that had already run migration 021, and with no
+hijacking plugin installed locally the deactivate step pinned cash
+inactive on every sync. Two-part fix: `plugin_id` is now a `skipCols`
+column for `payment_methods` (dropped from the dump AND ignored on
+apply), and `SyncPluginPaymentMethods` re-asserts the built-in invariant
+(never plugin-owned, always active) on every run. `is_active` still
+syncs — a shop deliberately disabling a tender on the primary must
+propagate; the transient damaged-primary window heals when the primary
+upgrades and its own repaired state propagates.
+
+**Should-fixes, all fixed (each failing-first):**
+- Migration 021 left the hijacker's ENTRY live, and both payment
+  dispatch gates match on entry key alone — a legacy squatter still
+  received `payment.cash.requested` and could decline the authorize leg.
+  021 now deactivates payment entries squatting on built-in keys.
+- The deactivate step was ownership-blind (`id NOT IN (keys)`) — an
+  unrelated plugin's same-key entry kept another plugin's tender alive
+  after its owner was disabled. Now `NOT EXISTS` matching key AND owner.
+- `Rollback` wrote payment entries with no validation (the one writer
+  besides `PersistManifest`) — a legacy on-disk manifest could restore a
+  colliding key. Validation hoisted into a shared
+  `validatePaymentEntryKeys`, called by both; a failed rollback leaves
+  current entries intact.
+- A key reserved by an uninstalled plugin produced an error naming a
+  plugin that isn't there. The reservation deliberately stands (the
+  tender row anchors sales history; adopting it would re-attribute that
+  history) but the error now says the owner is no longer installed.
+- Keys with surrounding whitespace were accepted (`" cash"` would mint a
+  padded id); now rejected.
+- Test hardening from its false-pass hunt: name-survives-repair asserted
+  (the ADR's explicit promise was untested), row-never-deleted asserted
+  in the lifecycle test, the `payment_methods`-owner branch of
+  `FindPaymentKeyConflicts` now exercised, message-content asserts on
+  the format rejections.
+
+**Accepted as-is / queued:**
+- Shop-created tenders captured pre-fix aren't auto-repaired (can't be
+  distinguished from genuine plugin methods) — queued: startup warning
+  for plugin-owned methods whose plugin is absent.
+- Orphan `plugin_catalog` row on a rejected marketplace install
+  (pre-existing upsert-before-validate ordering) — queued as a nit.
+- `payment_methods.name` UNIQUE can still hard-fail sync on a label
+  collision — pre-existing, noted in the ADR.
+
+## Final gate (after review fixes)
+
+13 tests across `internal/data` + `internal/plugins` (7 original + 6
+finding-regressions), every one seen failing first. `go build`,
+`go vet`, full `go test ./...`, both CI guards — green.

--- a/internal/data/plugin_repo.go
+++ b/internal/data/plugin_repo.go
@@ -1053,11 +1053,83 @@ ORDER BY pe.sort_order, pe.label`)
 	return out, rows.Err()
 }
 
+// PaymentKeyConflict is an install-time payment-entry key collision.
+type PaymentKeyConflict struct {
+	Key            string
+	Owner          string // owning plugin id; empty = built-in or shop-created tender
+	OwnerInstalled bool   // false when the owning plugin's row is gone (uninstalled; its tender row is retained for sales history)
+}
+
+// FindPaymentKeyConflicts returns, for the candidate payment-entry keys of
+// pluginID, those already taken by a non-plugin payment method (built-in or
+// shop-created via EnsurePaymentMethod) or by ANOTHER plugin's payment
+// entry. The plugin's own existing keys never conflict, so reinstall and
+// upgrade stay clean. Companion to SyncPluginPaymentMethods' ownership
+// guard (ADR-0031): the guard makes a collision harmless, this makes it
+// loud at install time.
+func (r *PluginRepo) FindPaymentKeyConflicts(ctx context.Context, tx *sql.Tx, pluginID string, keys []string) ([]PaymentKeyConflict, error) {
+	exec := r.executor(tx)
+	var out []PaymentKeyConflict
+	for _, key := range keys {
+		var owner sql.NullString
+		var ownerInstalled int
+		err := exec.QueryRowContext(ctx, `
+SELECT pm.plugin_id, CASE WHEN p.id IS NULL THEN 0 ELSE 1 END
+FROM payment_methods pm
+LEFT JOIN plugins p ON p.id = pm.plugin_id
+WHERE pm.id = ?`, key).Scan(&owner, &ownerInstalled)
+		switch {
+		case err == sql.ErrNoRows:
+			// no method row; fall through to the entry check
+		case err != nil:
+			return nil, pluginObs.wrap("payment_key_conflicts", err)
+		case !owner.Valid || owner.String == "":
+			out = append(out, PaymentKeyConflict{Key: key})
+			continue
+		case owner.String != pluginID:
+			out = append(out, PaymentKeyConflict{Key: key, Owner: owner.String, OwnerInstalled: ownerInstalled == 1})
+			continue
+		}
+		var entryOwner string
+		err = exec.QueryRowContext(ctx, `
+SELECT plugin_id FROM plugin_entries
+WHERE type = 'payment' AND key = ? AND plugin_id != ? LIMIT 1`, key, pluginID).Scan(&entryOwner)
+		if err == sql.ErrNoRows {
+			continue
+		}
+		if err != nil {
+			return nil, pluginObs.wrap("payment_key_conflicts", err)
+		}
+		out = append(out, PaymentKeyConflict{Key: key, Owner: entryOwner, OwnerInstalled: true})
+	}
+	return out, nil
+}
+
 // SyncPluginPaymentMethods derives payment_methods rows from active plugins'
 // payment entries: upserts a method per entry (id = entry key) and
 // deactivates plugin-backed methods whose plugin is gone or disabled.
 // Rows are never deleted — payments history references them.
+//
+// Ownership guard (ADR-0031): the upsert only updates a conflicting row the
+// same plugin already owns. A key colliding with a built-in (plugin_id NULL)
+// or another plugin's method leaves the existing row untouched — the entry
+// simply doesn't materialize (and install-time validation in
+// plugins.PersistManifest rejects such keys with a clear error). Before this
+// guard a plugin declaring key "cash" captured the built-in cash tender, and
+// the deactivate step below then removed cash from checkout entirely when
+// the plugin went away (migration 021 repairs tills hit by that).
 func (r *PluginRepo) SyncPluginPaymentMethods(ctx context.Context) error {
+	// Standing invariant, re-asserted EVERY run (not just migration 021):
+	// the seeded built-ins are never plugin-owned. Damage can re-enter a
+	// repaired till after the one-shot migration — e.g. LAN admin sync
+	// from a not-yet-upgraded primary — and the hijacking plugin may not
+	// even exist locally, so the deactivate step below would otherwise pin
+	// the row inactive forever.
+	if _, err := r.db.ExecContext(ctx, `
+UPDATE payment_methods SET plugin_id = NULL, is_active = 1
+WHERE id IN ('cash', 'card', 'gift') AND plugin_id IS NOT NULL`); err != nil {
+		return fmt.Errorf("sync plugin payment methods (built-in invariant): %w", err)
+	}
 	if _, err := r.db.ExecContext(ctx, `
 INSERT INTO payment_methods (id, name, type, is_active, sort_order, plugin_id)
 SELECT pe.key, pe.label,
@@ -1068,16 +1140,19 @@ JOIN plugins p ON p.id = pe.plugin_id
 WHERE pe.type = 'payment' AND pe.is_active = 1 AND p.is_active = 1
 ON CONFLICT(id) DO UPDATE SET
     name = excluded.name,
-    is_active = 1,
-    plugin_id = excluded.plugin_id`); err != nil {
+    is_active = 1
+WHERE payment_methods.plugin_id = excluded.plugin_id`); err != nil {
 		return fmt.Errorf("sync plugin payment methods (upsert): %w", err)
 	}
+	// Ownership-aware: only the OWNING plugin's live entries keep a row
+	// active — an unrelated plugin's entry with the same key must not.
 	if _, err := r.db.ExecContext(ctx, `
 UPDATE payment_methods SET is_active = 0
-WHERE plugin_id IS NOT NULL AND id NOT IN (
-    SELECT pe.key FROM plugin_entries pe
+WHERE plugin_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM plugin_entries pe
     JOIN plugins p ON p.id = pe.plugin_id
     WHERE pe.type = 'payment' AND pe.is_active = 1 AND p.is_active = 1
+      AND pe.key = payment_methods.id AND pe.plugin_id = payment_methods.plugin_id
 )`); err != nil {
 		return fmt.Errorf("sync plugin payment methods (deactivate): %w", err)
 	}

--- a/internal/data/plugin_repo_payment_guard_test.go
+++ b/internal/data/plugin_repo_payment_guard_test.go
@@ -1,0 +1,291 @@
+package data
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/db"
+)
+
+// Regression tests for the plugin payment-key hijack found by coverage
+// batch 9's independent review: SyncPluginPaymentMethods took
+// payment_methods.id verbatim from plugin_entries.key and its
+// ON CONFLICT(id) DO UPDATE stamped plugin_id onto whatever row already
+// owned that id — so a plugin declaring {type:"payment", key:"cash"}
+// captured the built-in cash tender, and the sync's deactivate step then
+// flipped it inactive once the plugin went away: cash silently vanished
+// from checkout ("checkout must never be blocked", universal-till
+// CLAUDE.md). Written failing-first against the unguarded sync.
+
+// pgPlugin inserts a minimal catalog+plugin pair on the REAL migrated
+// schema (plugins has an FK onto plugin_catalog).
+func pgPlugin(t *testing.T, d *db.DB, id string, active int) {
+	t.Helper()
+	mustExec(t, d, `INSERT INTO plugin_catalog (id, version, name, runtime, entrypoint, package_url, sha256, min_pos_version, api_version, published_at)
+VALUES (?, '1.0.0', ?, 'wasm', 'main.wasm', 'https://example.invalid/pkg', 'deadbeef', '0.0.1', '1', '2026-07-30T00:00:00Z')`, id, "Plugin "+id)
+	mustExec(t, d, `INSERT INTO plugins (id, name, version, install_state, runtime, entrypoint, is_active, trust_level)
+VALUES (?, ?, '1.0.0', 'installed', 'wasm', 'main.wasm', ?, 'trusted')`, id, "Plugin "+id, active)
+}
+
+func pgEntry(t *testing.T, d *db.DB, id, pluginID, key, label string) {
+	t.Helper()
+	mustExec(t, d, `INSERT INTO plugin_entries (id, plugin_id, type, key, label, sort_order, is_active, created_at, updated_at)
+VALUES (?, ?, 'payment', ?, ?, 1, 1, '2026-07-30T00:00:00Z', '2026-07-30T00:00:00Z')`, id, pluginID, key, label)
+}
+
+type paymentMethodState struct {
+	Name     string
+	Type     string
+	Active   int
+	PluginID string
+}
+
+func pgMethod(t *testing.T, d *db.DB, id string) (paymentMethodState, bool) {
+	t.Helper()
+	var s paymentMethodState
+	err := d.DB.QueryRow(`SELECT name, type, is_active, COALESCE(plugin_id,'') FROM payment_methods WHERE id = ?`, id).
+		Scan(&s.Name, &s.Type, &s.Active, &s.PluginID)
+	if err != nil {
+		return s, false
+	}
+	return s, true
+}
+
+func pgOpenDB(t *testing.T, name string) *db.DB {
+	t.Helper()
+	d, err := db.Open(filepath.Join(t.TempDir(), name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	return d
+}
+
+func TestSyncPluginPaymentMethods_CannotHijackBuiltins(t *testing.T) {
+	d := pgOpenDB(t, "hijack.db")
+	ctx := context.Background()
+	repo := NewPluginRepo(d.DB)
+
+	pgPlugin(t, d, "com.evil.tender", 1)
+	pgEntry(t, d, "pe-evil", "com.evil.tender", "cash", "Evil Cash")
+
+	if err := repo.SyncPluginPaymentMethods(ctx); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	got, ok := pgMethod(t, d, "cash")
+	if !ok {
+		t.Fatal("built-in cash row vanished")
+	}
+	if got.PluginID != "" || got.Name != "Cash" || got.Active != 1 {
+		t.Fatalf("built-in cash captured by plugin: %+v (want plugin_id '', name Cash, active)", got)
+	}
+
+	// The historically fatal half: plugin goes away, deactivate step runs.
+	mustExec(t, d, `UPDATE plugins SET is_active = 0 WHERE id = 'com.evil.tender'`)
+	if err := repo.SyncPluginPaymentMethods(ctx); err != nil {
+		t.Fatalf("sync after disable: %v", err)
+	}
+	got, _ = pgMethod(t, d, "cash")
+	if got.Active != 1 || got.PluginID != "" {
+		t.Fatalf("built-in cash deactivated after plugin disable: %+v — checkout would lose its cash tender", got)
+	}
+}
+
+func TestSyncPluginPaymentMethods_OwnLifecycleStillWorks(t *testing.T) {
+	d := pgOpenDB(t, "lifecycle.db")
+	ctx := context.Background()
+	repo := NewPluginRepo(d.DB)
+
+	pgPlugin(t, d, "com.good.pay", 1)
+	pgEntry(t, d, "pe-good", "com.good.pay", "goodpay", "GoodPay")
+
+	if err := repo.SyncPluginPaymentMethods(ctx); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	got, ok := pgMethod(t, d, "goodpay")
+	if !ok || got.PluginID != "com.good.pay" || got.Active != 1 || got.Name != "GoodPay" {
+		t.Fatalf("plugin method not materialized: %+v ok=%v", got, ok)
+	}
+
+	mustExec(t, d, `UPDATE plugins SET is_active = 0 WHERE id = 'com.good.pay'`)
+	if err := repo.SyncPluginPaymentMethods(ctx); err != nil {
+		t.Fatalf("sync after disable: %v", err)
+	}
+	got, ok = pgMethod(t, d, "goodpay")
+	if !ok {
+		t.Fatal("goodpay row deleted — rows must never be deleted (payments history references them)")
+	}
+	if got.Active != 0 {
+		t.Fatalf("disabled plugin's method must deactivate: %+v", got)
+	}
+
+	mustExec(t, d, `UPDATE plugins SET is_active = 1 WHERE id = 'com.good.pay'`)
+	if err := repo.SyncPluginPaymentMethods(ctx); err != nil {
+		t.Fatalf("sync after re-enable: %v", err)
+	}
+	if got, _ = pgMethod(t, d, "goodpay"); got.Active != 1 {
+		t.Fatalf("re-enabled plugin's method must reactivate: %+v", got)
+	}
+}
+
+func TestSyncPluginPaymentMethods_CrossPluginCollisionFirstOwnerWins(t *testing.T) {
+	d := pgOpenDB(t, "crossplugin.db")
+	ctx := context.Background()
+	repo := NewPluginRepo(d.DB)
+
+	pgPlugin(t, d, "com.first.pay", 1)
+	pgEntry(t, d, "pe-first", "com.first.pay", "shared", "First Pay")
+	if err := repo.SyncPluginPaymentMethods(ctx); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	pgPlugin(t, d, "com.second.pay", 1)
+	pgEntry(t, d, "pe-second", "com.second.pay", "shared", "Second Pay")
+	if err := repo.SyncPluginPaymentMethods(ctx); err != nil {
+		t.Fatalf("sync 2: %v", err)
+	}
+
+	got, _ := pgMethod(t, d, "shared")
+	if got.PluginID != "com.first.pay" || got.Name != "First Pay" {
+		t.Fatalf("second plugin captured first plugin's method row: %+v", got)
+	}
+}
+
+// The review's blocker scenario: a replica repaired by migration 021 can
+// re-import a captured built-in over LAN admin sync from a not-yet-upgraded
+// primary — and the hijacking plugin may not even exist locally. A one-shot
+// migration can't help; the sync must re-assert the built-in invariant on
+// EVERY run.
+func TestSyncPluginPaymentMethods_SelfHealsDamagedBuiltins(t *testing.T) {
+	d := pgOpenDB(t, "selfheal.db")
+	ctx := context.Background()
+	repo := NewPluginRepo(d.DB)
+
+	// Damage as admin-sync would import it: plugin-stamped + deactivated,
+	// with NO matching plugin installed on this till at all.
+	mustExec(t, d, `UPDATE payment_methods SET plugin_id = 'com.gone.evil', is_active = 0 WHERE id = 'cash'`)
+
+	if err := repo.SyncPluginPaymentMethods(ctx); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	got, ok := pgMethod(t, d, "cash")
+	if !ok || got.PluginID != "" || got.Active != 1 {
+		t.Fatalf("sync must self-heal a plugin-stamped built-in every run, got %+v ok=%v", got, ok)
+	}
+}
+
+// plugin_id on payment_methods is till-local derived state (which plugin on
+// THIS till owns the method) — it must never travel over LAN admin sync.
+func TestAdminSync_DoesNotImportPaymentMethodPluginOwnership(t *testing.T) {
+	ctx := context.Background()
+	primary := openMigratedDB(t, "pg-primary.db")
+	replica := openMigratedDB(t, "pg-replica.db")
+
+	// A damaged, not-yet-upgraded primary: built-in cash captured.
+	mustExec(t, primary, `UPDATE payment_methods SET plugin_id = 'com.evil.tender', name = 'Evil Cash', is_active = 0 WHERE id = 'cash'`)
+
+	bundle, err := NewSyncAdminRepo(primary.DB).DumpAdmin(ctx)
+	if err != nil {
+		t.Fatalf("dump: %v", err)
+	}
+	if err := NewSyncAdminRepo(replica.DB).ApplyAdmin(ctx, wireTrip(t, bundle)); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	got, ok := pgMethod(t, replica, "cash")
+	if !ok {
+		t.Fatal("replica cash row missing")
+	}
+	if got.PluginID != "" {
+		t.Fatalf("admin sync imported plugin ownership onto the replica's built-in: %+v", got)
+	}
+}
+
+// Legacy state (pre-fix capture or a rolled-back colliding manifest): the
+// deactivate step must key on the OWNING plugin's entries — an unrelated
+// plugin holding an entry with the same key must not keep the row alive.
+func TestSyncPluginPaymentMethods_DeactivateIsOwnershipAware(t *testing.T) {
+	d := pgOpenDB(t, "deactivate-owner.db")
+	ctx := context.Background()
+	repo := NewPluginRepo(d.DB)
+
+	pgPlugin(t, d, "com.a.pay", 1)
+	pgEntry(t, d, "pe-a", "com.a.pay", "shared", "A Pay")
+	if err := repo.SyncPluginPaymentMethods(ctx); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	// Unrelated plugin holds an entry with the same key (legacy state).
+	pgPlugin(t, d, "com.b.pay", 1)
+	pgEntry(t, d, "pe-b", "com.b.pay", "shared", "B Pay")
+
+	mustExec(t, d, `UPDATE plugins SET is_active = 0 WHERE id = 'com.a.pay'`)
+	if err := repo.SyncPluginPaymentMethods(ctx); err != nil {
+		t.Fatalf("sync after disabling owner: %v", err)
+	}
+	got, ok := pgMethod(t, d, "shared")
+	if !ok {
+		t.Fatal("shared row vanished — rows must never be deleted")
+	}
+	if got.Active != 0 || got.PluginID != "com.a.pay" {
+		t.Fatalf("owner disabled: row must deactivate and stay A's, got %+v", got)
+	}
+}
+
+func TestMigration021_RepairsHijackedBuiltins(t *testing.T) {
+	d := pgOpenDB(t, "repair.db")
+
+	// Recreate the pre-fix damage on a real schema: built-in captured,
+	// renamed, and deactivated by the old sync — with the hijacker's
+	// payment entry still installed.
+	pgPlugin(t, d, "com.evil.tender", 0)
+	pgEntry(t, d, "pe-evil", "com.evil.tender", "cash", "Evil Cash")
+	mustExec(t, d, `UPDATE payment_methods SET plugin_id = 'com.evil.tender', name = 'Evil Cash', is_active = 0 WHERE id = 'cash'`)
+
+	sqlBytes, err := os.ReadFile(repairMigrationPath(t))
+	if err != nil {
+		t.Fatalf("read repair migration: %v", err)
+	}
+	if _, err := d.DB.Exec(string(sqlBytes)); err != nil {
+		t.Fatalf("re-exec repair migration (must be idempotent): %v", err)
+	}
+
+	got, _ := pgMethod(t, d, "cash")
+	if got.PluginID != "" || got.Active != 1 {
+		t.Fatalf("hijacked built-in not repaired: %+v (want plugin ownership cleared + active)", got)
+	}
+	// Names are deliberately NOT reset (operators may rename tenders) —
+	// ADR-0031's explicit promise.
+	if got.Name != "Evil Cash" {
+		t.Fatalf("repair must not touch names, got %q", got.Name)
+	}
+	// The hijacking ENTRY must be disarmed too: both payment dispatch
+	// gates match on entry key alone, so a live entry with key 'cash'
+	// would still receive (and could veto) payment.cash.* events.
+	var entryActive int
+	if err := d.DB.QueryRow(`SELECT is_active FROM plugin_entries WHERE id = 'pe-evil'`).Scan(&entryActive); err != nil {
+		t.Fatalf("read hijacker entry: %v", err)
+	}
+	if entryActive != 0 {
+		t.Fatal("migration must deactivate legacy payment entries squatting on built-in keys")
+	}
+
+	// A genuine plugin-backed method must NOT be touched by the repair.
+	mustExec(t, d, `INSERT INTO payment_methods (id, name, type, is_active, sort_order, plugin_id) VALUES ('okpay','OK Pay','card',0,100,'com.evil.tender')`)
+	if _, err := d.DB.Exec(string(sqlBytes)); err != nil {
+		t.Fatalf("repair migration second run: %v", err)
+	}
+	if got, _ := pgMethod(t, d, "okpay"); got.PluginID != "com.evil.tender" || got.Active != 0 {
+		t.Fatalf("repair must only touch the seeded built-ins, got %+v", got)
+	}
+}
+
+func repairMigrationPath(t *testing.T) string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join("..", "db", "migrations", "021_*.sql"))
+	if err != nil || len(matches) != 1 {
+		t.Fatalf("expected exactly one 021 migration, got %v (err=%v)", matches, err)
+	}
+	return matches[0]
+}

--- a/internal/data/sync_admin_repo.go
+++ b/internal/data/sync_admin_repo.go
@@ -30,6 +30,8 @@ type adminTable struct {
 	// kept-but-retired row must release values like sku/username, or the
 	// primary's row upserts into a UNIQUE violation and the whole apply
 	// rolls back — on every pull, forever.
+	skipCols []string // till-LOCAL columns that must never travel: excluded
+	// from the dump and ignored on apply even if an older primary sends them.
 }
 
 // adminTables is the shop-wide state a replica mirrors. Deliberately NOT
@@ -44,7 +46,10 @@ var adminTables = []adminTable{
 	{name: "brands", pk: []string{"id"}, unique: []string{"name"}},
 	{name: "categories", pk: []string{"id"}},
 	{name: "customers", pk: []string{"id"}, unique: []string{"loyalty_no"}},
-	{name: "payment_methods", pk: []string{"id"}, hasIsActive: true, unique: []string{"name"}},
+	// plugin_id is till-local derived state (which plugin installed on THIS
+	// till owns the method) — importing it re-hijacks a repaired built-in
+	// from a not-yet-upgraded primary (ADR-0031).
+	{name: "payment_methods", pk: []string{"id"}, hasIsActive: true, unique: []string{"name"}, skipCols: []string{"plugin_id"}},
 	{name: "users", pk: []string{"id"}, hasIsActive: true, unique: []string{"username"}},
 	{name: "items", pk: []string{"id"}, hasIsActive: true, unique: []string{"sku"}},
 	{name: "item_barcodes", pk: []string{"barcode"}},
@@ -119,6 +124,11 @@ func (r *SyncAdminRepo) DumpAdmin(ctx context.Context) (AdminBundle, error) {
 				}
 			}
 			recs = kept
+		}
+		for _, c := range t.skipCols {
+			for _, rec := range recs {
+				delete(rec, c)
+			}
 		}
 		bundle.Tables[t.name] = recs
 	}
@@ -313,10 +323,17 @@ func upsertRow(ctx context.Context, tx *sql.Tx, t adminTable, cols []string, rec
 	for _, c := range t.pk {
 		isPK[c] = true
 	}
+	skip := map[string]bool{}
+	for _, c := range t.skipCols {
+		skip[c] = true
+	}
 	var names []string
 	var args []any
 	var sets []string
 	for _, c := range cols {
+		if skip[c] {
+			continue // till-local column; ignore even if an older primary sends it
+		}
 		v, ok := rec[c]
 		if !ok {
 			continue // column the primary doesn't know (newer replica schema)

--- a/internal/db/migrations/021_payment_method_hijack_repair.sql
+++ b/internal/db/migrations/021_payment_method_hijack_repair.sql
@@ -1,0 +1,28 @@
+-- Repair built-in tenders captured by a plugin payment-entry key collision.
+-- Before 2026-07-30, SyncPluginPaymentMethods' ON CONFLICT(id) DO UPDATE
+-- stamped plugin_id onto whatever payment_methods row already owned the
+-- plugin entry's key — a plugin declaring {type:"payment", key:"cash"}
+-- captured the seeded cash tender, and the sync's deactivate step then
+-- flipped the built-in inactive once the plugin was disabled/removed
+-- (cash silently vanished from checkout). The sync is now ownership-
+-- guarded; this restores any till already damaged. Only the three seeded
+-- built-ins are targeted: for them plugin_id can ONLY mean a capture
+-- (they predate every plugin). Names deliberately left as-is — an
+-- operator can rename a tender, so a name reset could destroy real
+-- configuration; ownership + availability are what checkout needs.
+UPDATE payment_methods
+SET plugin_id = NULL,
+    is_active = 1
+WHERE id IN ('cash', 'card', 'gift')
+  AND plugin_id IS NOT NULL;
+
+-- Disarm the squatting entries themselves: both payment dispatch gates
+-- match on entry key alone, so a legacy plugin entry with key 'cash'
+-- would still receive payment.cash.* events for every cash tender and —
+-- if it subscribes the authorize leg — could decline them. New installs
+-- with these keys are rejected outright; this covers what's already on
+-- disk from before the fix.
+UPDATE plugin_entries
+SET is_active = 0
+WHERE type = 'payment'
+  AND key IN ('cash', 'card', 'gift');

--- a/internal/plugins/manifest.go
+++ b/internal/plugins/manifest.go
@@ -133,6 +133,51 @@ func ComputeSHA256(filePath string) (string, error) {
 }
 
 // PersistManifest saves the manifest to database tables
+// validatePaymentEntryKeys enforces ADR-0031's install-time half for every
+// path that writes plugin_entries type='payment' (PersistManifest AND
+// Rollback — a legacy on-disk manifest can carry keys that predate
+// validation). Keys must be non-empty, whitespace-clean, contain no ':'
+// (reserved namespace separator), and not collide with a non-plugin tender
+// or another plugin's payment key. The plugin's own keys never
+// self-conflict, so reinstall/upgrade pass.
+func validatePaymentEntryKeys(ctx context.Context, repo *data.PluginRepo, tx *sql.Tx, pluginID string, entries []ManifestEntry) error {
+	var paymentKeys []string
+	for _, e := range entries {
+		if e.Type != "payment" {
+			continue
+		}
+		if e.Key == "" {
+			return fmt.Errorf("payment entry has an empty key")
+		}
+		if e.Key != strings.TrimSpace(e.Key) {
+			return fmt.Errorf("payment entry key %q has surrounding whitespace", e.Key)
+		}
+		if strings.Contains(e.Key, ":") {
+			return fmt.Errorf("payment entry key %q must not contain ':'", e.Key)
+		}
+		paymentKeys = append(paymentKeys, e.Key)
+	}
+	if len(paymentKeys) == 0 {
+		return nil
+	}
+	conflicts, err := repo.FindPaymentKeyConflicts(ctx, tx, pluginID, paymentKeys)
+	if err != nil {
+		return fmt.Errorf("check payment key conflicts: %w", err)
+	}
+	if len(conflicts) == 0 {
+		return nil
+	}
+	c := conflicts[0]
+	switch {
+	case c.Owner == "":
+		return fmt.Errorf("payment entry key %q collides with an existing built-in or shop-configured tender — pick a plugin-specific key", c.Key)
+	case !c.OwnerInstalled:
+		return fmt.Errorf("payment entry key %q belongs to plugin %s, which is no longer installed — its tender row is retained for sales history; reinstall it or pick a different key", c.Key, c.Owner)
+	default:
+		return fmt.Errorf("payment entry key %q is already provided by plugin %s — pick a different key", c.Key, c.Owner)
+	}
+}
+
 func PersistManifest(ctx context.Context, db *sql.DB, m *Manifest, opts InstallOptions) error {
 	repo := data.NewPluginRepo(db)
 	tx, err := db.BeginTx(ctx, nil)
@@ -142,6 +187,14 @@ func PersistManifest(ctx context.Context, db *sql.DB, m *Manifest, opts InstallO
 	defer tx.Rollback()
 
 	now := time.Now().UTC()
+
+	// 0. Payment-entry keys become payment_methods ids verbatim — a key
+	// colliding with a built-in tender or another plugin's method must be
+	// rejected here, loudly, instead of silently never materializing
+	// (the sync layer's ownership guard refuses the capture; ADR-0031).
+	if err := validatePaymentEntryKeys(ctx, repo, tx, m.ID, m.Entries); err != nil {
+		return err
+	}
 
 	// 1. Ensure a plugin_catalog row exists — plugins(id,version) has a
 	// foreign key onto plugin_catalog, and locally imported plugins have no

--- a/internal/plugins/payment_key_validation_test.go
+++ b/internal/plugins/payment_key_validation_test.go
@@ -1,0 +1,174 @@
+package plugins
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/db"
+)
+
+// Install-time half of the payment-key hijack fix (2026-07-30): the sync
+// guard stops a colliding key from capturing an existing tender row, but
+// the plugin author should hear about the collision at install time with
+// a clear error, not ship a tender that silently never materializes.
+
+func openRealDB(t *testing.T) *db.DB {
+	t.Helper()
+	d, err := db.Open(filepath.Join(t.TempDir(), "validate.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	return d
+}
+
+func paymentManifest(id, key string) *Manifest {
+	return &Manifest{
+		ID:         id,
+		Name:       "Pay " + id,
+		Version:    "1.0.0",
+		Entrypoint: "./main.wasm",
+		Entries: []ManifestEntry{
+			{Type: "payment", Key: key, Label: "Tender " + key},
+		},
+	}
+}
+
+func TestPersistManifest_RejectsPaymentKeyCollidingWithNonPluginMethod(t *testing.T) {
+	d := openRealDB(t)
+	ctx := context.Background()
+
+	// 'cash' is seeded by 001_init as a built-in tender.
+	err := PersistManifest(ctx, d.DB, paymentManifest("com.evil.tender", "cash"), InstallOptions{})
+	if err == nil {
+		t.Fatal("PersistManifest accepted a payment entry key colliding with the built-in cash tender")
+	}
+	if !strings.Contains(err.Error(), "cash") {
+		t.Fatalf("collision error should name the key, got: %v", err)
+	}
+	// The rejected plugin must not be half-installed.
+	var n int
+	if err := d.DB.QueryRow(`SELECT COUNT(*) FROM plugins WHERE id = 'com.evil.tender'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("rejected plugin left %d plugins row(s), want 0 (transaction must roll back)", n)
+	}
+}
+
+func TestPersistManifest_RejectsPaymentKeyOwnedByAnotherPlugin(t *testing.T) {
+	d := openRealDB(t)
+	ctx := context.Background()
+
+	if err := PersistManifest(ctx, d.DB, paymentManifest("com.first.pay", "shared"), InstallOptions{}); err != nil {
+		t.Fatalf("first plugin must install cleanly: %v", err)
+	}
+	err := PersistManifest(ctx, d.DB, paymentManifest("com.second.pay", "shared"), InstallOptions{})
+	if err == nil {
+		t.Fatal("PersistManifest accepted a payment key already owned by another plugin")
+	}
+	if !strings.Contains(err.Error(), "shared") || !strings.Contains(err.Error(), "com.first.pay") {
+		t.Fatalf("collision error should name the key and its owner, got: %v", err)
+	}
+}
+
+func TestPersistManifest_KeyReservedByUninstalledPluginSaysSo(t *testing.T) {
+	d := openRealDB(t)
+	ctx := context.Background()
+
+	// The uninstalled-plugin state: the tender ROW survives (sales history
+	// references it) but the plugins row is gone. The reservation stands —
+	// history keeps its method — but the error must not pretend the owner
+	// is installed.
+	mustExecSQL(t, d, `INSERT INTO payment_methods (id, name, type, is_active, sort_order, plugin_id)
+VALUES ('ghostpay', 'Ghost Pay', 'card', 0, 100, 'com.gone.pay')`)
+
+	err := PersistManifest(ctx, d.DB, paymentManifest("com.new.pay", "ghostpay"), InstallOptions{})
+	if err == nil {
+		t.Fatal("key held by an uninstalled plugin's retained tender row must still be rejected")
+	}
+	if !strings.Contains(err.Error(), "ghostpay") || !strings.Contains(err.Error(), "com.gone.pay") || !strings.Contains(err.Error(), "no longer installed") {
+		t.Fatalf("error should name key + former owner and say it is no longer installed, got: %v", err)
+	}
+}
+
+func mustExecSQL(t *testing.T, d *db.DB, q string, args ...any) {
+	t.Helper()
+	if _, err := d.Exec(q, args...); err != nil {
+		t.Fatalf("exec %q: %v", q, err)
+	}
+}
+
+func TestRollback_RejectsCollidingPaymentKeys(t *testing.T) {
+	d := openRealDB(t)
+	ctx := context.Background()
+	base := t.TempDir()
+
+	// Plugin currently at 2.0.0 with a clean key; its on-disk 1.0.0
+	// manifest (the rollback target) declares key "cash" — legacy versions
+	// predating validation can carry colliding keys, and rollback writes
+	// entries without going through PersistManifest.
+	v2 := paymentManifest("com.rb.pay", "rbpay")
+	v2.Version = "2.0.0"
+	if err := PersistManifest(ctx, d.DB, v2, InstallOptions{}); err != nil {
+		t.Fatalf("install v2: %v", err)
+	}
+	mustExecSQL(t, d, `INSERT INTO plugin_catalog (id, version, name, runtime, entrypoint, package_url, sha256, min_pos_version, api_version, published_at)
+VALUES ('com.rb.pay', '1.0.0', 'RB Pay', 'wasm', './main.wasm', 'https://example.invalid', 'deadbeef', '0.0.1', '1', '2026-07-30T00:00:00Z')`)
+
+	dir := filepath.Join(base, "com.rb.pay", "versions", "1.0.0")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{"id":"com.rb.pay","name":"RB Pay","version":"1.0.0","entrypoint":"./main.wasm","runtime":"wasm",
+"entries":[{"type":"payment","key":"cash","label":"Old Cash Grab"}]}`
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rm := NewRollbackManager(d.DB, base)
+	err := rm.Rollback(ctx, "com.rb.pay", "1.0.0", "tester")
+	if err == nil {
+		t.Fatal("rollback restored a payment entry key colliding with the built-in cash tender")
+	}
+	if !strings.Contains(err.Error(), "cash") {
+		t.Fatalf("rollback collision error should name the key, got: %v", err)
+	}
+	// The current version's entries must survive the failed rollback.
+	var n int
+	if err := d.DB.QueryRow(`SELECT COUNT(*) FROM plugin_entries WHERE plugin_id = 'com.rb.pay' AND key = 'rbpay'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("failed rollback must leave current entries intact, found %d", n)
+	}
+}
+
+func TestPersistManifest_PaymentKeyFormatAndSelfUpgrade(t *testing.T) {
+	d := openRealDB(t)
+	ctx := context.Background()
+
+	if err := PersistManifest(ctx, d.DB, paymentManifest("com.bad.pay", ""), InstallOptions{}); err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("empty payment key must be rejected with a clear message, got: %v", err)
+	}
+	if err := PersistManifest(ctx, d.DB, paymentManifest("com.bad.pay", "a:b"), InstallOptions{}); err == nil || !strings.Contains(err.Error(), ":") {
+		t.Fatalf("payment key containing ':' must be rejected, got: %v", err)
+	}
+	if err := PersistManifest(ctx, d.DB, paymentManifest("com.bad.pay", " cash"), InstallOptions{}); err == nil {
+		t.Fatal("payment key with surrounding whitespace must be rejected — ' cash' would mint a padded payment_methods id")
+	}
+
+	// Reinstall/upgrade of the SAME plugin with the same key is not a
+	// collision — its own earlier entry must not block it.
+	if err := PersistManifest(ctx, d.DB, paymentManifest("com.good.pay", "goodpay"), InstallOptions{}); err != nil {
+		t.Fatalf("initial install: %v", err)
+	}
+	m := paymentManifest("com.good.pay", "goodpay")
+	m.Version = "1.1.0"
+	if err := PersistManifest(ctx, d.DB, m, InstallOptions{}); err != nil {
+		t.Fatalf("self-upgrade with unchanged key must pass validation: %v", err)
+	}
+}

--- a/internal/plugins/rollback.go
+++ b/internal/plugins/rollback.go
@@ -125,6 +125,13 @@ func (rm *RollbackManager) Rollback(ctx context.Context, pluginID, targetVersion
 	}
 	defer tx.Rollback()
 
+	// A legacy on-disk manifest can carry payment keys that predate
+	// ADR-0031's validation — rolling back must not restore a colliding
+	// tender key that a fresh install would reject.
+	if err := validatePaymentEntryKeys(ctx, repo, tx, pluginID, manifest.Entries); err != nil {
+		return fmt.Errorf("rollback to %s rejected: %w", targetVersion, err)
+	}
+
 	// Update plugins table
 	if err := repo.UpdatePluginVersion(ctx, tx, pluginID, targetVersion, manifest.Entrypoint, "installed"); err != nil {
 		return err


### PR DESCRIPTION
Fixes the batch-9-review finding: a plugin declaring `{type:"payment", key:"cash"}` captured the built-in cash tender and, once disabled, the sync removed cash from checkout entirely.

Layers (all failing-first TDD, 13 tests): ownership-guarded sync upsert + every-run built-in invariant + ownership-aware deactivation; `plugin_id` excluded from LAN admin sync (the independent review's **blocker**: a not-yet-upgraded primary re-hijacked a repaired replica); shared install/rollback key validation with clear errors; migration 021 repairing captured built-ins and disarming legacy squatter entries.

Decision record: ut-docs **ADR-0031** — bare keys + guard; namespacing rejected because `payments.method_id` prints verbatim on customer receipts and would drag a history remap along.

Independent (opus) review revert-probed all production pieces, confirmed no ecosystem plugin uses colliding keys, and its blocker + 5 should-fixes were fixed and re-verified. Review record: `docs/code-reviews/2026-07-30-plugin-payment-key-hijack.md`.

Queued follow-ups: startup warning for plugin-owned methods whose plugin is absent; orphan catalog row on rejected marketplace install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PC7bUiXcj47ztWSZnNNG8V