### PR TITLE
test: cover internal/cloudsync (59.4%->95.3%) + internal/config (59.6%->100%)

### DIFF
--- a/docs/code-reviews/2026-07-30-coverage-cloudsync-config.md
+++ b/docs/code-reviews/2026-07-30-coverage-cloudsync-config.md
@@ -1,0 +1,205 @@
+# Batch 10: `internal/cloudsync` + `internal/config` test coverage
+
+**Date**: 2026-07-30
+**PR**: `test/coverage-batch10-cloudsync-config`
+**Coverage**: `internal/cloudsync` 59.4% → **95.3%**; `internal/config` 59.6% → **100.0%**
+
+## What shipped
+
+Continuation of the ongoing coverage push (batches 1–9), picking the
+next-lowest real packages per the queue item's own tracking note.
+
+### `internal/cloudsync`
+
+- `Start()` — the till's background sync loop — was previously **0%
+  covered**: no test had ever driven it at all. New tests cover the full
+  lifecycle: ticks on its own interval, stops cleanly on `ctx` cancellation
+  from both the pre-first-tick wait and the main loop, and survives a
+  `Tick()` failure without dying.
+- `apply()`'s directive-dispatch — many branches were untested despite a
+  large existing fixture test: every "hook is nil" branch for `set_setting`/
+  `install_plugin`, "hook present but the required id/field is blank" for
+  `set_price`/`adjust_stock`/`rename_item`/`deactivate_item`/`add_barcode`,
+  a hook returning an error, a hook returning an empty message (must
+  default to `"done"`), string-form vs. missing-entirely numeric JSON
+  payload values, and `remove_plugin` — never exercised as a directive type
+  at all before this batch.
+- `pushSync`/`pushSnapshotIfChanged`/`post` — DB-size reporting, a non-200
+  `/v1/stores/sync` response, a malformed JSON response, `ListItems`/
+  `ItemBarcodes` repository errors, and the catalog-snapshot upload itself
+  failing.
+- **A real gap proven, not a bug**: `pushSnapshotIfChanged`'s stock-quantity
+  path (`ListStockLevels` populating the snapshot's `qty` field) had never
+  actually succeeded in any prior test — the shared
+  `testsupport.NewCatalogTestDB()` minimal schema has no `stock_locations`
+  table, which the repository query `LEFT JOIN`s, so the query silently
+  errored every time (the error is swallowed by design — best-effort sync)
+  and `qty` was always `0`. No test ever caught this because nothing
+  asserted a non-zero quantity. New test uses a real, fully-migrated DB
+  (`internal/db.Open`) instead of the minimal schema — the tester skill's
+  own rule for exactly this shape — and proves real stock quantities now
+  flow through correctly. Not a production bug: the code was always
+  correct; the guarantee had simply never been verified for real.
+- `uploadIssueReport`/`attachFile`/`uploadPendingIssueReports` (the
+  ADR-0022 issue-report upload path) — previously 0%/0%/30%. New tests
+  cover the full multipart request shape (fields, audio, optional video,
+  log lines, `created_at`), the "not registered" and non-200 branches, a
+  missing-audio-file error, and the real `Pending → upload → Discard`
+  cycle (a bundle that uploads successfully is discarded; one the cloud
+  rejects stays pending for retry).
+
+### `internal/config`
+
+- `Init()`/`getenv()` had **zero direct coverage** — every field was only
+  ever exercised indirectly through whatever a real process's ambient
+  environment happened to be. New tests cover every field's default and
+  every field's env-var override, plus the one nested-fallback detail
+  (`UT_MARKETPLACE_STORE_ID` defaults onto `UT_STORE_NAME`'s *resolved*
+  value, not a separate hardcoded literal).
+- `SetOverlays`/`Available` (both live-called — `internal/plugins.go`'s
+  `SetOverlays` call, `internal/httpx`/`translations_page.go`'s `Available`
+  call) had zero direct coverage; a few small `i18n.go` edge branches
+  (malformed locale JSON, a missing fallback-locale file, a full BCP-47
+  region tag falling back to the base language) rounded the package to
+  100%.
+
+### One production change
+
+`cloudsync.go`'s `tickInterval`/`firstDelay` tuning knobs (documented
+"overridable in tests") moved from plain `time.Duration` vars to
+`atomic.Int64`-backed accessor functions. `Start()`'s spawned goroutine
+reads them on every loop iteration; testing `Start()` for the first time
+required overriding them to short durations, and a plain var raced the
+goroutine's read against the test's write under `-race` (reproduced
+consistently, not a fluke). Same default values (2 min / 15 s), same
+semantics, zero behavior change for the one real caller
+(`internal/app.Run` → `cloudsync.Start`) — confirmed by grep, no other
+reader exists.
+
+## Independent review (different model, opus)
+
+**Verdict: SAFE TO MERGE WITH FIXES.** The reviewer re-ran everything
+personally rather than trusting the summary: reverted the atomic change to
+confirm the race was real (`-race` failed on the very first run, reverted
+back), re-ran `-race -count=5` clean on the actual diff, re-confirmed the
+`stock_locations` claim by reading the repository query and the test
+schema directly, and mutation-tested several of the new assertions
+(deleting `apply()`'s `msg == "" → "done"` default, its `remove_plugin`
+missing-id guard, `num()`'s string-parse-error check, and hook-error
+propagation — all four caught by the intended test).
+
+Two real findings, both fixed pre-commit:
+
+- **F1 — a second instance of the same class of race the atomic fix
+  addressed.** `issue_reports_test.go`'s `withTempPendingDir` writes the
+  plain `issuereport.PendingDir` var, which a leaked `Start()`-spawned
+  goroutine can still be reading (via `Tick → uploadPendingIssueReports →
+  issuereport.Pending()`) with no synchronization between them. Reproduced
+  by the reviewer at 4/10 runs under `go test -race -shuffle=on` (this
+  repo's CI runs plain `go test ./...`, so it wasn't failing today, but a
+  real gap regardless).
+- **F2 — the two `Start()` tests didn't actually verify goroutine exit.**
+  Mutation-proved: deleting either of `Start()`'s two
+  `case <-ctx.Done(): return` branches left both `TestStart*` tests passing
+  anyway, because they inferred "the goroutine stopped" from "no more
+  observed HTTP calls" rather than proving it — a leaked, permanently
+  blocked goroutine produced the same observable symptom (no more ticks) as
+  a correctly-exited one.
+
+**Fix applied**: replaced the HTTP-call-counting inference with
+`waitGoroutineExit` — a helper that polls `runtime.NumGoroutine()` back
+down to (at most) a pre-`Start()` baseline before the test proceeds.
+Verified this actually closes F2: re-broke each of the two `ctx.Done()`
+branches in isolation and confirmed both now fail loudly (goroutine count
+never returns to baseline) instead of passing silently, then restored and
+confirmed green again.
+
+Getting `waitGoroutineExit` itself correct took two more rounds, both
+self-caught before considering the fix final:
+1. The shared package-level `httpClient`'s idle keep-alive connections
+   (and their read-loop goroutines) persist well past a request
+   completing — real, harmless, and unrelated to `Start()`, but
+   indistinguishable from a leak by raw goroutine count. Fixed by calling
+   `httpClient.CloseIdleConnections()` before each measurement.
+2. Two of the three `Start()` tests created their test DB
+   (`testDB(t)`, which spawns `database/sql`'s own permanent
+   `connectionOpener` background goroutine for the DB's lifetime) **as an
+   inline argument to `Start()`, after the baseline was already captured**
+   — so that goroutine was never in the baseline, only in the "after"
+   count, producing a persistent false "leak" that never resolved within
+   the timeout. Root-caused with a temporary diagnostic test dumping full
+   goroutine stacks (`runtime.Stack`), which named the exact goroutine
+   (`database/sql.(*DB).connectionOpener`) and its origin. Fixed by
+   hoisting `db := testDB(t)` before the baseline capture in both tests.
+
+**F1's residual state, disclosed rather than silently left**: even with
+`waitGoroutineExit`, `go test -race -shuffle=on` can still occasionally
+race `issue_reports_test.go` against a `Start()` test's straggler
+goroutine. This is not a timing margin `waitGoroutineExit` could widen —
+Go's race detector requires an actual synchronization primitive
+(channel/mutex/`WaitGroup`) to establish a happens-before edge; polling
+`runtime.NumGoroutine()` after the fact, however accurate in wall-clock
+terms, doesn't create one. The real fix is the same one the standing
+`app.Run doesn't join its background services on shutdown` queue item
+already needs (a done-channel/`WaitGroup` on `Start()`) — building that ad
+hoc here would risk conflicting with that item's own in-flight PR #101.
+Confirmed clean under this repo's actual CI invocation (plain `go test
+./...`, no `-race`) and under `-race` alone at `-count=10`. Logged as a new
+sibling instance on that queue item (`ut-docs/QUEUE.md`) rather than fixed
+in this batch — matching that item's own established pattern of cataloging
+other affected functions (`internal/plugins.Supervisor`, the wasm
+runtime's event-channel drainer) as scoped-out follow-ups instead of
+silently expanding its diff.
+
+Two small findings, both fixed:
+
+- **F3** — `TestUploadIssueReportSendsMultipartBundle`'s log-field
+  assertion (`gotLogFields < 0`) could never fail (`len()` is never
+  negative), and the bundle's `Logs` came from the process-wide
+  `logging.Recent()` ring buffer — shared, mutable, test-order-dependent —
+  so the mutation the doc comment claimed to cover (deleting the entire
+  logs-encoding loop, or the `created_at` field) broke no test. Fixed by
+  building the `Bundle` directly with known `Meta.Logs`/`CreatedAt` values
+  instead of going through `Save()`, and asserting the exact encoded
+  values.
+- **F4** — `t.Fatalf` called from inside an `httptest` handler goroutine
+  (invalid per the `testing` package's own documentation — it `Goexit`s
+  the wrong goroutine). Changed to `t.Errorf` + `return`.
+
+Two nitpicks fixed as drive-bys: a dead `_ = okID` assertion in
+`TestUploadPendingIssueReportsFullCycle` (now actually verifies the
+discarded bundle's directory is gone) and a missing assertion in
+`TestInitHonorsEnvOverrides` (`UT_DEFAULT_LOCALE` was set but
+`cfg.Locales.Locale` — the field it actually drives, distinct from
+`cfg.DefaultLocale`/`UT_MARKETPLACE_LOCALE` — was never checked).
+
+## Verified beyond automated tests
+
+- `go build ./...`, `go vet ./...` clean.
+- `bash scripts/ci/guard-data-access.sh`, `bash scripts/ci/guard-i18n.sh`
+  both pass (775 i18n keys, all locales matching).
+- Full `go test ./...`: clean except one pre-existing, unrelated failure
+  (`internal/issuereport.TestSaveCleansUpDirectoryOnWriteFailure`, which
+  relies on file-permission enforcement this sandbox's root user bypasses
+  — confirmed identical on `main` before this batch via `git stash`, not
+  caused by this diff).
+- `go test ./internal/cloudsync/... ./internal/config/... -race -count=10`:
+  clean.
+- Coverage numbers independently re-measured, not just quoted: 95.3% /
+  100.0%.
+
+## Deliberately out of scope
+
+- `internal/config`/`internal/cloudsync`'s remaining uncovered lines
+  (`post()`'s `NewRequestWithContext` error branch, a couple of
+  `uploadIssueReport`/`attachFile` multipart-writer error branches,
+  `uploadPendingIssueReports`'s `Discard`-failure branch,
+  `pushSnapshotIfChanged`'s `it.IsActive` skip — dead code given
+  `ListItems`'s own SQL already filters `is_active = 1`): each would need
+  invasive mocking disproportionate to the risk they guard against: no
+  production bug is plausible on any of them, and they're not reachable
+  through any realistic input.
+- `Start()`'s missing join/done signal — the root cause behind F1's
+  residual state above — logged on the existing
+  `app.Run doesn't join its background services on shutdown` queue item,
+  not fixed here.

--- a/internal/cloudsync/cloudsync.go
+++ b/internal/cloudsync/cloudsync.go
@@ -19,6 +19,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/universaltill/universal-till/internal/buildinfo"
@@ -31,14 +32,27 @@ import (
 var (
 	httpClient = &http.Client{Timeout: 30 * time.Second}
 	started    = time.Now()
-	// Overridable in tests. A till that was off picks up queued directives
-	// (e.g. a portal-side "install to tills") right after boot, and a running
-	// till within a couple of minutes — each tick is one tiny POST, so the
-	// short interval is cheap (Farshid, 2026-07-19). A push channel could
-	// replace the poll later; the poll stays as the NAT-safe fallback.
-	tickInterval = 2 * time.Minute
-	firstDelay   = 15 * time.Second
+	// tickIntervalNS/firstDelayNS back the two interval knobs below.
+	// atomic.Int64 (nanoseconds), not plain vars: Start()'s loop reads them
+	// on every iteration from its own background goroutine, and tests
+	// override them to run the loop fast — a plain var would race the
+	// goroutine's read against a test's write with no synchronization.
+	tickIntervalNS atomic.Int64
+	firstDelayNS   atomic.Int64
 )
+
+func init() {
+	// A till that was off picks up queued directives (e.g. a portal-side
+	// "install to tills") right after boot, and a running till within a
+	// couple of minutes — each tick is one tiny POST, so the short interval
+	// is cheap (Farshid, 2026-07-19). A push channel could replace the poll
+	// later; the poll stays as the NAT-safe fallback.
+	tickIntervalNS.Store(int64(2 * time.Minute))
+	firstDelayNS.Store(int64(15 * time.Second))
+}
+
+func tickInterval() time.Duration { return time.Duration(tickIntervalNS.Load()) }
+func firstDelay() time.Duration   { return time.Duration(firstDelayNS.Load()) }
 
 // Hooks are the till-local actions a directive may trigger. Each returns a
 // short human message for the cloud's result column. A nil hook marks the
@@ -402,7 +416,7 @@ func post(ctx context.Context, cfg *config.Config, path string, payload []byte) 
 // moment), then every few minutes. Ctx-cancelled with the server.
 func Start(ctx context.Context, cfg *config.Config, db *sql.DB, hooks Hooks) {
 	go func() {
-		first := time.NewTimer(firstDelay)
+		first := time.NewTimer(firstDelay())
 		defer first.Stop()
 		select {
 		case <-ctx.Done():
@@ -416,7 +430,7 @@ func Start(ctx context.Context, cfg *config.Config, db *sql.DB, hooks Hooks) {
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(tickInterval):
+			case <-time.After(tickInterval()):
 			}
 		}
 	}()

--- a/internal/cloudsync/cloudsync_test.go
+++ b/internal/cloudsync/cloudsync_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -699,33 +700,54 @@ func TestPushSnapshotIfChangedIncludesRealStockQty(t *testing.T) {
 	}
 }
 
-// waitQuiescent polls count() until it stops changing for a sustained
-// window. Used after cancelling a Start()-spawned goroutine: that goroutine
-// has no join/done signal (a real gap, same class as the standing
-// "app.Run doesn't join its background services" queue item — out of scope
-// to fix here), so a test that mutates the package-level firstDelay/
-// tickInterval vars it reads must give it real time to actually return
-// before doing so, or the race detector correctly flags the unsynchronized
-// access. A fixed short sleep flaked under -race's extra scheduling
-// overhead; this waits for genuine quiet instead of guessing a duration.
-func waitQuiescent(t *testing.T, count func() int) {
+// waitGoroutineExit proves Start()'s spawned goroutine has actually
+// returned — not inferred from "no more observed HTTP calls" (which stops
+// short of the goroutine's synchronous post-tick work, e.g.
+// uploadPendingIssueReports's filesystem read, and doesn't distinguish a
+// genuine return from a hung loop that just happens to be between network
+// calls). Start() has no join/done signal (a real gap, same class as the
+// standing "app.Run doesn't join its background services" queue item — out
+// of scope to fix here), so this is the direct proxy: sample
+// runtime.NumGoroutine() back down to (at most) its pre-Start baseline.
+// This is what actually catches a goroutine leak — deliberately breaking
+// either of Start()'s two `case <-ctx.Done(): return` branches leaves the
+// goroutine permanently blocked (spinning or parked on a never-firing
+// timer), and this fails loudly instead of passing on a stale HTTP-call
+// count.
+//
+// Known remaining boundary (not fully closed by this function, and not
+// closeable from a test at all without Start() itself gaining a real
+// join signal): confirmed under `go test -race -shuffle=on` that
+// issue_reports_test.go's plain `issuereport.PendingDir = ...` writes can
+// still race a Start-test goroutine's read of that same var, even after
+// this function has observed the goroutine's exit. That's not a timing
+// margin this function could widen — Go's race detector tracks actual
+// synchronization primitives (channels, mutexes, WaitGroups), not
+// wall-clock proof-of-quiescence from polling runtime.NumGoroutine(), so
+// no amount of waiting here creates the happens-before edge the detector
+// wants. Confirmed clean under plain `-race` (no shuffle, this package's
+// and this repo's CI's actual test invocation) at -count=10. Logged as a
+// follow-up on the "app.Run doesn't join its background services" item
+// rather than fixed here — the real fix is the same one that item already
+// needs (a done-channel/WaitGroup on Start()), and duplicating that
+// architecture ad hoc in this batch would conflict with it landing there.
+func waitGoroutineExit(t *testing.T, baseline int) {
 	t.Helper()
-	const stableWindow = 300 * time.Millisecond
-	const maxWait = 3 * time.Second
-	deadline := time.Now().Add(maxWait)
-	last := count()
-	lastChange := time.Now()
+	deadline := time.Now().Add(3 * time.Second)
 	for {
-		time.Sleep(2 * time.Millisecond)
-		if n := count(); n != last {
-			last, lastChange = n, time.Now()
-		}
-		if time.Since(lastChange) >= stableWindow {
+		// The shared package-level httpClient keeps idle keep-alive
+		// connections (and their read-loop goroutines) around well past
+		// when a request completes — real, harmless, and unrelated to
+		// Start()'s own goroutine, but indistinguishable from a leak by
+		// goroutine count alone unless closed explicitly first.
+		httpClient.CloseIdleConnections()
+		if n := runtime.NumGoroutine(); n <= baseline {
 			return
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("count never stabilized (stuck growing?): last=%d", last)
+			t.Fatalf("goroutine count still %d after cancel (baseline %d) — Start()'s goroutine leaked", runtime.NumGoroutine(), baseline)
 		}
+		time.Sleep(2 * time.Millisecond)
 	}
 }
 
@@ -744,6 +766,8 @@ func TestStartRunsTickLoopAndStopsOnCancel(t *testing.T) {
 	db := testDB(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	count := func() int { cloud.mu.Lock(); defer cloud.mu.Unlock(); return len(cloud.syncBodies) }
+	httpClient.CloseIdleConnections()
+	baseline := runtime.NumGoroutine()
 
 	Start(ctx, testCfg(srv.URL), db, Hooks{})
 
@@ -757,7 +781,7 @@ func TestStartRunsTickLoopAndStopsOnCancel(t *testing.T) {
 
 	cancel()
 	stoppedAt := count()
-	waitQuiescent(t, count) // let the goroutine actually exit before restoring the vars below
+	waitGoroutineExit(t, baseline) // proves the goroutine actually returned before restoring the vars below
 	firstDelayNS.Store(origFirst)
 	tickIntervalNS.Store(origTick)
 	if afterCancel := count(); afterCancel > stoppedAt+1 {
@@ -778,12 +802,17 @@ func TestStartStopsBeforeFirstTickWhenCancelledEarly(t *testing.T) {
 	cloud := &fakeCloud{}
 	srv := httptest.NewServer(cloud.handler())
 	defer srv.Close()
+	db := testDB(t) // created before baseline: sql.Open spawns a permanent
+	// background connectionOpener goroutine for the DB's lifetime — capturing
+	// baseline before this would count it as a false "leak" from Start().
 	ctx, cancel := context.WithCancel(context.Background())
 	count := func() int { cloud.mu.Lock(); defer cloud.mu.Unlock(); return len(cloud.syncBodies) }
+	httpClient.CloseIdleConnections()
+	baseline := runtime.NumGoroutine()
 
-	Start(ctx, testCfg(srv.URL), testDB(t), Hooks{})
+	Start(ctx, testCfg(srv.URL), db, Hooks{})
 	cancel()
-	waitQuiescent(t, count)
+	waitGoroutineExit(t, baseline)
 	firstDelayNS.Store(origFirst)
 	tickIntervalNS.Store(origTick)
 
@@ -813,10 +842,13 @@ func TestStartToleratesTickFailureAndKeepsLooping(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"directives": []any{}}})
 	}))
 	defer srv.Close()
+	db := testDB(t) // created before baseline, same reason as the test above
 	ctx, cancel := context.WithCancel(context.Background())
 	count := func() int { mu.Lock(); defer mu.Unlock(); return calls }
+	httpClient.CloseIdleConnections()
+	baseline := runtime.NumGoroutine()
 
-	Start(ctx, testCfg(srv.URL), testDB(t), Hooks{})
+	Start(ctx, testCfg(srv.URL), db, Hooks{})
 
 	deadline := time.Now().Add(2 * time.Second)
 	for count() < 2 {
@@ -827,7 +859,7 @@ func TestStartToleratesTickFailureAndKeepsLooping(t *testing.T) {
 	}
 
 	cancel()
-	waitQuiescent(t, count)
+	waitGoroutineExit(t, baseline)
 	firstDelayNS.Store(origFirst)
 	tickIntervalNS.Store(origTick)
 }

--- a/internal/cloudsync/cloudsync_test.go
+++ b/internal/cloudsync/cloudsync_test.go
@@ -4,17 +4,34 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	_ "modernc.org/sqlite"
 
 	"github.com/universaltill/universal-till/internal/config"
 	"github.com/universaltill/universal-till/internal/data"
+	"github.com/universaltill/universal-till/internal/db"
 	"github.com/universaltill/universal-till/internal/testsupport"
 )
+
+// openMigratedDB gives a test a real, fully migrated schema — same helper
+// shape as internal/data's own (unexported there, so duplicated here).
+func openMigratedDB(t *testing.T, name string) *db.DB {
+	t.Helper()
+	d, err := db.Open(filepath.Join(t.TempDir(), name))
+	if err != nil {
+		t.Fatalf("open %s: %v", name, err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
 
 func testDB(t *testing.T) *sql.DB {
 	t.Helper()
@@ -334,6 +351,485 @@ func TestSetItemPriceReachesVariants(t *testing.T) {
 	if err := db.QueryRow(`SELECT price FROM item_variants WHERE id='var-9'`).Scan(&vprice); err != nil || vprice != 160 {
 		t.Fatalf("variant = %d, %v", vprice, err)
 	}
+}
+
+// apply() with no hooks configured must fail cleanly (not panic) for every
+// directive type that install_plugin/set_setting's existing test coverage
+// doesn't already exercise — remove_plugin was never even given a directive
+// in the big TestTickPushesHeartbeatAndAppliesDirectives table, and every
+// other type's own "hook is nil" branch was untested there too (that table
+// always wired every hook).
+func TestApplyMissingHooksFailCleanly(t *testing.T) {
+	cases := []directive{
+		{ID: "x1", Type: "remove_plugin", Payload: map[string]any{"plugin_id": "p1"}},
+		{ID: "x2", Type: "set_price", Payload: map[string]any{"item_id": "i1", "price_minor": 100}},
+		{ID: "x3", Type: "adjust_stock", Payload: map[string]any{"item_id": "i1", "qty_delta": 1}},
+		{ID: "x4", Type: "rename_item", Payload: map[string]any{"item_id": "i1", "name": "n"}},
+		{ID: "x5", Type: "deactivate_item", Payload: map[string]any{"item_id": "i1"}},
+		{ID: "x6", Type: "create_item", Payload: map[string]any{"name": "n", "price_minor": 100}},
+		{ID: "x7", Type: "add_barcode", Payload: map[string]any{"item_id": "i1", "barcode": "b"}},
+	}
+	for _, d := range cases {
+		status, msg := apply(context.Background(), d, Hooks{})
+		if status != "failed" {
+			t.Fatalf("%s: status = %q, want failed (msg %q)", d.Type, status, msg)
+		}
+	}
+}
+
+// set_setting/install_plugin's own nil-hook branches, and their "hook is
+// present but the required field is blank" branches — the giant fixture
+// table always wired both hooks, so neither nil-hook path ever ran, and it
+// never sent an install_plugin directive with an empty listing_id.
+func TestApplySetSettingAndInstallPluginGaps(t *testing.T) {
+	status, _ := apply(context.Background(), directive{Type: "set_setting", Payload: map[string]any{"key": "k", "value": "v"}}, Hooks{})
+	if status != "failed" {
+		t.Fatalf("set_setting nil hook: status=%q", status)
+	}
+	status, _ = apply(context.Background(), directive{Type: "install_plugin", Payload: map[string]any{"listing_id": "l1"}}, Hooks{})
+	if status != "failed" {
+		t.Fatalf("install_plugin nil hook: status=%q", status)
+	}
+
+	hooks := Hooks{
+		SetSetting:    func(ctx context.Context, key, value string) (string, error) { return "ok", nil },
+		InstallPlugin: func(ctx context.Context, listingID string) (string, error) { return "ok", nil },
+	}
+	status, _ = apply(context.Background(), directive{Type: "set_setting", Payload: map[string]any{"value": "v"}}, hooks)
+	if status != "failed" {
+		t.Fatalf("set_setting empty key: status=%q", status)
+	}
+	status, _ = apply(context.Background(), directive{Type: "install_plugin", Payload: map[string]any{}}, hooks)
+	if status != "failed" {
+		t.Fatalf("install_plugin empty listing_id: status=%q", status)
+	}
+}
+
+// Every hook-present-but-item_id-blank branch: the giant fixture table only
+// ever sent these directives with a real item_id (it varied the OTHER
+// field — price, delta, name — to test rejection), so this specific
+// short-circuit was never hit for any of these five types.
+func TestApplyEmptyItemIDWithHookPresent(t *testing.T) {
+	hooks := Hooks{
+		SetPrice: func(ctx context.Context, itemID string, priceMinor int64) (string, error) { return "ok", nil },
+		AdjustStock: func(ctx context.Context, itemID string, delta float64, reason string) (string, error) {
+			return "ok", nil
+		},
+		RenameItem:     func(ctx context.Context, itemID, name string) (string, error) { return "ok", nil },
+		DeactivateItem: func(ctx context.Context, itemID string) (string, error) { return "ok", nil },
+		AddBarcode:     func(ctx context.Context, itemID, barcode string) (string, error) { return "ok", nil },
+	}
+	cases := []directive{
+		{Type: "set_price", Payload: map[string]any{"price_minor": float64(100)}},
+		{Type: "adjust_stock", Payload: map[string]any{"qty_delta": float64(1)}},
+		{Type: "rename_item", Payload: map[string]any{"name": "n"}},
+		{Type: "deactivate_item", Payload: map[string]any{}},
+		{Type: "add_barcode", Payload: map[string]any{"barcode": "b"}},
+	}
+	for _, d := range cases {
+		if status, msg := apply(context.Background(), d, hooks); status != "failed" {
+			t.Fatalf("%s with blank item_id: status=%q msg=%q", d.Type, status, msg)
+		}
+	}
+}
+
+// num()/fnum()'s final fallback (`return 0, false`) fires when the payload
+// key is missing entirely or holds a non-numeric type (not just an
+// unparseable string) — untested by every existing case, which always sends
+// either a valid float64 or a numeric-looking string.
+func TestApplyMissingNumericKeyRejected(t *testing.T) {
+	hooks := Hooks{
+		SetPrice: func(ctx context.Context, itemID string, priceMinor int64) (string, error) { return "ok", nil },
+		AdjustStock: func(ctx context.Context, itemID string, delta float64, reason string) (string, error) {
+			return "ok", nil
+		},
+	}
+	status, _ := apply(context.Background(), directive{Type: "set_price", Payload: map[string]any{"item_id": "i1"}}, hooks)
+	if status != "failed" {
+		t.Fatalf("missing price_minor key: status=%q", status)
+	}
+	status, _ = apply(context.Background(), directive{Type: "adjust_stock", Payload: map[string]any{"item_id": "i1", "qty_delta": true}}, hooks)
+	if status != "failed" {
+		t.Fatalf("bool-typed qty_delta: status=%q", status)
+	}
+}
+
+// A postResult delivery failure must not fail Tick itself — the directive
+// stays "pending" on the cloud and the next tick's re-apply/re-report is
+// exactly how this is meant to recover (see Tick's own comment).
+func TestTickToleratesPostResultFailure(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/stores/sync", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"directives": []map[string]any{
+				{"id": "d1", "type": "set_setting", "payload": map[string]any{"key": "k", "value": "v"}},
+			}},
+		})
+	})
+	mux.HandleFunc("/v1/stores/directives/result", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	hooks := Hooks{SetSetting: func(ctx context.Context, key, value string) (string, error) { return "set", nil }}
+	if err := Tick(context.Background(), testCfg(srv.URL), testDB(t), hooks); err != nil {
+		t.Fatalf("tick should tolerate a postResult failure, got %v", err)
+	}
+}
+
+// pushSnapshotIfChanged's own upload failing (as opposed to the repo-read
+// failures above) must surface as a real error too.
+func TestPushSnapshotIfChangedUploadFails(t *testing.T) {
+	d := openMigratedDB(t, "cloudsync-upload-fail.db")
+	if _, err := d.Exec(`INSERT INTO items (id, sku, name, base_price, is_active) VALUES ('it-1','SKU1','Coke',100,1)`); err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	if err := pushSnapshotIfChanged(context.Background(), testCfg(srv.URL), d.DB); err == nil {
+		t.Fatal("want error when the catalog-snapshot upload fails")
+	}
+}
+
+// remove_plugin's own success path and its missing-plugin_id rejection — the
+// only directive type the original apply() test table never included at all.
+func TestApplyRemovePluginSuccess(t *testing.T) {
+	var removed string
+	hooks := Hooks{RemovePlugin: func(ctx context.Context, pluginID string) (string, error) {
+		removed = pluginID
+		return "removed x", nil
+	}}
+	status, msg := apply(context.Background(), directive{ID: "r1", Type: "remove_plugin", Payload: map[string]any{"plugin_id": "p-9"}}, hooks)
+	if status != "applied" || msg != "removed x" || removed != "p-9" {
+		t.Fatalf("remove_plugin success: status=%q msg=%q removed=%q", status, msg, removed)
+	}
+	status, msg = apply(context.Background(), directive{ID: "r2", Type: "remove_plugin", Payload: map[string]any{}}, hooks)
+	if status != "failed" {
+		t.Fatalf("remove_plugin missing id: status=%q msg=%q", status, msg)
+	}
+}
+
+// A hook returning an error must surface as a "failed" result carrying the
+// error text — untested by every existing case (all test hooks return nil).
+func TestApplyHookErrorPropagates(t *testing.T) {
+	hooks := Hooks{SetSetting: func(ctx context.Context, key, value string) (string, error) {
+		return "", errors.New("disk full")
+	}}
+	status, msg := apply(context.Background(), directive{ID: "e1", Type: "set_setting", Payload: map[string]any{"key": "k", "value": "v"}}, hooks)
+	if status != "failed" || msg != "disk full" {
+		t.Fatalf("status=%q msg=%q, want failed/disk full", status, msg)
+	}
+}
+
+// An applied hook that returns an empty message must default to "done" — the
+// cloud's result column should never show a blank success.
+func TestApplyDefaultsMessageWhenHookReturnsEmpty(t *testing.T) {
+	hooks := Hooks{SetSetting: func(ctx context.Context, key, value string) (string, error) {
+		return "", nil
+	}}
+	status, msg := apply(context.Background(), directive{ID: "e2", Type: "set_setting", Payload: map[string]any{"key": "k", "value": "v"}}, hooks)
+	if status != "applied" || msg != "done" {
+		t.Fatalf("status=%q msg=%q, want applied/done", status, msg)
+	}
+}
+
+// JSON numbers normally decode as float64, but num()/fnum() also tolerate a
+// string-encoded number — untested by every existing directive fixture,
+// which only ever sends float64 payload values.
+func TestApplyAcceptsStringFormNumbers(t *testing.T) {
+	var pricedMinor int64
+	var delta float64
+	hooks := Hooks{
+		SetPrice: func(ctx context.Context, itemID string, priceMinor int64) (string, error) {
+			pricedMinor = priceMinor
+			return "ok", nil
+		},
+		AdjustStock: func(ctx context.Context, itemID string, d float64, reason string) (string, error) {
+			delta = d
+			return "ok", nil
+		},
+	}
+	status, _ := apply(context.Background(), directive{ID: "s1", Type: "set_price", Payload: map[string]any{"item_id": "i1", "price_minor": "250"}}, hooks)
+	if status != "applied" || pricedMinor != 250 {
+		t.Fatalf("string price_minor: status=%q priced=%d", status, pricedMinor)
+	}
+	status, _ = apply(context.Background(), directive{ID: "s2", Type: "adjust_stock", Payload: map[string]any{"item_id": "i1", "qty_delta": "-2.5"}}, hooks)
+	if status != "applied" || delta != -2.5 {
+		t.Fatalf("string qty_delta: status=%q delta=%g", status, delta)
+	}
+	// A non-numeric string must be rejected, not silently parsed as 0.
+	status, _ = apply(context.Background(), directive{ID: "s3", Type: "set_price", Payload: map[string]any{"item_id": "i1", "price_minor": "not-a-number"}}, hooks)
+	if status != "failed" {
+		t.Fatalf("garbage price_minor string: status=%q, want failed", status)
+	}
+}
+
+// pushSync's os.Stat(cfg.DBPath) success branch — every other test points
+// DBPath at "/nonexistent" specifically to skip it.
+func TestPushSyncReportsDBSize(t *testing.T) {
+	cloud := &fakeCloud{}
+	srv := httptest.NewServer(cloud.handler())
+	defer srv.Close()
+	db := testDB(t)
+
+	f, err := os.CreateTemp(t.TempDir(), "fake.db")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	if _, err := f.Write(make([]byte, 2<<20)); err != nil { // 2 MiB
+		t.Fatalf("write: %v", err)
+	}
+	f.Close()
+
+	cfg := testCfg(srv.URL)
+	cfg.DBPath = f.Name()
+	if err := Tick(context.Background(), cfg, db, Hooks{}); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	devs := cloud.syncBodies[0]["devices"].([]any)
+	health := devs[0].(map[string]any)["health"].(map[string]any)
+	if health["db_mb"] != float64(2) {
+		t.Fatalf("db_mb = %v, want 2", health["db_mb"])
+	}
+}
+
+// A non-200 /v1/stores/sync response must surface as a real error out of
+// Tick, not be swallowed — untested by every existing test, which always
+// hits a 200.
+func TestTickPropagatesSyncFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	err := Tick(context.Background(), testCfg(srv.URL), testDB(t), Hooks{})
+	if err == nil {
+		t.Fatal("want error on 500 sync response")
+	}
+}
+
+// A malformed JSON body from /v1/stores/sync must surface as a decode error.
+func TestPushSyncDecodeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+	err := Tick(context.Background(), testCfg(srv.URL), testDB(t), Hooks{})
+	if err == nil {
+		t.Fatal("want decode error on malformed sync response")
+	}
+}
+
+// ListItems/ItemBarcodes failing must surface as a real error from
+// pushSnapshotIfChanged, not panic or silently push an empty snapshot.
+func TestPushSnapshotIfChangedRepoErrors(t *testing.T) {
+	cfg := testCfg("http://unused.example")
+
+	itemsDB := testsupport.NewCatalogTestDB(t)
+	if _, err := itemsDB.Exec(`DROP TABLE items`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := itemsDB.Exec(`CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT, updated_at TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := pushSnapshotIfChanged(context.Background(), cfg, itemsDB); err == nil {
+		t.Fatal("want error when items table is gone")
+	}
+
+	barcodesDB := testsupport.NewCatalogTestDB(t)
+	if _, err := barcodesDB.Exec(`DROP TABLE item_barcodes`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := barcodesDB.Exec(`CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT, updated_at TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	testsupport.SeedItem(t, barcodesDB, testsupport.ItemSeed{ID: "it-1", SKU: "SKU1", Name: "Coke", BasePrice: 100, IsActive: true})
+	if err := pushSnapshotIfChanged(context.Background(), cfg, barcodesDB); err == nil {
+		t.Fatal("want error when item_barcodes table is gone")
+	}
+}
+
+// A real stock quantity must actually reach the snapshot's "qty" field — the
+// existing snapshot test never seeds an inventory row (and the shared test
+// schema has no stock_locations table at all, which ListStockLevels' query
+// LEFT JOINs — so that query silently errors out (the err is never even
+// logged), and this success path had never actually run for real. Per the
+// tester skill's own rule for this exact shape ("use a real fully-migrated
+// database instead of a partial schema that might drift from production"),
+// this uses a real migrated DB rather than patching the minimal schema.
+func TestPushSnapshotIfChangedIncludesRealStockQty(t *testing.T) {
+	cloud := &fakeCloud{}
+	srv := httptest.NewServer(cloud.handler())
+	defer srv.Close()
+	d := openMigratedDB(t, "cloudsync.db")
+
+	// Inserted directly (not via testsupport.SeedItem) so tax_code_id is a
+	// real NULL rather than ""  — the real migrated schema FK-enforces it,
+	// unlike the minimal test schema SeedItem is normally used against.
+	if _, err := d.Exec(`INSERT INTO items (id, sku, name, base_price, is_active) VALUES ('it-1','SKU1','Coke',100,1)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.Exec(`INSERT INTO inventory (id, item_id, location_id, quantity) VALUES ('inv-1','it-1','loc_main', 7.5)`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Tick(context.Background(), testCfg(srv.URL), d.DB, Hooks{}); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	if len(cloud.snapshots) != 1 {
+		t.Fatalf("snapshots = %d, want 1", len(cloud.snapshots))
+	}
+	// The real migration seeds its own demo catalog alongside "it-1", so find
+	// this test's own row rather than assuming it's first.
+	var row map[string]any
+	for _, r := range cloud.snapshots[0]["items"].([]any) {
+		m := r.(map[string]any)
+		if m["id"] == "it-1" {
+			row = m
+			break
+		}
+	}
+	if row == nil {
+		t.Fatal("it-1 not present in snapshot")
+	}
+	if row["qty"] != 7.5 {
+		t.Fatalf("qty = %v, want 7.5", row["qty"])
+	}
+}
+
+// waitQuiescent polls count() until it stops changing for a sustained
+// window. Used after cancelling a Start()-spawned goroutine: that goroutine
+// has no join/done signal (a real gap, same class as the standing
+// "app.Run doesn't join its background services" queue item — out of scope
+// to fix here), so a test that mutates the package-level firstDelay/
+// tickInterval vars it reads must give it real time to actually return
+// before doing so, or the race detector correctly flags the unsynchronized
+// access. A fixed short sleep flaked under -race's extra scheduling
+// overhead; this waits for genuine quiet instead of guessing a duration.
+func waitQuiescent(t *testing.T, count func() int) {
+	t.Helper()
+	const stableWindow = 300 * time.Millisecond
+	const maxWait = 3 * time.Second
+	deadline := time.Now().Add(maxWait)
+	last := count()
+	lastChange := time.Now()
+	for {
+		time.Sleep(2 * time.Millisecond)
+		if n := count(); n != last {
+			last, lastChange = n, time.Now()
+		}
+		if time.Since(lastChange) >= stableWindow {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("count never stabilized (stuck growing?): last=%d", last)
+		}
+	}
+}
+
+// Start()'s background loop: fires shortly after boot, ticks on its own
+// interval, and stops cleanly when its context is cancelled. Uses the
+// package's own test-overridable firstDelay/tickInterval (see their comment)
+// so this doesn't take real wall-clock minutes.
+func TestStartRunsTickLoopAndStopsOnCancel(t *testing.T) {
+	origFirst, origTick := firstDelayNS.Load(), tickIntervalNS.Load()
+	firstDelayNS.Store(int64(5 * time.Millisecond))
+	tickIntervalNS.Store(int64(5 * time.Millisecond))
+
+	cloud := &fakeCloud{}
+	srv := httptest.NewServer(cloud.handler())
+	defer srv.Close()
+	db := testDB(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	count := func() int { cloud.mu.Lock(); defer cloud.mu.Unlock(); return len(cloud.syncBodies) }
+
+	Start(ctx, testCfg(srv.URL), db, Hooks{})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for count() < 2 {
+		if time.Now().After(deadline) {
+			t.Fatalf("only %d ticks after 2s, want at least 2", count())
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	cancel()
+	stoppedAt := count()
+	waitQuiescent(t, count) // let the goroutine actually exit before restoring the vars below
+	firstDelayNS.Store(origFirst)
+	tickIntervalNS.Store(origTick)
+	if afterCancel := count(); afterCancel > stoppedAt+1 {
+		// allow one in-flight tick to land right after cancel; anything more
+		// means the loop kept running past ctx.Done().
+		t.Fatalf("ticks kept growing after cancel: %d -> %d", stoppedAt, afterCancel)
+	}
+}
+
+// Cancelling before the first tick ever fires must return the goroutine via
+// its OUTER select's ctx.Done() case, not the loop's inner one — a longer
+// firstDelay than the cancellation makes that the only reachable path.
+func TestStartStopsBeforeFirstTickWhenCancelledEarly(t *testing.T) {
+	origFirst, origTick := firstDelayNS.Load(), tickIntervalNS.Load()
+	firstDelayNS.Store(int64(time.Hour)) // long enough it will never fire in this test
+	tickIntervalNS.Store(int64(time.Millisecond))
+
+	cloud := &fakeCloud{}
+	srv := httptest.NewServer(cloud.handler())
+	defer srv.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	count := func() int { cloud.mu.Lock(); defer cloud.mu.Unlock(); return len(cloud.syncBodies) }
+
+	Start(ctx, testCfg(srv.URL), testDB(t), Hooks{})
+	cancel()
+	waitQuiescent(t, count)
+	firstDelayNS.Store(origFirst)
+	tickIntervalNS.Store(origTick)
+
+	if n := count(); n != 0 {
+		t.Fatalf("tick fired %d times despite being cancelled before firstDelay elapsed", n)
+	}
+}
+
+// A Tick error inside the loop (not the pre-first-tick wait) must be
+// tolerated — logged, not fatal to the goroutine, and the loop keeps ticking.
+func TestStartToleratesTickFailureAndKeepsLooping(t *testing.T) {
+	origFirst, origTick := firstDelayNS.Load(), tickIntervalNS.Load()
+	firstDelayNS.Store(int64(2 * time.Millisecond))
+	tickIntervalNS.Store(int64(2 * time.Millisecond))
+
+	var mu sync.Mutex
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+		if n == 1 {
+			w.WriteHeader(http.StatusInternalServerError) // first tick: Tick() returns an error
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"directives": []any{}}})
+	}))
+	defer srv.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	count := func() int { mu.Lock(); defer mu.Unlock(); return calls }
+
+	Start(ctx, testCfg(srv.URL), testDB(t), Hooks{})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for count() < 2 {
+		if time.Now().After(deadline) {
+			t.Fatalf("only %d calls after 2s; loop did not survive the first tick's failure", count())
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	cancel()
+	waitQuiescent(t, count)
+	firstDelayNS.Store(origFirst)
+	tickIntervalNS.Store(origTick)
 }
 
 // The real create path is idempotent on retry and refuses a taken barcode.

--- a/internal/cloudsync/issue_reports_test.go
+++ b/internal/cloudsync/issue_reports_test.go
@@ -6,11 +6,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/universaltill/universal-till/internal/config"
 	"github.com/universaltill/universal-till/internal/issuereport"
+	"github.com/universaltill/universal-till/internal/logging"
 )
 
 func withTempPendingDir(t *testing.T) {
@@ -32,31 +35,52 @@ func registeredCfg(url string) *config.Config {
 // field the cloud-side receiving endpoint (ADR-0022 spec 012 Phase 2)
 // expects, including an optional video and the recent-logs lines — this
 // function had zero direct coverage before this batch.
+//
+// The bundle is built directly (not via issuereport.Save, which pulls
+// Meta.Logs from the process-wide logging.Recent() ring buffer — shared,
+// mutable, order-dependent across the whole test binary) so Logs and
+// CreatedAt are known values this test can actually assert against,
+// instead of merely asserting a field is present.
 func TestUploadIssueReportSendsMultipartBundle(t *testing.T) {
-	withTempPendingDir(t)
-	id, err := issuereport.Save("printer jammed", []byte("fake-audio"), []byte("fake-video"))
-	if err != nil {
-		t.Fatalf("Save: %v", err)
+	dir := t.TempDir()
+	audioPath := filepath.Join(dir, "audio.webm")
+	if err := os.WriteFile(audioPath, []byte("fake-audio"), 0o644); err != nil {
+		t.Fatalf("write audio fixture: %v", err)
 	}
-	bundles, err := issuereport.Pending()
-	if err != nil || len(bundles) != 1 {
-		t.Fatalf("Pending: %v (%d bundles)", err, len(bundles))
+	videoPath := filepath.Join(dir, "video.webm")
+	if err := os.WriteFile(videoPath, []byte("fake-video"), 0o644); err != nil {
+		t.Fatalf("write video fixture: %v", err)
 	}
-	b := bundles[0]
+	createdAt := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	b := issuereport.Bundle{
+		Meta: issuereport.Meta{
+			ID:        "report-123",
+			Note:      "printer jammed",
+			CreatedAt: createdAt,
+			Logs: []logging.Problem{
+				{At: createdAt, Level: "WARN", Msg: "printer offline"},
+				{At: createdAt, Level: "ERROR", Msg: "paper jam sensor tripped"},
+			},
+		},
+		Dir:       dir,
+		AudioPath: audioPath,
+		VideoPath: videoPath,
+	}
 
-	var gotStoreID, gotDeviceless, gotReportID, gotNote, gotAuth string
+	var gotStoreID, gotReportID, gotNote, gotAuth, gotCreatedAt string
 	var gotAudio, gotVideo []byte
-	var gotLogFields int
+	var gotLogs []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
 		if err := r.ParseMultipartForm(10 << 20); err != nil {
-			t.Fatalf("server: parse multipart: %v", err)
+			t.Errorf("server: parse multipart: %v", err)
+			return
 		}
 		gotStoreID = r.FormValue("store_id")
-		gotDeviceless = r.FormValue("device_id")
 		gotReportID = r.FormValue("report_id")
 		gotNote = r.FormValue("note")
-		gotLogFields = len(r.MultipartForm.Value["logs"])
+		gotCreatedAt = r.FormValue("created_at")
+		gotLogs = append([]string(nil), r.MultipartForm.Value["logs"]...)
 		if fh := r.MultipartForm.File["audio"]; len(fh) == 1 {
 			f, _ := fh[0].Open()
 			gotAudio = make([]byte, fh[0].Size)
@@ -79,18 +103,24 @@ func TestUploadIssueReportSendsMultipartBundle(t *testing.T) {
 	if gotAuth != "Bearer tok-1" {
 		t.Fatalf("auth header = %q", gotAuth)
 	}
-	if gotStoreID != "store-1" || gotReportID != id || gotNote != "printer jammed" {
+	if gotStoreID != "store-1" || gotReportID != "report-123" || gotNote != "printer jammed" {
 		t.Fatalf("fields: store=%q report=%q note=%q", gotStoreID, gotReportID, gotNote)
 	}
-	_ = gotDeviceless // device_id: no enrolled device in this test, empty string is fine
+	if gotCreatedAt != createdAt.Format("2006-01-02T15:04:05.000000000Z07:00") {
+		t.Fatalf("created_at = %q", gotCreatedAt)
+	}
 	if string(gotAudio) != "fake-audio" {
 		t.Fatalf("audio = %q", gotAudio)
 	}
 	if string(gotVideo) != "fake-video" {
 		t.Fatalf("video = %q", gotVideo)
 	}
-	if gotLogFields < 0 {
-		t.Fatalf("logs fields = %d", gotLogFields)
+	wantLogs := []string{
+		createdAt.Format("2006-01-02T15:04:05Z07:00") + "\tWARN\tprinter offline",
+		createdAt.Format("2006-01-02T15:04:05Z07:00") + "\tERROR\tpaper jam sensor tripped",
+	}
+	if len(gotLogs) != len(wantLogs) || gotLogs[0] != wantLogs[0] || gotLogs[1] != wantLogs[1] {
+		t.Fatalf("logs = %v, want %v", gotLogs, wantLogs)
 	}
 }
 
@@ -208,7 +238,9 @@ func TestUploadPendingIssueReportsFullCycle(t *testing.T) {
 		}
 		t.Fatalf("remaining pending = %v, want only %q", ids, failID)
 	}
-	_ = okID
+	if _, err := os.Stat(filepath.Join(issuereport.PendingDir, okID)); !os.IsNotExist(err) {
+		t.Fatalf("discarded bundle dir for %q should be gone, stat err = %v", okID, err)
+	}
 }
 
 // Pending() itself erroring (not just "no bundles yet") must not panic the

--- a/internal/cloudsync/issue_reports_test.go
+++ b/internal/cloudsync/issue_reports_test.go
@@ -1,0 +1,247 @@
+package cloudsync
+
+import (
+	"context"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/config"
+	"github.com/universaltill/universal-till/internal/issuereport"
+)
+
+func withTempPendingDir(t *testing.T) {
+	t.Helper()
+	orig := issuereport.PendingDir
+	issuereport.PendingDir = t.TempDir()
+	t.Cleanup(func() { issuereport.PendingDir = orig })
+}
+
+func registeredCfg(url string) *config.Config {
+	cfg := &config.Config{}
+	cfg.Marketplace.EndpointURL = url
+	cfg.Marketplace.StoreID = "store-1"
+	cfg.Marketplace.MerchantToken = "tok-1"
+	return cfg
+}
+
+// uploadIssueReport must build a real multipart request carrying every
+// field the cloud-side receiving endpoint (ADR-0022 spec 012 Phase 2)
+// expects, including an optional video and the recent-logs lines — this
+// function had zero direct coverage before this batch.
+func TestUploadIssueReportSendsMultipartBundle(t *testing.T) {
+	withTempPendingDir(t)
+	id, err := issuereport.Save("printer jammed", []byte("fake-audio"), []byte("fake-video"))
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	bundles, err := issuereport.Pending()
+	if err != nil || len(bundles) != 1 {
+		t.Fatalf("Pending: %v (%d bundles)", err, len(bundles))
+	}
+	b := bundles[0]
+
+	var gotStoreID, gotDeviceless, gotReportID, gotNote, gotAuth string
+	var gotAudio, gotVideo []byte
+	var gotLogFields int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		if err := r.ParseMultipartForm(10 << 20); err != nil {
+			t.Fatalf("server: parse multipart: %v", err)
+		}
+		gotStoreID = r.FormValue("store_id")
+		gotDeviceless = r.FormValue("device_id")
+		gotReportID = r.FormValue("report_id")
+		gotNote = r.FormValue("note")
+		gotLogFields = len(r.MultipartForm.Value["logs"])
+		if fh := r.MultipartForm.File["audio"]; len(fh) == 1 {
+			f, _ := fh[0].Open()
+			gotAudio = make([]byte, fh[0].Size)
+			_, _ = f.Read(gotAudio)
+			f.Close()
+		}
+		if fh := r.MultipartForm.File["video"]; len(fh) == 1 {
+			f, _ := fh[0].Open()
+			gotVideo = make([]byte, fh[0].Size)
+			_, _ = f.Read(gotVideo)
+			f.Close()
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if err := uploadIssueReport(context.Background(), registeredCfg(srv.URL), b); err != nil {
+		t.Fatalf("uploadIssueReport: %v", err)
+	}
+	if gotAuth != "Bearer tok-1" {
+		t.Fatalf("auth header = %q", gotAuth)
+	}
+	if gotStoreID != "store-1" || gotReportID != id || gotNote != "printer jammed" {
+		t.Fatalf("fields: store=%q report=%q note=%q", gotStoreID, gotReportID, gotNote)
+	}
+	_ = gotDeviceless // device_id: no enrolled device in this test, empty string is fine
+	if string(gotAudio) != "fake-audio" {
+		t.Fatalf("audio = %q", gotAudio)
+	}
+	if string(gotVideo) != "fake-video" {
+		t.Fatalf("video = %q", gotVideo)
+	}
+	if gotLogFields < 0 {
+		t.Fatalf("logs fields = %d", gotLogFields)
+	}
+}
+
+// A bundle with no video must omit the video part entirely rather than send
+// an empty one — attachFile's "only if VideoPath != ”" guard.
+func TestUploadIssueReportOmitsVideoWhenAbsent(t *testing.T) {
+	withTempPendingDir(t)
+	if _, err := issuereport.Save("no video", []byte("fake-audio"), nil); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	bundles, err := issuereport.Pending()
+	if err != nil || len(bundles) != 1 {
+		t.Fatalf("Pending: %v (%d)", err, len(bundles))
+	}
+	if bundles[0].VideoPath != "" {
+		t.Fatalf("VideoPath = %q, want empty", bundles[0].VideoPath)
+	}
+
+	var hadVideoPart bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseMultipartForm(10 << 20)
+		hadVideoPart = len(r.MultipartForm.File["video"]) > 0
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if err := uploadIssueReport(context.Background(), registeredCfg(srv.URL), bundles[0]); err != nil {
+		t.Fatalf("uploadIssueReport: %v", err)
+	}
+	if hadVideoPart {
+		t.Fatal("video part sent for a bundle with no recording")
+	}
+}
+
+func TestUploadIssueReportUnregistered(t *testing.T) {
+	withTempPendingDir(t)
+	if _, err := issuereport.Save("note", []byte("a"), nil); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	bundles, _ := issuereport.Pending()
+	err := uploadIssueReport(context.Background(), &config.Config{}, bundles[0])
+	if err == nil || !strings.Contains(err.Error(), "not registered") {
+		t.Fatalf("err = %v, want not registered", err)
+	}
+}
+
+func TestUploadIssueReportNon200Fails(t *testing.T) {
+	withTempPendingDir(t)
+	if _, err := issuereport.Save("note", []byte("a"), nil); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	bundles, _ := issuereport.Pending()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	if err := uploadIssueReport(context.Background(), registeredCfg(srv.URL), bundles[0]); err == nil {
+		t.Fatal("want error on 500 response")
+	}
+}
+
+// attachFile's own error branch: a bundle whose audio file vanished from
+// disk between Pending() listing it and upload actually being attempted.
+func TestUploadIssueReportMissingAudioFileErrors(t *testing.T) {
+	withTempPendingDir(t)
+	if _, err := issuereport.Save("note", []byte("a"), nil); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	bundles, _ := issuereport.Pending()
+	b := bundles[0]
+	// Simulate the audio file disappearing after Pending() already listed it.
+	if err := os.Remove(b.AudioPath); err != nil {
+		t.Fatalf("remove audio: %v", err)
+	}
+	err := uploadIssueReport(context.Background(), registeredCfg("http://unused.example"), b)
+	if err == nil {
+		t.Fatal("want error when the audio file is missing")
+	}
+}
+
+// uploadPendingIssueReports drives the real Pending -> upload -> Discard
+// cycle: a bundle that uploads successfully must be discarded, and a bundle
+// the cloud rejects must stay pending for the next tick to retry.
+func TestUploadPendingIssueReportsFullCycle(t *testing.T) {
+	withTempPendingDir(t)
+	okID, err := issuereport.Save("this one uploads", []byte("audio-ok"), nil)
+	if err != nil {
+		t.Fatalf("Save ok bundle: %v", err)
+	}
+	failID, err := issuereport.Save("this one fails", []byte("audio-fail"), nil)
+	if err != nil {
+		t.Fatalf("Save failing bundle: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseMultipartForm(10 << 20)
+		if r.FormValue("report_id") == failID {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	uploadPendingIssueReports(context.Background(), registeredCfg(srv.URL))
+
+	remaining, err := issuereport.Pending()
+	if err != nil {
+		t.Fatalf("Pending after upload: %v", err)
+	}
+	if len(remaining) != 1 || remaining[0].Meta.ID != failID {
+		ids := make([]string, len(remaining))
+		for i, b := range remaining {
+			ids[i] = b.Meta.ID
+		}
+		t.Fatalf("remaining pending = %v, want only %q", ids, failID)
+	}
+	_ = okID
+}
+
+// Pending() itself erroring (not just "no bundles yet") must not panic the
+// tick loop — uploadPendingIssueReports logs and returns.
+func TestUploadPendingIssueReportsPendingListError(t *testing.T) {
+	orig := issuereport.PendingDir
+	// A regular file where a directory is expected makes os.ReadDir fail with
+	// something other than the plain "does not exist" case Pending() already
+	// handles.
+	f := t.TempDir() + "/not-a-dir"
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	issuereport.PendingDir = f
+	t.Cleanup(func() { issuereport.PendingDir = orig })
+
+	// Must not panic; nothing to assert on the (empty) cloud side.
+	uploadPendingIssueReports(context.Background(), registeredCfg("http://unused.example"))
+}
+
+func TestAttachFileMultipartFormWritesRealBytes(t *testing.T) {
+	withTempPendingDir(t)
+	if _, err := issuereport.Save("note", []byte("hello-bytes"), nil); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	bundles, _ := issuereport.Pending()
+	var buf strings.Builder
+	w := multipart.NewWriter(&buf)
+	if err := attachFile(w, "audio", "audio.webm", bundles[0].AudioPath); err != nil {
+		t.Fatalf("attachFile: %v", err)
+	}
+	w.Close()
+	if !strings.Contains(buf.String(), "hello-bytes") {
+		t.Fatal("attached file content missing from multipart body")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -214,8 +214,14 @@ func TestInitHonorsEnvOverrides(t *testing.T) {
 	if cfg.Locales.TaxInclusive {
 		t.Error("TaxInclusive should be false")
 	}
+	// Two distinct fields, two distinct env vars — UT_DEFAULT_LOCALE drives
+	// Locales.Locale, UT_MARKETPLACE_LOCALE drives the top-level
+	// DefaultLocale; easy to conflate since the names point the other way.
+	if cfg.Locales.Locale != "de-DE" {
+		t.Errorf("Locales.Locale = %q, want the UT_DEFAULT_LOCALE override", cfg.Locales.Locale)
+	}
 	if cfg.DefaultLocale != "de-DE" {
-		t.Errorf("DefaultLocale = %q", cfg.DefaultLocale)
+		t.Errorf("DefaultLocale = %q, want the UT_MARKETPLACE_LOCALE override", cfg.DefaultLocale)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,236 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// configEnvKeys lists every env var Init() reads. Kept in one place so both
+// tests below stay in sync with config.go if a var is ever added/removed.
+var configEnvKeys = []string{
+	"UT_DATA_DIR", "UT_STORE_NAME", "UT_LISTEN_ADDR", "UT_DB_PATH", "UT_LOG_LEVEL",
+	"UT_THEME", "UT_DEV_MODE",
+	"UT_MARKETPLACE_ENDPOINT_URL", "UT_MARKETPLACE_STORE_ID", "UT_MARKETPLACE_DEVICE_ID",
+	"UT_MARKETPLACE_PUBLIC_KEY", "UT_MARKETPLACE_UPLOAD_TOKEN", "UT_MARKETPLACE_MERCHANT_TOKEN",
+	"UT_MARKETPLACE_CLIENT_ID", "UT_MARKETPLACE_CLIENT_SECRET", "UT_MARKETPLACE_API_VERSION",
+	"UT_MARKETPLACE_TELEMETRY_OPT_IN", "UT_MARKETPLACE_DEV_OVERRIDE_URL",
+	"UT_MARKETPLACE_HEALTH_CHECK_TIMEOUT_SEC", "UT_MARKETPLACE_FALLBACK_TIMEOUT_SEC",
+	"UT_TAX_RATE", "UT_TAX_INCLUSIVE", "UT_CURRENCY", "UT_CURRENCY_SYMBOL",
+	"UT_DEFAULT_LOCALE", "UT_MARKETPLACE_LOCALE",
+}
+
+// unsetForTest clears every key in configEnvKeys for the duration of the
+// test, restoring each one's original value (set or unset) afterwards — so
+// this test's assertions about Init()'s hardcoded defaults aren't at the
+// mercy of whatever happens to be in the ambient environment.
+func unsetForTest(t *testing.T, keys []string) {
+	t.Helper()
+	for _, k := range keys {
+		orig, had := os.LookupEnv(k)
+		if err := os.Unsetenv(k); err != nil {
+			t.Fatalf("unsetenv %s: %v", k, err)
+		}
+		t.Cleanup(func() {
+			if had {
+				_ = os.Setenv(k, orig)
+			}
+		})
+	}
+}
+
+// With nothing set in the environment, Init() must fall back to its own
+// hardcoded defaults for every field — Init and getenv had zero direct test
+// coverage before this batch (only ever exercised indirectly via whatever
+// happened to be in a real process's environment).
+func TestInitDefaults(t *testing.T) {
+	unsetForTest(t, configEnvKeys)
+
+	cfg, err := Init()
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if cfg.StoreName != "My Store" {
+		t.Errorf("StoreName = %q", cfg.StoreName)
+	}
+	if cfg.ListenAddr != ":8080" {
+		t.Errorf("ListenAddr = %q", cfg.ListenAddr)
+	}
+	if cfg.DataDir == "" {
+		t.Error("DataDir must default to paths.Default(), got empty")
+	}
+	if cfg.DBPath == "" {
+		t.Error("DBPath must default to <DataDir>/unitill-pos.db, got empty")
+	}
+	if cfg.LogLevel != "info" {
+		t.Errorf("LogLevel = %q", cfg.LogLevel)
+	}
+	if cfg.Theme != "monarch" {
+		t.Errorf("Theme = %q", cfg.Theme)
+	}
+	if cfg.DevMode {
+		t.Error("DevMode must default to false")
+	}
+	m := cfg.Marketplace
+	if m.EndpointURL != "http://127.0.0.1:8081" {
+		t.Errorf("EndpointURL = %q", m.EndpointURL)
+	}
+	if m.StoreID != "My Store" {
+		t.Errorf("StoreID must fall back to the StoreName default, got %q", m.StoreID)
+	}
+	if m.DeviceID != "" || m.PublicKey != "" || m.UploadToken != "" || m.MerchantToken != "" {
+		t.Errorf("marketplace secrets must default empty: %+v", m)
+	}
+	if m.APIVersion != "1.0.0" {
+		t.Errorf("APIVersion = %q", m.APIVersion)
+	}
+	if m.TelemetryOptIn {
+		t.Error("TelemetryOptIn must default to false")
+	}
+	if m.DevMode {
+		t.Error("Marketplace.DevMode must mirror the top-level default (false)")
+	}
+	if m.HealthCheckTimeoutSec != 5 {
+		t.Errorf("HealthCheckTimeoutSec = %d, want 5", m.HealthCheckTimeoutSec)
+	}
+	if m.FallbackTimeoutSec != 30 {
+		t.Errorf("FallbackTimeoutSec = %d, want 30", m.FallbackTimeoutSec)
+	}
+	if m.RequestTimeoutSec != 30 {
+		t.Errorf("RequestTimeoutSec = %d, want 30 (not env-driven)", m.RequestTimeoutSec)
+	}
+	if cfg.Locales.Currency != "GBP" || cfg.Locales.CurrencySymbol != "£" {
+		t.Errorf("Locales currency = %+v", cfg.Locales)
+	}
+	if cfg.Locales.TaxRate != 20 {
+		t.Errorf("TaxRate = %d, want 20", cfg.Locales.TaxRate)
+	}
+	if !cfg.Locales.TaxInclusive {
+		t.Error("TaxInclusive must default to true")
+	}
+	if cfg.Locales.Locale != "en-US" {
+		t.Errorf("Locales.Locale = %q", cfg.Locales.Locale)
+	}
+	if cfg.DefaultLocale != "en-US" {
+		t.Errorf("DefaultLocale = %q", cfg.DefaultLocale)
+	}
+}
+
+// Every env var must actually reach the field it's documented to control —
+// the inverse of TestInitDefaults, and the only test that ever exercises
+// Init()'s override path at all.
+func TestInitHonorsEnvOverrides(t *testing.T) {
+	unsetForTest(t, configEnvKeys)
+	dataDir := t.TempDir()
+
+	t.Setenv("UT_DATA_DIR", dataDir)
+	t.Setenv("UT_STORE_NAME", "Cafe Berlin")
+	t.Setenv("UT_LISTEN_ADDR", ":9090")
+	t.Setenv("UT_DB_PATH", dataDir+"/custom.db")
+	t.Setenv("UT_LOG_LEVEL", "debug")
+	t.Setenv("UT_THEME", "midnight")
+	t.Setenv("UT_DEV_MODE", "true")
+	t.Setenv("UT_MARKETPLACE_ENDPOINT_URL", "https://cloud.example.test")
+	t.Setenv("UT_MARKETPLACE_STORE_ID", "store-42")
+	t.Setenv("UT_MARKETPLACE_DEVICE_ID", "dev-1")
+	t.Setenv("UT_MARKETPLACE_PUBLIC_KEY", "pk-abc")
+	t.Setenv("UT_MARKETPLACE_UPLOAD_TOKEN", "up-tok")
+	t.Setenv("UT_MARKETPLACE_MERCHANT_TOKEN", "mt-tok")
+	t.Setenv("UT_MARKETPLACE_CLIENT_ID", "cid")
+	t.Setenv("UT_MARKETPLACE_CLIENT_SECRET", "csec")
+	t.Setenv("UT_MARKETPLACE_API_VERSION", "2.1.0")
+	t.Setenv("UT_MARKETPLACE_TELEMETRY_OPT_IN", "true")
+	t.Setenv("UT_MARKETPLACE_DEV_OVERRIDE_URL", "http://localhost:9999")
+	t.Setenv("UT_MARKETPLACE_HEALTH_CHECK_TIMEOUT_SEC", "9")
+	t.Setenv("UT_MARKETPLACE_FALLBACK_TIMEOUT_SEC", "42")
+	t.Setenv("UT_TAX_RATE", "19")
+	t.Setenv("UT_TAX_INCLUSIVE", "false")
+	t.Setenv("UT_CURRENCY", "EUR")
+	t.Setenv("UT_CURRENCY_SYMBOL", "€")
+	t.Setenv("UT_DEFAULT_LOCALE", "de-DE")
+	t.Setenv("UT_MARKETPLACE_LOCALE", "de-DE")
+
+	cfg, err := Init()
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if cfg.DataDir != dataDir {
+		t.Errorf("DataDir = %q, want %q", cfg.DataDir, dataDir)
+	}
+	if cfg.StoreName != "Cafe Berlin" {
+		t.Errorf("StoreName = %q", cfg.StoreName)
+	}
+	if cfg.ListenAddr != ":9090" {
+		t.Errorf("ListenAddr = %q", cfg.ListenAddr)
+	}
+	if cfg.DBPath != dataDir+"/custom.db" {
+		t.Errorf("DBPath = %q", cfg.DBPath)
+	}
+	if cfg.LogLevel != "debug" {
+		t.Errorf("LogLevel = %q", cfg.LogLevel)
+	}
+	if cfg.Theme != "midnight" {
+		t.Errorf("Theme = %q", cfg.Theme)
+	}
+	if !cfg.DevMode {
+		t.Error("DevMode should be true")
+	}
+	m := cfg.Marketplace
+	if m.EndpointURL != "https://cloud.example.test" {
+		t.Errorf("EndpointURL = %q", m.EndpointURL)
+	}
+	if m.StoreID != "store-42" {
+		t.Errorf("StoreID = %q, must not fall back once explicitly set", m.StoreID)
+	}
+	if m.DeviceID != "dev-1" || m.PublicKey != "pk-abc" || m.UploadToken != "up-tok" || m.MerchantToken != "mt-tok" {
+		t.Errorf("marketplace identity/token fields: %+v", m)
+	}
+	if m.ClientID != "cid" || m.ClientSecret != "csec" {
+		t.Errorf("oauth fields: %+v", m)
+	}
+	if m.APIVersion != "2.1.0" {
+		t.Errorf("APIVersion = %q", m.APIVersion)
+	}
+	if !m.TelemetryOptIn {
+		t.Error("TelemetryOptIn should be true")
+	}
+	if !m.DevMode {
+		t.Error("Marketplace.DevMode should mirror the top-level DevMode")
+	}
+	if m.DevOverrideURL != "http://localhost:9999" {
+		t.Errorf("DevOverrideURL = %q", m.DevOverrideURL)
+	}
+	if m.HealthCheckTimeoutSec != 9 {
+		t.Errorf("HealthCheckTimeoutSec = %d", m.HealthCheckTimeoutSec)
+	}
+	if m.FallbackTimeoutSec != 42 {
+		t.Errorf("FallbackTimeoutSec = %d", m.FallbackTimeoutSec)
+	}
+	if cfg.Locales.Currency != "EUR" || cfg.Locales.CurrencySymbol != "€" {
+		t.Errorf("Locales currency = %+v", cfg.Locales)
+	}
+	if cfg.Locales.TaxRate != 19 {
+		t.Errorf("TaxRate = %d", cfg.Locales.TaxRate)
+	}
+	if cfg.Locales.TaxInclusive {
+		t.Error("TaxInclusive should be false")
+	}
+	if cfg.DefaultLocale != "de-DE" {
+		t.Errorf("DefaultLocale = %q", cfg.DefaultLocale)
+	}
+}
+
+// UT_MARKETPLACE_STORE_ID's own default is a NESTED getenv fallback onto
+// UT_STORE_NAME's resolved value (not a hardcoded literal) — easy to
+// regress silently since both env-var lookups happen on the same line.
+func TestInitMarketplaceStoreIDFallsBackToStoreName(t *testing.T) {
+	unsetForTest(t, configEnvKeys)
+	t.Setenv("UT_STORE_NAME", "My Custom Shop")
+
+	cfg, err := Init()
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if cfg.Marketplace.StoreID != "My Custom Shop" {
+		t.Errorf("Marketplace.StoreID = %q, want it to fall back to StoreName", cfg.Marketplace.StoreID)
+	}
+}

--- a/internal/config/i18n_overrides_test.go
+++ b/internal/config/i18n_overrides_test.go
@@ -65,3 +65,48 @@ func TestEntriesUnionAndSources(t *testing.T) {
 		t.Fatalf("only.base = %+v", e)
 	}
 }
+
+// SetOverlays (language-pack plugin translations) had zero direct test
+// coverage before this batch — only ever exercised transitively through T()
+// via a hand-built struct literal, never through the setter itself.
+func TestSetOverlaysReplacesAtomically(t *testing.T) {
+	i := newTestI18n(t)
+
+	if got := i.T("fa", "plugin.faq.menu"); got != "راهنما" {
+		t.Fatalf("base overlay = %q", got)
+	}
+	i.SetOverlays(map[string]map[string]string{
+		"fa": {"plugin.faq.menu": "پرسش‌ها"},
+	})
+	if got := i.T("fa", "plugin.faq.menu"); got != "پرسش‌ها" {
+		t.Fatalf("after SetOverlays = %q, want the new overlay value", got)
+	}
+	// A resync with nil (e.g. every plugin uninstalled) must clear existing
+	// overlays rather than panic on a nil map.
+	i.SetOverlays(nil)
+	if got := i.T("fa", "plugin.faq.menu"); got != "plugin.faq.menu" {
+		t.Fatalf("after SetOverlays(nil) = %q, want the untranslated key back", got)
+	}
+}
+
+// Available() had zero direct test coverage before this batch.
+func TestAvailableListsLocalesWithRealTranslations(t *testing.T) {
+	i := newTestI18n(t)
+	// "en"/"fa" both carry base messages; add an overlay-only locale and an
+	// empty one that must NOT count as "available" (len(m) > 0 gate).
+	i.SetOverlays(map[string]map[string]string{
+		"tr": {"basket.total": "Toplam"},
+		"de": {}, // present but empty: must not appear
+	})
+
+	got := i.Available()
+	want := []string{"en", "fa", "tr"}
+	if len(got) != len(want) {
+		t.Fatalf("Available() = %v, want %v", got, want)
+	}
+	for idx, w := range want {
+		if got[idx] != w {
+			t.Fatalf("Available() = %v, want %v (sorted)", got, want)
+		}
+	}
+}

--- a/internal/config/i18n_test.go
+++ b/internal/config/i18n_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"testing"
 	"testing/fstest"
@@ -61,5 +63,91 @@ func TestNewI18n_BackCompatWithOSDirectory(t *testing.T) {
 	}
 	if got := i18n.T("en", "hello"); got != "Hello" {
 		t.Fatalf("T(en, hello) = %q, want Hello", got)
+	}
+}
+
+// errOpenFS fails Open unconditionally — used to force fs.ReadDir's own
+// error branch, which no prior test (or NewI18nFS's happy path) ever hit.
+type errOpenFS struct{ err error }
+
+func (e errOpenFS) Open(string) (fs.File, error) { return nil, e.err }
+
+func TestNewI18nFS_ReadDirError(t *testing.T) {
+	_, err := NewI18nFS(errOpenFS{err: errors.New("boom")}, "en")
+	if err == nil {
+		t.Fatal("want an error when the FS can't be listed")
+	}
+}
+
+// A malformed locale file must be reported, not silently skipped or
+// partially loaded.
+func TestNewI18nFS_MalformedJSON(t *testing.T) {
+	fsys := fstest.MapFS{"en.json": &fstest.MapFile{Data: []byte(`{not valid json`)}}
+	_, err := NewI18nFS(fsys, "en")
+	if err == nil {
+		t.Fatal("want an error for malformed locale JSON")
+	}
+}
+
+// Non-JSON entries and subdirectories in the locales FS must be skipped,
+// not treated as locale files.
+func TestNewI18nFS_SkipsNonJSONAndDirs(t *testing.T) {
+	fsys := fstest.MapFS{
+		"en.json":      &fstest.MapFile{Data: []byte(`{"hello":"Hello"}`)},
+		"README.md":    &fstest.MapFile{Data: []byte(`not a locale`)},
+		"sub/note.txt": &fstest.MapFile{Data: []byte(`nested, not top-level`)},
+	}
+	i18n, err := NewI18nFS(fsys, "en")
+	if err != nil {
+		t.Fatalf("NewI18nFS: %v", err)
+	}
+	if got := i18n.T("en", "hello"); got != "Hello" {
+		t.Fatalf("T(en, hello) = %q", got)
+	}
+	if len(i18n.Available()) != 1 {
+		t.Fatalf("Available() = %v, want only en", i18n.Available())
+	}
+}
+
+// readFileErrFS lists one real entry via ReadDir but fails ReadFile for it —
+// forces NewI18nFS's own read-after-list error branch, distinct from a
+// directory-listing failure.
+type readFileErrFS struct{ fs.FS }
+
+func (r readFileErrFS) Open(name string) (fs.File, error) {
+	if name == "en.json" {
+		return nil, errors.New("simulated read failure")
+	}
+	return r.FS.Open(name)
+}
+
+func TestNewI18nFS_ReadFileError(t *testing.T) {
+	base := fstest.MapFS{"en.json": &fstest.MapFile{Data: []byte(`{"hello":"Hello"}`)}}
+	_, err := NewI18nFS(readFileErrFS{FS: base}, "en")
+	if err == nil {
+		t.Fatal("want an error when a listed locale file can't be read")
+	}
+}
+
+// If the fallback locale has no file of its own, NewI18nFS must still
+// succeed with an empty map for it (so T() never index-panics on a lookup
+// against the fallback), not error out.
+func TestNewI18nFS_MissingFallbackLocaleIsEmptyNotError(t *testing.T) {
+	fsys := fstest.MapFS{"tr.json": &fstest.MapFile{Data: []byte(`{"hello":"Merhaba"}`)}}
+	i18n, err := NewI18nFS(fsys, "en") // "en" has no file at all
+	if err != nil {
+		t.Fatalf("NewI18nFS: %v", err)
+	}
+	if got := i18n.T("en", "hello"); got != "hello" {
+		t.Fatalf("T(en, hello) = %q, want the bare key back (untranslated)", got)
+	}
+}
+
+// baseLang's region-stripping branch (idx > 0) is only exercised by a full
+// BCP-47 tag; every existing fixture uses bare base-language codes already.
+func TestT_FallsBackFromRegionTagToBaseLanguage(t *testing.T) {
+	i := newTestI18n(t)
+	if got := i.T("fa-IR", "basket.total"); got != "جمع" {
+		t.Fatalf("T(fa-IR, basket.total) = %q, want the fa base translation", got)
 	}
 }


### PR DESCRIPTION
## Summary

Batch 10 of the ongoing test-coverage push (see `ut-docs/QUEUE.md`).

- `internal/cloudsync`: 59.4% → **95.3%**. Full coverage of `Start()`'s background sync loop (previously 0%), `apply()`'s untested directive-dispatch branches (`remove_plugin` was never even exercised as a directive type), and the issue-report upload path (`uploadIssueReport`/`attachFile`, previously 0%/0%/30%).
- `internal/config`: 59.6% → **100.0%**. `Init`/`getenv` had zero direct coverage; `SetOverlays`/`Available` (both live-called) were untested; a few i18n edge branches rounded out to 100%.
- **Real gap proven, not a bug**: `pushSnapshotIfChanged`'s stock-quantity path was never actually exercised successfully by any prior test — the shared minimal test schema has no `stock_locations` table (which the repo query `LEFT JOIN`s), so the query silently errored every time and `qty` was always 0. New test uses a real migrated DB to prove real quantities flow through.
- **One production change**: `cloudsync.go`'s `tickInterval`/`firstDelay` moved from plain vars to `atomic.Int64`-backed accessors so `Start()`'s spawned goroutine and a test overriding them for speed don't race under `-race` (same default values/semantics, zero behavior change for the one real caller).

Independent review (different model, opus): **SAFE TO MERGE WITH FIXES** — all findings fixed pre-merge (mutation-tested `Start()` exit verification, a second latent race the fix surfaced, a tautological assertion, `t.Fatalf` in a non-test goroutine). Full record: `docs/code-reviews/2026-07-30-coverage-cloudsync-config.md`.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` clean (one pre-existing, unrelated failure confirmed via `git stash` — `internal/issuereport.TestSaveCleansUpDirectoryOnWriteFailure`, a root-permission sandbox artifact, not caused by this diff)
- [x] `go test ./internal/cloudsync/... ./internal/config/... -race -count=10` clean
- [x] `scripts/ci/guard-data-access.sh` / `scripts/ci/guard-i18n.sh` pass
- [x] Mutation-tested `Start()`'s two `ctx.Done()` branches (each individually re-broken and confirmed to now fail loudly)
- [x] Coverage independently re-measured: 95.3% / 100.0%

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01KzZ2Vs8K2u6HZD3dSVxYtg

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzZ2Vs8K2u6HZD3dSVxYtg)_