### PR TITLE
test: cover internal/settings + internal/pages/common (0% -> 84.6%/100%)

### DIFF
--- a/docs/code-reviews/2026-07-30-coverage-settings-pages-common.md
+++ b/docs/code-reviews/2026-07-30-coverage-settings-pages-common.md
@@ -1,0 +1,162 @@
+# Coverage batch 11: `internal/settings` + `internal/pages/common`
+
+**Date**: 2026-07-30
+**Branch**: `test-coverage-settings-pages-common`
+**Author**: autonomous SDLC pipeline (Sonnet)
+**Independent review**: opus (different model, subagent)
+
+## What shipped
+
+Continuation of the `ut-docs/QUEUE.md` test-coverage push
+(`internal/plugins` → `pages/catalog` → `data` batches 7–9 →
+`cloudsync`/`config` batch 10). The queue's own note named three 0%
+micro-packages as the next candidates: `internal/app`,
+`internal/settings`, `internal/pages/common`.
+
+**`internal/app` was scoped OUT of this batch** — it's already at
+**79.7%** coverage from PR #101's unrelated shutdown-join fix
+(`app_test.go` exists and covers `drainBackgroundServices`/`Run`'s
+early-error path). The queue note calling it a 0% candidate was stale;
+this is now corrected in the closing `QUEUE.md` entry.
+
+**`internal/settings`**: 0% → **84.6%**. Covers the thin `Store`
+wrapper (`Get`/`Set`/`All`) and `LoadRuntimeConfig`/`SaveRuntimeConfig`
+— the boot-time config↔DB-settings mapping (`internal/app/app.go:86-87`
+calls both back-to-back on every start).
+
+**`internal/pages/common`**: 0% → **100.0%**. Covers `Deps.CurrentState`/
+`UpdateState`/`SyncPrimaryURL`, and `state.go`'s `LoadState`/`SaveState`/
+`BuildMenu`.
+
+## Real bugs found and fixed, TDD-first
+
+1. **`LoadRuntimeConfig` currency_symbol mis-gated** (`runtime.go:26`,
+   originally): gated the `CurrencySymbol` assignment on
+   `if curr != ""` (the *currency* value) instead of
+   `if curr_symbol != ""` — a currency_symbol-only override (currency
+   itself unset) was silently dropped. Regression test written to fail
+   against the original code (confirmed), then fixed.
+
+2. **`SaveRuntimeConfig` wrote `tax_inclusive` to the wrong key**
+   (`runtime.go:64`, originally `"pos.tax_inclusive"`): `LoadRuntimeConfig`
+   (and `internal/pages/common`'s `KeyTaxInclusive`, the real
+   settings-admin UI's read/write key) both read `"store.tax_inclusive"`
+   — so a value written by `SaveRuntimeConfig` at boot was never read
+   back by anyone. Fixed to `"store.tax_inclusive"`. This closes a
+   known loose end flagged in `2026-07-14-first-boot-wizard.md` and
+   `2026-07-14-receipt-printing.md` (found independently by the
+   reviewer, not previously connected to this code path).
+   `internal/db/migrations/001_init.sql:564` separately seeds
+   `pos.tax_inclusive='false'` as an initial default row — that row is
+   now confirmed orphaned (nothing ever read it, before or after this
+   fix); left in place since migrations are append-only and the row is
+   inert. Logged as a follow-up in `QUEUE.md`.
+
+3. **`LoadState` silently discarded the cfg default on a garbage
+   stored value** (`state.go`, `TaxInclusive`/`AllowNegativeInventory`
+   only) — found by the independent reviewer, not the author.
+   `st.X, _ = strconv.ParseBool(v)` left the field at Go's zero value
+   (`false`) on a parse error instead of keeping cfg's default,
+   inconsistent with every sibling field (`TaxRate`/`UIScale`/
+   `IdleLock`/`KioskIdleReset`), which all guard on `err == nil` and
+   leave a pre-set default untouched on failure. Pre-existing bug, not
+   introduced by this batch. Fixed to match the sibling pattern
+   (pre-set `TaxInclusive` from `cfg.Locales.TaxInclusive` in the
+   `RuntimeState` literal, only overwrite on successful parse).
+   Verified failing-then-passing against both the original code and
+   the fix.
+
+## Independent review (opus) — verdict: SAFE TO MERGE WITH FIXES
+
+Ran the full gate itself rather than trusting the author's report:
+`go build`/`go vet` clean; `go test -race -count=1 -cover` green at the
+claimed 84.6%/100.0% (verified via `go tool cover -func`); both CI
+guards pass; full `go test ./... -race -count=1` green except one
+**pre-existing, unrelated** failure
+(`internal/issuereport TestSaveCleansUpDirectoryOnWriteFailure`,
+root-in-container bypasses the read-only-directory check the test
+relies on) — the reviewer independently confirmed this via a fresh
+`git worktree` on unmodified `main`, same failure.
+
+Independently re-verified both original bug-fix claims by reverting
+each production line, confirming a real assertion failure (not a
+compile error), then restoring and confirming green again.
+
+**Findings, all addressed**:
+- **F1/F2 (medium)** — the same seeded-default blind spot the author
+  had already caught and fixed once (for `currency_symbol`) was still
+  present in three other tests: `TestLoadRuntimeConfig_
+  EmptyStoreKeepsDefaults`, `TestLoadState_DefaultsWhenStoreEmpty`, and
+  (transitively) the unparsable-values test — `001_init.sql` seeds
+  `store.name`/`store.currency`, which coincide with `baseCfg()`'s
+  values, so removing the corresponding `if x != ""` guards in
+  production code wouldn't have failed any of these tests. Fixed with
+  two new targeted tests (`TestLoadRuntimeConfig_
+  EmptyNameKeepsCfgDefault`, `TestLoadState_
+  CurrencyFallsBackToCfgDefaultWhenUnset`) that explicitly delete the
+  seeded row via `data.NewSettingsRepo(db).Delete(...)` before
+  asserting — both independently mutation-probed by the author after
+  the fix and confirmed to fail against the reverted guard.
+- **F3 (medium → real bug)** — the `LoadState` zero-value discard bug
+  above; fixed, TDD-verified.
+- **F4 (low)** — `TestBuildMenu`'s "doesn't mutate the caller's slice"
+  assertion couldn't fail: a same-length composite literal always has
+  `len == cap`, so `append` reallocates regardless of whether
+  `BuildMenu` copies first. Fixed with a dedicated test giving the
+  base slice real spare capacity and a sentinel value at the
+  overwrite-risk index; mutation-probed (`items := base` instead of a
+  copy) and confirmed to fail.
+- **F5 (doc)** — noted here: after this fix, `UT_TAX_INCLUSIVE` becomes
+  DB-pinned from the first boot post-upgrade onward (the boot-time
+  Load→Save pattern materializes the row), same as `UT_CURRENCY`/
+  `UT_STORE_NAME`/`UT_TAX_RATE` already behave. Not a behavior change
+  in practice (those fields already worked this way; `tax_inclusive`
+  now joins them) and doesn't change any documented env-var contract
+  in `README.md`, so no README edit — recorded here per CLAUDE.md's
+  behaviour-change rule.
+- **F6 (process)** — this review record.
+- **F7 (nice-to-have)** — logged the orphaned `pos.tax_inclusive` seed
+  row cleanup as a `QUEUE.md` follow-up (a future append-only migration
+  `DELETE FROM settings WHERE key='pos.tax_inclusive'`).
+- **F8 (nice-to-have)** — added `TestSaveRuntimeConfig_
+  WritesExpectedKeys`, pinning the literal key names `SaveRuntimeConfig`
+  writes (can't reference `pages/common`'s `Key*` constants directly —
+  `common` imports `settings`, so that would be a cycle) so a future
+  key-name drift between the two packages fails loudly rather than the
+  way `pos.tax_inclusive`/`store.tax_inclusive` silently diverged.
+
+The reviewer also confirmed as genuine (its own independent mutation
+probes, not the author's): `TestDeps_StateMuSerializesConcurrentAccess`
+(removing the mutex produces a real `-race` failure),
+`TestSaveState_RoundTripsThroughLoadState` (swapping two field writes
+in `SaveState` fails with a clear diff), the repository-pattern
+compliance of the diff (zero raw SQL; `data.NewSettingsRepo(db).Delete`
+in tests is legitimate use of a pre-existing repo method), and the
+absence of real client/shop names or secret-shaped literals.
+
+**Accepted remainder, not pursued**: `internal/settings`'s uncovered
+~15.4% is `SaveRuntimeConfig`'s six near-identical
+`if err := s.Set(...); err != nil { return err }` branches past the
+first `Set` call. The reviewer confirmed a SQLite `CREATE TRIGGER …
+RAISE(ABORT)` *could* target any single branch and would pass CI (the
+data-access guard exempts `_test.go`), but rejected it as coverage
+theater — all six branches are byte-identical with no distinct
+behavior to verify. The reviewer's own suggested alternative (whether
+`SaveRuntimeConfig` should be transactional, so a mid-way failure
+doesn't leave keys 1..n-1 written and n..7 not) is a real but
+low-impact gap given the idempotent boot-time Load→Save usage —
+logged as a `QUEUE.md` follow-up rather than expanded here.
+
+## Verified beyond automated tests
+
+- `go test ./internal/pages/...` (the real production caller of
+  `LoadState`/`SaveState`, `internal/pages/init.go`,
+  `settings_page.go`, `setup_page.go`) re-run clean after the
+  `state.go` fix, under `-race`.
+- 8 mutation probes total across both packages (author: currency_symbol
+  guard, tax_inclusive key, name guard, currency fallback, BuildMenu
+  aliasing; reviewer: name-guard drop, currency-default drop, mutex
+  removal, SaveState field swap) — every one caught a real assertion
+  failure, none passed against broken code.
+- Full `go build ./...`, `go vet ./...`, both CI guards
+  (`guard-data-access.sh`, `guard-i18n.sh`) green.

--- a/internal/pages/common/deps_test.go
+++ b/internal/pages/common/deps_test.go
@@ -1,0 +1,87 @@
+package common
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestDeps_CurrentStateReturnsCopy(t *testing.T) {
+	d := &Deps{State: RuntimeState{Theme: "dark"}}
+
+	got := d.CurrentState()
+	if got.Theme != "dark" {
+		t.Fatalf("CurrentState().Theme = %q, want %q", got.Theme, "dark")
+	}
+
+	// Mutating the returned copy must not affect Deps' own state.
+	got.Theme = "light"
+	if d.State.Theme != "dark" {
+		t.Fatalf("Deps.State.Theme = %q after mutating a CurrentState() copy, want unchanged %q", d.State.Theme, "dark")
+	}
+}
+
+func TestDeps_UpdateStateAppliesAndReturns(t *testing.T) {
+	d := &Deps{State: RuntimeState{Theme: "dark"}}
+
+	got := d.UpdateState(func(s *RuntimeState) { s.Theme = "light" })
+
+	if got.Theme != "light" {
+		t.Fatalf("UpdateState return = %q, want %q", got.Theme, "light")
+	}
+	if d.State.Theme != "light" {
+		t.Fatalf("Deps.State.Theme = %q after UpdateState, want %q", d.State.Theme, "light")
+	}
+}
+
+// StateMu must actually serialize concurrent readers/writers — this is the
+// exact concurrency guarantee the field's own doc comment promises
+// ("settings handlers replace fields while every request renders from
+// them"). Run under -race to prove it.
+func TestDeps_StateMuSerializesConcurrentAccess(t *testing.T) {
+	d := &Deps{}
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func(n int) {
+			defer wg.Done()
+			d.UpdateState(func(s *RuntimeState) { s.TaxRatePct = n })
+		}(i)
+		go func() {
+			defer wg.Done()
+			_ = d.CurrentState()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestDeps_SyncPrimaryURL_NilSettings(t *testing.T) {
+	d := &Deps{}
+	if got := d.SyncPrimaryURL(context.Background()); got != "" {
+		t.Fatalf("SyncPrimaryURL with nil Settings = %q, want empty", got)
+	}
+}
+
+func TestDeps_SyncPrimaryURL_TrimsAndReturnsValue(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	if err := store.Set(ctx, "sync.primary_url", "  https://primary.local  "); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	d := &Deps{Settings: store}
+
+	got := d.SyncPrimaryURL(ctx)
+	if got != "https://primary.local" {
+		t.Fatalf("SyncPrimaryURL = %q, want trimmed %q", got, "https://primary.local")
+	}
+}
+
+func TestDeps_SyncPrimaryURL_EmptyWhenUnset(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	d := &Deps{Settings: store}
+
+	if got := d.SyncPrimaryURL(ctx); got != "" {
+		t.Fatalf("SyncPrimaryURL with unset key = %q, want empty", got)
+	}
+}

--- a/internal/pages/common/state.go
+++ b/internal/pages/common/state.go
@@ -48,11 +48,14 @@ func LoadState(ctx context.Context, store *settings.Store, cfg *config.Config) R
 		Country:                get(KeyCountry, "GB"),
 		Region:                 get(KeyRegion, ""),
 		TaxRatePct:             cfg.Locales.TaxRate,
+		TaxInclusive:           cfg.Locales.TaxInclusive,
 		AllowNegativeInventory: false,
 	}
 
 	if v := get(KeyTaxInclusive, strconv.FormatBool(cfg.Locales.TaxInclusive)); v != "" {
-		st.TaxInclusive, _ = strconv.ParseBool(v)
+		if b, err := strconv.ParseBool(v); err == nil {
+			st.TaxInclusive = b
+		}
 	}
 	if v := get(KeyUIScale, ""); v != "" {
 		if f, err := strconv.ParseFloat(v, 64); err == nil {
@@ -65,7 +68,9 @@ func LoadState(ctx context.Context, store *settings.Store, cfg *config.Config) R
 		}
 	}
 	if v := get("pos.allow_negative_inventory", strconv.FormatBool(st.AllowNegativeInventory)); v != "" {
-		st.AllowNegativeInventory, _ = strconv.ParseBool(v)
+		if b, err := strconv.ParseBool(v); err == nil {
+			st.AllowNegativeInventory = b
+		}
 	}
 	st.IdleLockMinutes = DefaultIdleLockMinutes
 	if v := get(KeyIdleLock, ""); v != "" {

--- a/internal/pages/common/state_test.go
+++ b/internal/pages/common/state_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/universaltill/universal-till/internal/config"
+	"github.com/universaltill/universal-till/internal/data"
 	"github.com/universaltill/universal-till/internal/db"
 	"github.com/universaltill/universal-till/internal/plugins"
 	"github.com/universaltill/universal-till/internal/settings"
@@ -157,21 +158,34 @@ func TestLoadState_NegativeOverridesIgnored(t *testing.T) {
 	}
 }
 
-// A non-numeric stored value must not panic or corrupt state — LoadState
-// silently falls back rather than propagating a parse error.
-func TestLoadState_UnparsableValuesFallBackSilently(t *testing.T) {
+// A non-numeric/non-bool stored value must not panic or corrupt state —
+// LoadState silently falls back to the cfg default rather than propagating
+// a parse error. Uses a cfg whose TaxInclusive default is TRUE specifically
+// so this is a real proof, not a coincidence: strconv.ParseBool/Atoi/
+// ParseFloat's own error-path zero values (false/0/0.0) all happen to equal
+// this package's OTHER defaults, so a naive assertion here could pass even
+// if LoadState discarded the cfg default and fell through to a bare zero
+// value instead of actually keeping it (a real bug this test caught in
+// TaxInclusive/AllowNegativeInventory: they used to do exactly that, via
+// `st.TaxInclusive, _ = strconv.ParseBool(v)` swallowing the error and
+// leaving the zero value — fixed to guard on `err == nil` like every
+// sibling field already does).
+func TestLoadState_UnparsableValuesFallBackToCfgDefault(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)
-	for _, k := range []string{KeyTaxInclusive, KeyUIScale, KeyTaxRate, KeyIdleLock, KeyKioskIdleReset} {
+	for _, k := range []string{KeyTaxInclusive, KeyUIScale, KeyTaxRate, KeyIdleLock, KeyKioskIdleReset, "pos.allow_negative_inventory"} {
 		if err := store.Set(ctx, k, "not-a-number"); err != nil {
 			t.Fatalf("seed %s: %v", k, err)
 		}
 	}
 
-	st := LoadState(ctx, store, baseCfg())
+	cfg := baseCfg()
+	cfg.Locales.TaxInclusive = true // distinguishes "kept the cfg default" from "fell to the zero value"
 
-	if st.TaxInclusive {
-		t.Errorf("TaxInclusive = true from unparsable value, want default false")
+	st := LoadState(ctx, store, cfg)
+
+	if !st.TaxInclusive {
+		t.Errorf("TaxInclusive = false from an unparsable stored value, want cfg default true (must not silently discard it)")
 	}
 	if st.UIScale != 0 {
 		t.Errorf("UIScale = %v from unparsable value, want 0", st.UIScale)
@@ -184,6 +198,38 @@ func TestLoadState_UnparsableValuesFallBackSilently(t *testing.T) {
 	}
 	if st.KioskIdleResetSeconds != DefaultKioskIdleResetSeconds {
 		t.Errorf("KioskIdleResetSeconds = %d from unparsable value, want default %d", st.KioskIdleResetSeconds, DefaultKioskIdleResetSeconds)
+	}
+	// AllowNegativeInventory's own "default" is a fixed false, not cfg-derived,
+	// so an unparsable value must still leave it at that same false — this
+	// assertion alone can't distinguish the bug (false is both the buggy
+	// zero-value AND the correct default here), which is exactly why
+	// TaxInclusive above is pinned to true instead.
+	if st.AllowNegativeInventory {
+		t.Errorf("AllowNegativeInventory = true from unparsable value, want default false")
+	}
+}
+
+// 001_init.sql seeds "store.currency"='GBP' by default, and baseCfg() also
+// uses "GBP" — so every other LoadState test in this file can't actually
+// distinguish "fell back to cfg.Locales.Currency" from "read the seeded
+// row" for the Currency field. Clear the seeded row and use a cfg default
+// that couldn't be confused with it, so this one genuinely proves the
+// get(KeyCurrency, cfg.Locales.Currency) wiring, not just its coincidental
+// agreement with the migration's own default.
+func TestLoadState_CurrencyFallsBackToCfgDefaultWhenUnset(t *testing.T) {
+	ctx := context.Background()
+	d := openMigratedDB(t, "state.db")
+	store := settings.NewStore(d.DB)
+	if err := data.NewSettingsRepo(d.DB).Delete(ctx, KeyCurrency); err != nil {
+		t.Fatalf("clear seeded default: %v", err)
+	}
+
+	cfg := baseCfg()
+	cfg.Locales.Currency = "JPY"
+
+	st := LoadState(ctx, store, cfg)
+	if st.Currency != "JPY" {
+		t.Fatalf("Currency = %q, want cfg default %q when store.currency is genuinely unset", st.Currency, "JPY")
 	}
 }
 
@@ -262,10 +308,32 @@ func TestBuildMenu(t *testing.T) {
 	if got[1] != want {
 		t.Errorf("BuildMenu()[1] = %+v, want %+v", got[1], want)
 	}
+}
 
-	// The base slice itself must not be mutated (BuildMenu appends to a copy).
+// BuildMenu must not write into the caller's backing array — a naive
+// `items := base` (rather than a fresh copy) would only be caught if base
+// has spare capacity, since Go's append reuses backing storage when it
+// fits. A same-length composite literal always has len==cap, so append
+// reallocates regardless of whether BuildMenu copies first — this test
+// gives base real spare capacity via a sentinel so a missing copy is
+// actually observable.
+func TestBuildMenu_DoesNotWriteIntoCallersBackingArray(t *testing.T) {
+	backing := make([]MenuItem, 2, 4)
+	backing[0] = MenuItem{Href: "/", Label: "Home"}
+	sentinel := MenuItem{Href: "/sentinel", Label: "Sentinel"}
+	backing[1] = sentinel
+	base := backing[:1] // len 1, cap 4 — plenty of room for append to reuse in place
+
+	pm := &plugins.Manager{MenuPlugins: map[string]plugins.MenuPlugin{
+		"a": {Route: "/plugin-a", Label: "Plugin A"},
+	}}
+	_ = BuildMenu(base, pm)
+
+	if backing[1] != sentinel {
+		t.Fatalf("BuildMenu overwrote the caller's backing array at index 1: got %+v, want untouched sentinel %+v", backing[1], sentinel)
+	}
 	if len(base) != 1 {
-		t.Fatalf("BuildMenu mutated the caller's base slice: len=%d, want 1", len(base))
+		t.Fatalf("BuildMenu mutated the caller's base slice header: len=%d, want 1", len(base))
 	}
 }
 

--- a/internal/pages/common/state_test.go
+++ b/internal/pages/common/state_test.go
@@ -1,0 +1,281 @@
+package common
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/config"
+	"github.com/universaltill/universal-till/internal/db"
+	"github.com/universaltill/universal-till/internal/plugins"
+	"github.com/universaltill/universal-till/internal/settings"
+)
+
+// openMigratedDB gives the test a real, fully migrated schema — same
+// pattern as internal/data and internal/cloudsync's own test helpers.
+func openMigratedDB(t *testing.T, name string) *db.DB {
+	t.Helper()
+	d, err := db.Open(filepath.Join(t.TempDir(), name))
+	if err != nil {
+		t.Fatalf("open %s: %v", name, err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+func newTestStore(t *testing.T) *settings.Store {
+	t.Helper()
+	return settings.NewStore(openMigratedDB(t, "state.db").DB)
+}
+
+func baseCfg() *config.Config {
+	return &config.Config{
+		Theme: "monarch",
+		Locales: config.Locales{
+			Currency: "GBP",
+			TaxRate:  2000,
+		},
+	}
+}
+
+func TestLoadState_DefaultsWhenStoreEmpty(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	cfg := baseCfg()
+
+	st := LoadState(ctx, store, cfg)
+
+	if st.Theme != "monarch" {
+		t.Errorf("Theme = %q, want cfg default %q", st.Theme, "monarch")
+	}
+	if st.Currency != "GBP" {
+		t.Errorf("Currency = %q, want cfg default %q", st.Currency, "GBP")
+	}
+	if st.Country != "GB" {
+		t.Errorf("Country = %q, want hardcoded default %q", st.Country, "GB")
+	}
+	if st.TaxRatePct != 2000 {
+		t.Errorf("TaxRatePct = %d, want cfg default 2000", st.TaxRatePct)
+	}
+	if st.TaxInclusive {
+		t.Errorf("TaxInclusive = true, want cfg default false")
+	}
+	if st.AllowNegativeInventory {
+		t.Errorf("AllowNegativeInventory = true, want default false")
+	}
+	if st.IdleLockMinutes != DefaultIdleLockMinutes {
+		t.Errorf("IdleLockMinutes = %d, want default %d", st.IdleLockMinutes, DefaultIdleLockMinutes)
+	}
+	if st.OSKMode != "auto" {
+		t.Errorf("OSKMode = %q, want default %q", st.OSKMode, "auto")
+	}
+	if st.KioskIdleResetSeconds != DefaultKioskIdleResetSeconds {
+		t.Errorf("KioskIdleResetSeconds = %d, want default %d", st.KioskIdleResetSeconds, DefaultKioskIdleResetSeconds)
+	}
+	if st.UIScale != 0 {
+		t.Errorf("UIScale = %v, want 0 (unset) when never configured", st.UIScale)
+	}
+}
+
+func TestLoadState_OverridesFromStore(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	for k, v := range map[string]string{
+		KeyTheme:                       "dark",
+		KeyCurrency:                    "EUR",
+		KeyCountry:                     "DE",
+		KeyRegion:                      "BY",
+		KeyTaxInclusive:                "true",
+		KeyUIScale:                     "1.75",
+		KeyTaxRate:                     "1900",
+		"pos.allow_negative_inventory": "true",
+		KeyIdleLock:                    "15",
+		KeyOSK:                         "on",
+		KeyKioskIdleReset:              "120",
+	} {
+		if err := store.Set(ctx, k, v); err != nil {
+			t.Fatalf("seed %s: %v", k, err)
+		}
+	}
+
+	st := LoadState(ctx, store, baseCfg())
+
+	if st.Theme != "dark" {
+		t.Errorf("Theme = %q, want %q", st.Theme, "dark")
+	}
+	if st.Currency != "EUR" {
+		t.Errorf("Currency = %q, want %q", st.Currency, "EUR")
+	}
+	if st.Country != "DE" {
+		t.Errorf("Country = %q, want %q", st.Country, "DE")
+	}
+	if st.Region != "BY" {
+		t.Errorf("Region = %q, want %q", st.Region, "BY")
+	}
+	if !st.TaxInclusive {
+		t.Errorf("TaxInclusive = false, want true")
+	}
+	if st.UIScale != 1.75 {
+		t.Errorf("UIScale = %v, want 1.75", st.UIScale)
+	}
+	if st.TaxRatePct != 1900 {
+		t.Errorf("TaxRatePct = %d, want 1900", st.TaxRatePct)
+	}
+	if !st.AllowNegativeInventory {
+		t.Errorf("AllowNegativeInventory = false, want true")
+	}
+	if st.IdleLockMinutes != 15 {
+		t.Errorf("IdleLockMinutes = %d, want 15", st.IdleLockMinutes)
+	}
+	if st.OSKMode != "on" {
+		t.Errorf("OSKMode = %q, want %q", st.OSKMode, "on")
+	}
+	if st.KioskIdleResetSeconds != 120 {
+		t.Errorf("KioskIdleResetSeconds = %d, want 120", st.KioskIdleResetSeconds)
+	}
+}
+
+// A negative stored idle-lock/kiosk-reset value must not override the
+// positive default — both guard with "n >= 0" specifically to reject that.
+func TestLoadState_NegativeOverridesIgnored(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	if err := store.Set(ctx, KeyIdleLock, "-5"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := store.Set(ctx, KeyKioskIdleReset, "-1"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	st := LoadState(ctx, store, baseCfg())
+
+	if st.IdleLockMinutes != DefaultIdleLockMinutes {
+		t.Errorf("IdleLockMinutes = %d, want default %d (negative override must be rejected)", st.IdleLockMinutes, DefaultIdleLockMinutes)
+	}
+	if st.KioskIdleResetSeconds != DefaultKioskIdleResetSeconds {
+		t.Errorf("KioskIdleResetSeconds = %d, want default %d (negative override must be rejected)", st.KioskIdleResetSeconds, DefaultKioskIdleResetSeconds)
+	}
+}
+
+// A non-numeric stored value must not panic or corrupt state — LoadState
+// silently falls back rather than propagating a parse error.
+func TestLoadState_UnparsableValuesFallBackSilently(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	for _, k := range []string{KeyTaxInclusive, KeyUIScale, KeyTaxRate, KeyIdleLock, KeyKioskIdleReset} {
+		if err := store.Set(ctx, k, "not-a-number"); err != nil {
+			t.Fatalf("seed %s: %v", k, err)
+		}
+	}
+
+	st := LoadState(ctx, store, baseCfg())
+
+	if st.TaxInclusive {
+		t.Errorf("TaxInclusive = true from unparsable value, want default false")
+	}
+	if st.UIScale != 0 {
+		t.Errorf("UIScale = %v from unparsable value, want 0", st.UIScale)
+	}
+	if st.TaxRatePct != 2000 {
+		t.Errorf("TaxRatePct = %d from unparsable value, want cfg default 2000", st.TaxRatePct)
+	}
+	if st.IdleLockMinutes != DefaultIdleLockMinutes {
+		t.Errorf("IdleLockMinutes = %d from unparsable value, want default %d", st.IdleLockMinutes, DefaultIdleLockMinutes)
+	}
+	if st.KioskIdleResetSeconds != DefaultKioskIdleResetSeconds {
+		t.Errorf("KioskIdleResetSeconds = %d from unparsable value, want default %d", st.KioskIdleResetSeconds, DefaultKioskIdleResetSeconds)
+	}
+}
+
+func TestSaveState_RoundTripsThroughLoadState(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	want := RuntimeState{
+		Theme:                  "dark",
+		Currency:               "EUR",
+		Country:                "DE",
+		Region:                 "BY",
+		TaxInclusive:           true,
+		TaxRatePct:             1900,
+		AllowNegativeInventory: true,
+		UIScale:                1.5,
+		IdleLockMinutes:        20,
+		OSKMode:                "off",
+		KioskIdleResetSeconds:  45,
+	}
+
+	SaveState(ctx, store, want)
+	got := LoadState(ctx, store, baseCfg())
+
+	if got != want {
+		t.Fatalf("round trip mismatch: got %+v, want %+v", got, want)
+	}
+}
+
+// SaveState only writes UIScale when it's > 0 — 0 means "unset, use the
+// browser/kiosk default", not "explicitly zero scale". Confirm a
+// previously-saved nonzero scale isn't clobbered by a later save with 0.
+func TestSaveState_ZeroUIScaleDoesNotClobberPriorValue(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	SaveState(ctx, store, RuntimeState{UIScale: 1.5})
+	SaveState(ctx, store, RuntimeState{UIScale: 0})
+
+	st := LoadState(ctx, store, baseCfg())
+	if st.UIScale != 1.5 {
+		t.Fatalf("UIScale = %v after a zero-value save, want the untouched prior value 1.5", st.UIScale)
+	}
+}
+
+// SaveState only writes OSKMode when non-empty, matching UIScale's guard.
+func TestSaveState_EmptyOSKModeDoesNotClobberPriorValue(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	SaveState(ctx, store, RuntimeState{OSKMode: "on"})
+	SaveState(ctx, store, RuntimeState{OSKMode: ""})
+
+	st := LoadState(ctx, store, baseCfg())
+	if st.OSKMode != "on" {
+		t.Fatalf("OSKMode = %q after an empty-value save, want the untouched prior value %q", st.OSKMode, "on")
+	}
+}
+
+func TestBuildMenu(t *testing.T) {
+	base := []MenuItem{{Href: "/", Label: "Home"}}
+	pm := &plugins.Manager{
+		MenuPlugins: map[string]plugins.MenuPlugin{
+			"a": {Route: "/plugin-a", Label: "Plugin A"},
+			"b": {Route: "", Label: "No Route"},  // must be skipped
+			"c": {Route: "/plugin-c", Label: ""}, // must be skipped
+		},
+	}
+
+	got := BuildMenu(base, pm)
+
+	if len(got) != 2 {
+		t.Fatalf("BuildMenu returned %d items, want 2 (base + 1 valid plugin): %+v", len(got), got)
+	}
+	if got[0] != base[0] {
+		t.Errorf("BuildMenu()[0] = %+v, want unchanged base item %+v", got[0], base[0])
+	}
+	want := MenuItem{Href: "/plugin-a", Label: "Plugin A"}
+	if got[1] != want {
+		t.Errorf("BuildMenu()[1] = %+v, want %+v", got[1], want)
+	}
+
+	// The base slice itself must not be mutated (BuildMenu appends to a copy).
+	if len(base) != 1 {
+		t.Fatalf("BuildMenu mutated the caller's base slice: len=%d, want 1", len(base))
+	}
+}
+
+func TestBuildMenu_EmptyPlugins(t *testing.T) {
+	base := []MenuItem{{Href: "/", Label: "Home"}}
+	pm := &plugins.Manager{}
+
+	got := BuildMenu(base, pm)
+
+	if len(got) != 1 || got[0] != base[0] {
+		t.Fatalf("BuildMenu with no plugins = %+v, want just the base item", got)
+	}
+}

--- a/internal/settings/runtime.go
+++ b/internal/settings/runtime.go
@@ -23,7 +23,7 @@ func (s *Store) LoadRuntimeConfig(ctx context.Context, cfg *config.Config) {
 	}
 
 	curr_symbol, _, _ := s.Get(ctx, "store.currency_symbol")
-	if curr != "" {
+	if curr_symbol != "" {
 		cfg.Locales.CurrencySymbol = curr_symbol
 	}
 
@@ -61,7 +61,7 @@ func (s *Store) SaveRuntimeConfig(ctx context.Context, cfg *config.Config) error
 	if err := s.Set(ctx, "store.locale", cfg.Locales.Locale); err != nil {
 		return err
 	}
-	if err := s.Set(ctx, "pos.tax_inclusive", strconv.FormatBool(cfg.Locales.TaxInclusive)); err != nil {
+	if err := s.Set(ctx, "store.tax_inclusive", strconv.FormatBool(cfg.Locales.TaxInclusive)); err != nil {
 		return err
 	}
 	if err := s.Set(ctx, "store.tax_rate", strconv.Itoa(cfg.Locales.TaxRate)); err != nil {

--- a/internal/settings/runtime_test.go
+++ b/internal/settings/runtime_test.go
@@ -1,0 +1,219 @@
+package settings
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/config"
+	"github.com/universaltill/universal-till/internal/db"
+)
+
+// openMigratedDB gives the test a real, fully migrated schema — same
+// pattern as internal/data and internal/cloudsync's own test helpers.
+func openMigratedDB(t *testing.T, name string) *db.DB {
+	t.Helper()
+	d, err := db.Open(filepath.Join(t.TempDir(), name))
+	if err != nil {
+		t.Fatalf("open %s: %v", name, err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	return NewStore(openMigratedDB(t, "settings.db").DB)
+}
+
+func TestStore_GetSetAll(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	// "theme" is not one of 001_init.sql's seeded defaults (store.name,
+	// store.currency, pos.tax_inclusive), so it's genuinely absent here.
+	if _, ok, err := s.Get(ctx, "theme"); err != nil || ok {
+		t.Fatalf("Get(theme) before any Set = ok=%v err=%v, want ok=false err=nil", ok, err)
+	}
+
+	if err := s.Set(ctx, "theme", "dark"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	v, ok, err := s.Get(ctx, "theme")
+	if err != nil || !ok || v != "dark" {
+		t.Fatalf("Get(theme) = %q ok=%v err=%v, want %q ok=true", v, ok, err, "dark")
+	}
+
+	// ON CONFLICT update, not a duplicate row.
+	if err := s.Set(ctx, "theme", "light"); err != nil {
+		t.Fatalf("Set overwrite: %v", err)
+	}
+
+	all, err := s.All(ctx)
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if all["theme"] != "light" {
+		t.Fatalf("All()[theme] = %q, want %q (Set must UPDATE on conflict, not insert a second row)", all["theme"], "light")
+	}
+}
+
+func baseCfg() *config.Config {
+	return &config.Config{
+		Theme:     "monarch",
+		StoreName: "My Store",
+		Locales: config.Locales{
+			Currency:       "GBP",
+			CurrencySymbol: "£",
+			Locale:         "en-GB",
+			TaxRate:        2000,
+			TaxInclusive:   false,
+		},
+	}
+}
+
+// Beyond 001_init.sql's own seeded rows (store.name, store.currency,
+// pos.tax_inclusive — which happen to already match baseCfg's values, and
+// pos.tax_inclusive isn't a key LoadRuntimeConfig reads at all), nothing
+// else is in the DB: every other field must keep whatever the caller's cfg
+// already had (env/default-derived), not get zeroed out.
+func TestLoadRuntimeConfig_EmptyStoreKeepsDefaults(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	cfg := baseCfg()
+	want := *cfg
+
+	s.LoadRuntimeConfig(ctx, cfg)
+
+	if *cfg != want {
+		t.Fatalf("LoadRuntimeConfig mutated cfg from an empty store: got %+v, want %+v", *cfg, want)
+	}
+}
+
+func TestLoadRuntimeConfig_OverridesFromStore(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	for k, v := range map[string]string{
+		"theme":                 "dark",
+		"store.name":            "Farshid's Shop",
+		"store.currency":        "EUR",
+		"store.currency_symbol": "€",
+		"store.locale":          "de-DE",
+		"store.tax_inclusive":   "true",
+		"store.tax_rate":        "1900",
+	} {
+		if err := s.Set(ctx, k, v); err != nil {
+			t.Fatalf("seed %s: %v", k, err)
+		}
+	}
+
+	cfg := baseCfg()
+	s.LoadRuntimeConfig(ctx, cfg)
+
+	if cfg.Theme != "dark" {
+		t.Errorf("Theme = %q, want %q", cfg.Theme, "dark")
+	}
+	if cfg.StoreName != "Farshid's Shop" {
+		t.Errorf("StoreName = %q, want %q", cfg.StoreName, "Farshid's Shop")
+	}
+	if cfg.Locales.Currency != "EUR" {
+		t.Errorf("Currency = %q, want %q", cfg.Locales.Currency, "EUR")
+	}
+	if cfg.Locales.CurrencySymbol != "€" {
+		t.Errorf("CurrencySymbol = %q, want %q", cfg.Locales.CurrencySymbol, "€")
+	}
+	if cfg.Locales.Locale != "de-DE" {
+		t.Errorf("Locale = %q, want %q", cfg.Locales.Locale, "de-DE")
+	}
+	if !cfg.Locales.TaxInclusive {
+		t.Errorf("TaxInclusive = false, want true")
+	}
+	if cfg.Locales.TaxRate != 1900 {
+		t.Errorf("TaxRate = %d, want 1900", cfg.Locales.TaxRate)
+	}
+}
+
+// Regression: LoadRuntimeConfig used to gate the currency_symbol assignment
+// on whether "store.currency" was set, not "store.currency_symbol" — so a
+// symbol-only override (currency itself left at its cfg default) was
+// silently dropped. Currency and its symbol are independent settings keys
+// and must be loaded independently.
+func TestLoadRuntimeConfig_CurrencySymbolIndependentOfCurrency(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	if err := s.Set(ctx, "store.currency_symbol", "kr"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// deliberately do NOT set store.currency — cfg.Locales.Currency stays
+	// at its baseCfg default ("GBP")
+
+	cfg := baseCfg()
+	s.LoadRuntimeConfig(ctx, cfg)
+
+	if cfg.Locales.CurrencySymbol != "kr" {
+		t.Fatalf("CurrencySymbol = %q, want %q (a currency_symbol-only override must not be ignored)", cfg.Locales.CurrencySymbol, "kr")
+	}
+	if cfg.Locales.Currency != "GBP" {
+		t.Fatalf("Currency = %q, want unchanged default %q", cfg.Locales.Currency, "GBP")
+	}
+}
+
+// SaveRuntimeConfig must persist under the exact keys LoadRuntimeConfig
+// reads back — otherwise a value written at boot is never seen again.
+// Regression: tax_inclusive was written to "pos.tax_inclusive" while
+// LoadRuntimeConfig (and pages/common's KeyTaxInclusive, the real
+// settings-admin path) both read "store.tax_inclusive", so a saved value
+// was silently orphaned and never round-tripped.
+func TestSaveRuntimeConfig_RoundTripsThroughLoad(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	cfg := baseCfg()
+	cfg.Theme = "dark"
+	cfg.StoreName = "Farshid's Shop"
+	cfg.Locales.Currency = "EUR"
+	cfg.Locales.CurrencySymbol = "€"
+	cfg.Locales.Locale = "de-DE"
+	cfg.Locales.TaxInclusive = true
+	cfg.Locales.TaxRate = 1900
+
+	if err := s.SaveRuntimeConfig(ctx, cfg); err != nil {
+		t.Fatalf("SaveRuntimeConfig: %v", err)
+	}
+
+	reloaded := baseCfg()
+	*reloaded = config.Config{} // zero it so Load must actually populate every field from the store
+	s.LoadRuntimeConfig(ctx, reloaded)
+
+	if reloaded.Theme != cfg.Theme {
+		t.Errorf("Theme round-trip = %q, want %q", reloaded.Theme, cfg.Theme)
+	}
+	if reloaded.StoreName != cfg.StoreName {
+		t.Errorf("StoreName round-trip = %q, want %q", reloaded.StoreName, cfg.StoreName)
+	}
+	if reloaded.Locales.Currency != cfg.Locales.Currency {
+		t.Errorf("Currency round-trip = %q, want %q", reloaded.Locales.Currency, cfg.Locales.Currency)
+	}
+	if reloaded.Locales.CurrencySymbol != cfg.Locales.CurrencySymbol {
+		t.Errorf("CurrencySymbol round-trip = %q, want %q", reloaded.Locales.CurrencySymbol, cfg.Locales.CurrencySymbol)
+	}
+	if reloaded.Locales.Locale != cfg.Locales.Locale {
+		t.Errorf("Locale round-trip = %q, want %q", reloaded.Locales.Locale, cfg.Locales.Locale)
+	}
+	if reloaded.Locales.TaxInclusive != cfg.Locales.TaxInclusive {
+		t.Errorf("TaxInclusive round-trip = %v, want %v", reloaded.Locales.TaxInclusive, cfg.Locales.TaxInclusive)
+	}
+	if reloaded.Locales.TaxRate != cfg.Locales.TaxRate {
+		t.Errorf("TaxRate round-trip = %d, want %d", reloaded.Locales.TaxRate, cfg.Locales.TaxRate)
+	}
+}
+
+func TestSaveRuntimeConfig_PropagatesRepoError(t *testing.T) {
+	ctx := context.Background()
+	d := openMigratedDB(t, "settings.db")
+	s := NewStore(d.DB)
+	d.Close() // force every subsequent Set to fail
+
+	if err := s.SaveRuntimeConfig(ctx, baseCfg()); err == nil {
+		t.Fatal("SaveRuntimeConfig on a closed DB returned nil error, want non-nil")
+	}
+}

--- a/internal/settings/runtime_test.go
+++ b/internal/settings/runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/universaltill/universal-till/internal/config"
+	"github.com/universaltill/universal-till/internal/data"
 	"github.com/universaltill/universal-till/internal/db"
 )
 
@@ -135,17 +136,26 @@ func TestLoadRuntimeConfig_OverridesFromStore(t *testing.T) {
 
 // Regression: LoadRuntimeConfig used to gate the currency_symbol assignment
 // on whether "store.currency" was set, not "store.currency_symbol" — so a
-// symbol-only override (currency itself left at its cfg default) was
-// silently dropped. Currency and its symbol are independent settings keys
-// and must be loaded independently.
+// symbol-only override (currency itself genuinely unset) was silently
+// dropped. Currency and its symbol are independent settings keys and must
+// be loaded independently.
 func TestLoadRuntimeConfig_CurrencySymbolIndependentOfCurrency(t *testing.T) {
 	ctx := context.Background()
-	s := newTestStore(t)
+	d := openMigratedDB(t, "settings.db")
+	s := NewStore(d.DB)
+
+	// 001_init.sql seeds "store.currency"='GBP' by default — clear it so
+	// this test genuinely exercises "currency unset, symbol set" rather
+	// than accidentally passing because the seeded default is non-empty
+	// (which is exactly what let the original buggy `if curr != ""` guard
+	// slip through: curr is never actually empty in a fresh migrated DB).
+	repo := data.NewSettingsRepo(d.DB)
+	if err := repo.Delete(ctx, "store.currency"); err != nil {
+		t.Fatalf("clear seeded default: %v", err)
+	}
 	if err := s.Set(ctx, "store.currency_symbol", "kr"); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	// deliberately do NOT set store.currency — cfg.Locales.Currency stays
-	// at its baseCfg default ("GBP")
 
 	cfg := baseCfg()
 	s.LoadRuntimeConfig(ctx, cfg)

--- a/internal/settings/runtime_test.go
+++ b/internal/settings/runtime_test.go
@@ -217,6 +217,59 @@ func TestSaveRuntimeConfig_RoundTripsThroughLoad(t *testing.T) {
 	}
 }
 
+// 001_init.sql seeds "store.name"='My Store' by default, and baseCfg() also
+// uses "My Store" — so TestLoadRuntimeConfig_EmptyStoreKeepsDefaults can't
+// actually distinguish "kept cfg.StoreName" from "read the seeded row" for
+// this field (an independent review of this batch caught the same blind
+// spot the currency_symbol test above was already fixed for). Clear the
+// seeded row and use a cfg value that couldn't be confused with it.
+func TestLoadRuntimeConfig_EmptyNameKeepsCfgDefault(t *testing.T) {
+	ctx := context.Background()
+	d := openMigratedDB(t, "settings.db")
+	s := NewStore(d.DB)
+	if err := data.NewSettingsRepo(d.DB).Delete(ctx, "store.name"); err != nil {
+		t.Fatalf("clear seeded default: %v", err)
+	}
+
+	cfg := baseCfg()
+	cfg.StoreName = "Farshid's Shop"
+	s.LoadRuntimeConfig(ctx, cfg)
+
+	if cfg.StoreName != "Farshid's Shop" {
+		t.Fatalf("StoreName = %q, want unchanged cfg default %q when store.name is genuinely unset", cfg.StoreName, "Farshid's Shop")
+	}
+}
+
+// SaveRuntimeConfig's bug #2 above was exactly a key-name divergence
+// between what it wrote and what LoadRuntimeConfig/pages/common read back —
+// the round-trip test catches Save and Load disagreeing, but not both
+// sides silently agreeing on the WRONG key. Pin the literal key names here
+// (rather than referencing internal/pages/common's Key* constants, which
+// would risk an import cycle since common imports settings) so a future
+// rename on either side fails loudly.
+func TestSaveRuntimeConfig_WritesExpectedKeys(t *testing.T) {
+	ctx := context.Background()
+	d := openMigratedDB(t, "settings.db")
+	s := NewStore(d.DB)
+
+	if err := s.SaveRuntimeConfig(ctx, baseCfg()); err != nil {
+		t.Fatalf("SaveRuntimeConfig: %v", err)
+	}
+
+	all, err := s.All(ctx)
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	for _, k := range []string{
+		"theme", "store.name", "store.currency", "store.currency_symbol",
+		"store.locale", "store.tax_inclusive", "store.tax_rate",
+	} {
+		if _, ok := all[k]; !ok {
+			t.Errorf("SaveRuntimeConfig did not write expected key %q (all keys: %v)", k, all)
+		}
+	}
+}
+
 func TestSaveRuntimeConfig_PropagatesRepoError(t *testing.T) {
 	ctx := context.Background()
 	d := openMigratedDB(t, "settings.db")


### PR DESCRIPTION
## Summary
- Coverage batch 11 of the ongoing `ut-docs/QUEUE.md` test-coverage push: `internal/settings` 0% → 84.6%, `internal/pages/common` 0% → 100%. `internal/app` scoped out — already at 79.7% from unrelated PR #101 (the QUEUE.md note calling it a 0% candidate was stale).
- Two real bugs found TDD-first in `internal/settings/runtime.go`: `LoadRuntimeConfig`'s `CurrencySymbol` assignment was gated on the wrong variable (`curr` instead of `curr_symbol`), silently dropping a symbol-only override; `SaveRuntimeConfig` persisted `tax_inclusive` under `"pos.tax_inclusive"`, a key nothing reads — `LoadRuntimeConfig` and the real settings-admin UI both read `"store.tax_inclusive"`, so a value saved at boot was never round-tripped back.
- Independent review (opus, different model) found a third real bug — `internal/pages/common/state.go`'s `LoadState` silently discarded the cfg default (falling to Go's zero value) on a garbage stored value for `TaxInclusive`/`AllowNegativeInventory`, inconsistent with every sibling field's `err == nil` guard pattern — plus several test-quality gaps (the same "seeded-default masks the guard" blind spot recurring in two more tests, and a couple of assertions that couldn't actually fail). All fixed, all mutation-probed by both author and reviewer.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/settings/... ./internal/pages/common/... -race -count=1 -cover` green (84.6% / 100.0%)
- [x] `go test ./internal/pages/... -race -count=1` green (real production caller of the fixed `LoadState`)
- [x] `bash scripts/ci/guard-data-access.sh` / `guard-i18n.sh` pass
- [x] Full `go test ./... -race -count=1` — green except one pre-existing, unrelated failure (`internal/issuereport`, root-in-container permission-check artifact, reproduces identically on unmodified `main`)
- [x] Both production bug fixes verified failing-then-passing (reverted, confirmed real assertion failure, restored, confirmed green) by both author and independent reviewer
- [x] 8 mutation probes across both packages, all caught real regressions
- [x] Independent review: `universal-till/docs/code-reviews/2026-07-30-coverage-settings-pages-common.md` — SAFE TO MERGE WITH FIXES, all findings addressed

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018hLkr55Hp1UHPvjQB1eSFg)_