### PR TITLE
feat: restyle default till theme for 10-inch touch screens (#144 Phase A)

### DIFF
--- a/docs/code-reviews/2026-07-30-till-ui-10inch-restyle.md
+++ b/docs/code-reviews/2026-07-30-till-ui-10inch-restyle.md
@@ -1,0 +1,64 @@
+# Code review — till default-theme 10-inch restyle (board #144, Phase A)
+
+- **Date**: 2026-07-30
+- **Branch**: `feat/till-ui-10inch-restyle`
+- **Card**: ut-docs #144 (Farshid's field report — "till UI not good on the
+  10-inch screen, everything should be larger + better style"). Direction
+  he chose: **Both** (restyle default now + curated theme plugins later),
+  style **"you decide"** → clean, modern, high-contrast, large-touch
+  (Square/Loyverse-ish). Phase B (theme plugins) is follow-up card #145.
+- **Scope (Phase A)**: CSS-only, `web/public/app.css` (the default theme).
+
+## What changed
+
+A coherent "large-touch" pass on the default theme: `html` base 16→17px
+(gentle global +6%, everything is rem-based); product-tile grid
+`minmax(118px→150px)` with `.thumb` 54→72px and `.tile-name`/`.tile-price`
+→ .95rem and a `.btn-tile` `min-height: 8.5rem`; primary `.btn` padding up
++ `min-height: 3rem`, font .9→1rem; touch-menu tiles bigger (minmax
+160→190, min-height 130→160, icon 2.4→2.9rem, label 1.05→1.2rem). No
+palette/aesthetic overhaul — sizing/spacing/contrast only. The runtime
+per-till UI-scale (0.7–2.0) still layers on top.
+
+## Verification
+
+- `go build ./...`, `guard-i18n.sh`, `internal/pages` tests — green
+  (CSS-only; Go tests don't cover it, so the check is layout reasoning +
+  a real render).
+- **Real driven run at 1280×800** (headless Chrome against the built
+  binary, demo catalog): sale screen shows large product tiles with
+  images, readable names/prices, big high-contrast Cash/Card/Gift/QR
+  tender buttons, clear basket; touch menu tiles roomy. No clipping.
+  Screenshots delivered to Farshid to judge on the real device.
+
+## Independent (opus) review — ship-able Phase A, no blockers
+
+The reviewer confirmed the change is internally coherent (all rem-based,
+symmetric padding, no physical-direction props → RTL-safe) and that the
+sale/checkout path, the self-order kiosk (its own scoped classes +
+`body.kiosk` overrides), and the basket zero-height-collapse history are
+all unaffected. Two should-fixes on **admin** surfaces, both from the
+global 17px bump — **fixed before commit**:
+
+1. `.vg-cols` variant editor: its 8 fixed-rem columns sum grew past a
+   1280px screen (the target device), and the `overflow-x:auto` guard only
+   armed at ≤900px — so 900–1289px was unprotected. **Fixed**: raised that
+   guard to ≤1300px so the variant grid scrolls horizontally instead of
+   overflowing the page on a 10-inch screen.
+2. `.btn { min-height: 3rem }` leaked into `.btn-actions .btn` (compact
+   catalog-row action buttons), inflating row height ~70% — the author had
+   protected `.btn-x`/`.held-chip` but missed this one. **Fixed**: added
+   `min-height: 0` to `.btn-actions .btn` to keep rows compact.
+
+Accepted nits (not fixed — pre-existing/low-value): the product grid's
+`minmax(150px)`/`thumb 72px` are px (don't track UI-scale like the rest of
+the tile) — pre-existing px/rem mix, amplified but not introduced here;
+`.btn-tile 8.5rem` also applies to the button-layout admin editor
+(makes editable tiles taller — acceptable for a touch theme).
+
+## Note
+
+Aesthetics are Farshid's call (he said "you decide"); this ships the
+objective sizing/contrast baseline. He should judge the look on the real
+10-inch device — proportion tweaks are a cheap follow-up. Curated theme
+plugins = #145.

--- a/web/public/app.css
+++ b/web/public/app.css
@@ -24,7 +24,7 @@
 
 /* ---------- Base ---------- */
 * { box-sizing: border-box; }
-html { font-size: 16px; }
+html { font-size: 17px; } /* 10-inch touch baseline (#144) */
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif,
@@ -87,20 +87,20 @@ body.menu-screen .session-admin-link { display: none; }
 
 /* Menu launcher page: a grid of large touch tiles. */
 .menu-grid {
-  display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-  gap: 1rem; margin-top: 1rem;
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+  gap: 1.1rem; margin-top: 1rem;
 }
 .menu-tile {
   display: flex; flex-direction: column; align-items: center; justify-content: center;
-  gap: .6rem; min-height: 130px; padding: 1.2rem;
+  gap: .7rem; min-height: 160px; padding: 1.4rem;
   background: var(--surface); border: 1px solid var(--border);
   border-radius: var(--radius-lg); box-shadow: var(--shadow);
   color: var(--text); text-decoration: none; text-align: center;
   transition: transform .06s ease, border-color .15s ease;
 }
 .menu-tile:hover, .menu-tile:active { border-color: var(--brand); transform: translateY(-2px); }
-.menu-ico { font-size: 2.4rem; line-height: 1; }
-.menu-label { font-size: 1.05rem; font-weight: 600; }
+.menu-ico { font-size: 2.9rem; line-height: 1; }
+.menu-label { font-size: 1.2rem; font-weight: 600; }
 .btn-touch { min-height: 46px; display: inline-flex; align-items: center; }
 
 /* Language switcher on the touch menu page — big, obvious buttons so a
@@ -224,7 +224,9 @@ body.osk-padded { padding-block-end: 15.5rem; }
 .vg-row .chip-add input[type="text"] { inline-size: 7.5rem; }
 .vg-inactive > input, .vg-inactive > .chip-row { opacity: .55; }
 .vg-new { background: var(--surface-2); border-radius: 8px; padding-inline: .5rem; }
-@media (max-width: 900px) {
+/* Raised to 1300px (was 900): the 17px base (#144) widens .vg-cols'
+   fixed-rem sum past a 1280px 10-inch screen, so arm the scroll earlier. */
+@media (max-width: 1300px) {
   .variant-grid { overflow-x: auto; }
   .vg-cols { min-inline-size: 54rem; }
 }
@@ -354,8 +356,8 @@ label { font-size: .85rem; color: var(--text); }
 .btn {
   display: inline-flex; align-items: center; justify-content: center; gap: .4rem;
   background: var(--accent); color: var(--accent-contrast);
-  border: 1px solid transparent; padding: .55rem .95rem; border-radius: 9px;
-  cursor: pointer; font: inherit; font-size: .9rem; font-weight: 600;
+  border: 1px solid transparent; padding: .7rem 1.15rem; border-radius: 9px;
+  cursor: pointer; font: inherit; font-size: 1rem; font-weight: 600; min-height: 3rem;
   text-decoration: none; line-height: 1.2;
   transition: background .12s ease, transform .05s ease;
 }
@@ -369,24 +371,24 @@ label { font-size: .85rem; color: var(--text); }
 .btn.danger:hover { background: #b91c1c; }
 a.btn, a.btn:hover { text-decoration: none; }
 .btn-actions { display: flex; gap: .25rem; justify-content: center; }
-.btn-actions .btn { padding: .4rem .6rem; font-size: .85rem; }
+.btn-actions .btn { padding: .4rem .6rem; font-size: .85rem; min-height: 0; }
 
 /* ---------- Product tiles ----------
    The whole tile is one touch target: image, name, price. */
-.grid { display: grid; gap: .5rem; grid-template-columns: repeat(auto-fill, minmax(118px, 1fr)); }
+.grid { display: grid; gap: .6rem; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); }
 .btn-tile {
-  display: flex; flex-direction: column; align-items: stretch; gap: .25rem;
-  padding: .35rem .35rem .45rem; border: 1px solid var(--border);
+  display: flex; flex-direction: column; align-items: stretch; gap: .3rem;
+  padding: .55rem .5rem .6rem; min-height: 8.5rem; border: 1px solid var(--border);
   border-radius: var(--radius); background: var(--surface); box-shadow: var(--shadow);
   font: inherit; color: var(--text); cursor: pointer; text-align: center;
   transition: border-color .12s ease, box-shadow .12s ease, transform .05s ease;
 }
 .btn-tile:hover { border-color: #cbd5e1; box-shadow: 0 3px 8px rgba(15, 23, 42, .12); }
 .btn-tile:active { transform: scale(.97); }
-.tile-name { font-weight: 600; font-size: .8rem; line-height: 1.15; white-space: normal; }
-.tile-price { font-size: .82rem; color: var(--accent); font-weight: 700;
+.tile-name { font-weight: 600; font-size: .95rem; line-height: 1.2; white-space: normal; }
+.tile-price { font-size: .95rem; color: var(--accent); font-weight: 700;
               font-variant-numeric: tabular-nums; }
-.thumb { width: 100%; height: 54px; object-fit: contain;
+.thumb { width: 100%; height: 72px; object-fit: contain;
          border-radius: 7px; background: var(--surface-2); }
 .thumb.small { width: 40px; height: 40px; aspect-ratio: auto; margin-inline-end: .5rem;
                vertical-align: middle; }


### PR DESCRIPTION
Field report #144: the till UI is too small on a 10-inch screen. Direction chosen: restyle the default now (Phase A) + curated theme plugins later (#145); style 'you decide' → clean modern large-touch.

CSS-only pass on the default theme (`web/public/app.css`): bigger product tiles (118→150px) + thumbnails (54→72px) + text, taller touch buttons (min-height 3rem), roomier touch-menu tiles, +6% global baseline. Per-till UI-scale (0.7–2.0) still layers on top.

Verified at 1280×800 on a real driven run (screenshots shared with Farshid). Independent opus review: ship-able, no blockers — its two admin-surface regressions from the 17px bump were fixed (variant-editor horizontal-scroll guard raised to ≤1300px so the 10-inch device doesn't overflow; `.btn-actions` row buttons kept compact).

Aesthetics are the owner's call; judge on the real device. Review: `docs/code-reviews/2026-07-30-till-ui-10inch-restyle.md`.

Closes universaltill/ut-docs#144

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PC7bUiXcj47ztWSZnNNG8V
EOF
)