### PR TITLE
feat: add Fresh/Amber/Slate built-in till themes from reference images (#145)

### DIFF
--- a/docs/code-reviews/2026-07-31-curated-till-themes.md
+++ b/docs/code-reviews/2026-07-31-curated-till-themes.md
@@ -1,0 +1,67 @@
+# Code review — curated built-in till themes Fresh/Amber/Slate (board #145)
+
+- **Date**: 2026-07-31
+- **Branch**: `feat/theme-fresh` → PR #110
+- **Card**: ut-docs #145 (Phase B of #144). Farshid supplied 8 reference
+  images (#146) — "you should create themes like these images" — asking for
+  curated themes matching those looks.
+- **Scope**: three new CSS themes under `web/public/themes/`, plus a test
+  fix. No Go behavior change; the default theme (`app.css`, #144) is
+  untouched, and no default is changed — all three are opt-in.
+
+## What shipped
+
+Three curated themes, each a coherent modern-POS look keyed to one
+reference image:
+
+- **Fresh** (`fresh.css`) — sky-blue accent (`--accent:#0ea5e9`), rounded
+  photo-tile cards with soft shadow, bold min-3.4rem tender buttons, navy
+  nav (ref7).
+- **Amber** (`amber.css`) — warm orange accent (`--accent:#f97316`) on a
+  cream background, photo tiles (ref3).
+- **Slate** (`slate.css`) — navy accent (`--accent:#1d4ed8`), **text-only
+  tiles** (`.btn-tile .thumb{display:none}`) with a left accent bar and a
+  denser `minmax(130px)` grid, for photo-less grocery/retail catalogs (ref1
+  Opencloud look).
+
+Each is a pure `:root` token override plus a handful of component tweaks —
+the same shape the existing `monarch.css` built-in and plugin themes use.
+They're picked up automatically: `availableThemes` unions the on-disk
+`web/public/themes` dir with the embedded `public/themes` FS, so dropping a
+`*.css` file in is all that's needed — no Go wiring, no migration.
+
+## Verification
+
+- `go build ./...`, `go vet`, `guard-data-access.sh`, `guard-i18n.sh` — all
+  green (CSS is not i18n/SQL-bearing; guards confirm nothing else drifted).
+- Full `internal/pages` package test — green.
+- **Real driven render at 1280×800** (headless Chrome, built binary, demo
+  catalog) for all three: Fresh and Amber show large photo tiles with
+  readable names/accent-coloured prices and high-contrast tender buttons;
+  Slate shows compact text tiles (no thumbnails), navy accent bars, more
+  products per screen. No clipping. Screenshots delivered to Farshid.
+
+## Test fix — de-brittled the themes assertion
+
+Adding the three CSS files broke `TestThemesHandler_ServesBuiltinAndPluginCSS`,
+which hardcoded `len(opts)==2` and a fixed `[monarch, midnight]` order — it
+assumed monarch was the *only* embedded built-in. That assumption is exactly
+what #145 changes. Rewrote it to assert the real contract instead: built-in
+themes are sorted and all precede any plugin theme, monarch is present as a
+built-in, and the `midnight` plugin theme carries its plugin-id source. It
+still fails on a genuine regression (built-ins mis-sorted, a plugin theme
+ordered before a built-in, or the plugin source wrong) — verified by reading
+the ordering/source guards, not just that it now passes. Robust to future
+built-in themes being added.
+
+## Notes / follow-ups
+
+- Aesthetics remain Farshid's call — he judges the three looks on the real
+  10-inch device and can ask for palette/proportion tweaks (cheap CSS
+  follow-ups) or more themes from the remaining reference images.
+- These are built-in themes in core (simplest path for a curated set that
+  ships with every install); if the set grows large or wants independent
+  release cadence, a `ut-plugin-theme-*` repo is the plugin-first home —
+  not warranted for three first-party themes today.
+- Below the release-cadence threshold on its own (feature merges since the
+  last tag < 5, no p1); rides the next release rather than cutting one now.

--- a/internal/pages/themes_test.go
+++ b/internal/pages/themes_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
 	"testing"
 
 	_ "modernc.org/sqlite"
@@ -91,11 +93,40 @@ func TestThemesHandler_ServesBuiltinAndPluginCSS(t *testing.T) {
 		}
 	}
 
-	// availableThemes lists both, built-in first.
+	// availableThemes lists built-in themes first (sorted), then plugin themes.
+	// Don't hardcode the built-in count: the embedded set grows as curated
+	// built-in themes are added under web/public/themes (fresh/amber/slate/…),
+	// which the fallback FS unions with the disk dir. Assert the contract
+	// instead — monarch is a built-in, midnight is the plugin theme, built-ins
+	// are sorted and all precede any plugin theme.
 	opts := availableThemes(t.Context(), d)
-	if len(opts) != 2 || opts[0].Key != "monarch" || opts[0].Source != "built-in" ||
-		opts[1].Key != "midnight" || opts[1].Source != "com.x.midnight" {
-		t.Errorf("availableThemes = %+v", opts)
+	var builtinKeys []string
+	firstPluginIdx := len(opts)
+	var midnight *ThemeOption
+	for i := range opts {
+		o := opts[i]
+		if o.Source == "built-in" {
+			if i > firstPluginIdx {
+				t.Errorf("built-in %q appears after a plugin theme; built-ins must be first: %+v", o.Key, opts)
+			}
+			builtinKeys = append(builtinKeys, o.Key)
+			continue
+		}
+		if i < firstPluginIdx {
+			firstPluginIdx = i
+		}
+		if o.Key == "midnight" {
+			midnight = &opts[i]
+		}
+	}
+	if !sort.StringsAreSorted(builtinKeys) {
+		t.Errorf("built-in themes not sorted: %v", builtinKeys)
+	}
+	if !slices.Contains(builtinKeys, "monarch") {
+		t.Errorf("expected monarch among built-in themes, got %v", builtinKeys)
+	}
+	if midnight == nil || midnight.Source != "com.x.midnight" {
+		t.Errorf("expected midnight plugin theme with source com.x.midnight, got %+v", opts)
 	}
 }
 

--- a/web/public/themes/amber.css
+++ b/web/public/themes/amber.css
@@ -1,0 +1,28 @@
+/* "Amber" — clean light POS, warm orange accent (board #145 / brief #146,
+   ref3). Same crisp photo-tile cards as Fresh; warm palette + bold Pay. */
+:root {
+  --brand: #1c1917;
+  --accent: #f97316;          /* orange */
+  --accent-contrast: #ffffff;
+  --bg: #fbf7f2;
+  --surface: #ffffff;
+  --surface-2: #f6efe6;
+  --border: #ece2d5;
+  --text: #1c1917;
+  --muted: #78716c;
+  --radius: 12px;
+  --radius-lg: 16px;
+  --shadow: 0 1px 2px rgba(28,25,23,.05), 0 2px 6px rgba(28,25,23,.06);
+}
+.btn-tile { border-radius: 16px; box-shadow: 0 2px 6px rgba(28,25,23,.07); }
+.btn-tile:hover { border-color: #f6c99a; box-shadow: 0 8px 20px rgba(249,115,22,.16); }
+.btn-tile:active { transform: scale(.97); }
+.tile-price { color: var(--accent); font-weight: 800; }
+.thumb { background: var(--surface-2); }
+.chip, .cat-chip, .category-chip { border-radius: 999px; }
+.tender .btn.primary, .btn.primary { box-shadow: 0 2px 10px rgba(249,115,22,.35); }
+.tender .btn.primary { min-height: 3.4rem; font-size: 1.12rem; }
+.basket .total, .basket .totals .grand, .kpi-value { color: var(--accent); }
+.basket .totals { border-top: 2px solid var(--surface-2); }
+.nav, header.nav { background: var(--brand); color: #fff; }
+.nav a { color: #fed7aa; }

--- a/web/public/themes/fresh.css
+++ b/web/public/themes/fresh.css
@@ -1,0 +1,43 @@
+/* "Fresh" — a clean, modern light POS theme (board #145 / brief #146).
+   Sky-blue accent, crisp rounded product cards, a bold full-width PAY.
+   Loaded AFTER app.css, so it only re-skins via tokens + a few surfaces;
+   all sizing/layout stays with app.css (incl. the #144 10-inch pass). */
+:root {
+  --brand: #0b1324;
+  --accent: #0ea5e9;          /* sky blue */
+  --accent-contrast: #ffffff;
+  --bg: #f5f8fc;
+  --surface: #ffffff;
+  --surface-2: #eef4fb;
+  --border: #e3ecf6;
+  --text: #0b1324;
+  --muted: #5b6b82;
+  --radius: 12px;
+  --radius-lg: 16px;
+  --shadow: 0 1px 2px rgba(11,19,36,.05), 0 2px 6px rgba(11,19,36,.06);
+}
+
+/* Product tiles: crisper cards with a clear hover/active lift. */
+.btn-tile { border-radius: 16px; box-shadow: 0 2px 6px rgba(11,19,36,.07); }
+.btn-tile:hover { border-color: #bfe0f5; box-shadow: 0 8px 20px rgba(14,165,233,.16); }
+.btn-tile:active { transform: scale(.97); }
+.tile-price { color: var(--accent); font-weight: 800; }
+.thumb { background: var(--surface-2); }
+
+/* Category chips read as pills. */
+.chip, .cat-chip, .category-chip { border-radius: 999px; }
+
+/* Tender: a bold, unmistakable PAY. The primary tender buttons pop. */
+.tender .btn.primary, .btn.primary {
+  box-shadow: 0 2px 10px rgba(14,165,233,.35);
+  letter-spacing: .01em;
+}
+.tender .btn.primary { min-height: 3.4rem; font-size: 1.12rem; }
+
+/* Basket: bold accent total + a clear order-type toggle. */
+.basket .total, .basket .totals .grand, .kpi-value { color: var(--accent); }
+.basket .totals { border-top: 2px solid var(--surface-2); }
+
+/* Header keeps the deep brand bar, white text (like the reference tablets). */
+.nav, header.nav { background: var(--brand); color: #fff; }
+.nav a { color: #dbeafe; }

--- a/web/public/themes/slate.css
+++ b/web/public/themes/slate.css
@@ -1,0 +1,30 @@
+/* "Slate" — light POS with a navy accent and COMPACT TEXT tiles (no photos),
+   for grocery/retail catalogs (board #145 / brief #146, ref1 Opencloud look).
+   Hides thumbnails and tightens tiles into dense, color-dotted buttons. */
+:root {
+  --brand: #0f172a;
+  --accent: #1d4ed8;          /* navy/indigo */
+  --accent-contrast: #ffffff;
+  --bg: #f1f5f9;
+  --surface: #ffffff;
+  --surface-2: #eef2f7;
+  --border: #dbe3ec;
+  --text: #0f172a;
+  --muted: #64748b;
+  --radius: 8px;
+  --radius-lg: 10px;
+  --shadow: 0 1px 2px rgba(15,23,42,.06);
+}
+/* Text-forward tiles: drop the photo, make tiles denser + a left accent bar. */
+.btn-tile .thumb { display: none; }
+.btn-tile { min-height: 4.6rem; border-radius: 10px; border-inline-start: 4px solid var(--accent);
+            justify-content: center; box-shadow: 0 1px 2px rgba(15,23,42,.06); }
+.grid { grid-template-columns: repeat(auto-fill, minmax(130px, 1fr)); }
+.tile-name { font-size: 1rem; }
+.tile-price { color: var(--accent); font-weight: 800; }
+.chip, .cat-chip, .category-chip { border-radius: 6px; }
+.tender .btn.primary, .btn.primary { box-shadow: none; }
+.tender .btn.primary { min-height: 3.2rem; font-size: 1.1rem; }
+.basket .total, .basket .totals .grand, .kpi-value { color: var(--accent); }
+.nav, header.nav { background: var(--brand); color: #fff; }
+.nav a { color: #cbd5e1; }


### PR DESCRIPTION
Three curated themes from Farshid's reference images (#146), each a clean modern POS look matching one reference:
- **Fresh** — sky-blue accent, rounded photo-tile cards (ref7)
- **Amber** — warm orange accent, photo tiles (ref3)
- **Slate** — navy accent, compact **text tiles** (photos hidden, denser grid) for photo-less grocery/retail catalogs (ref1)

All additive + opt-in: auto-discovered CSS files in `web/public/themes/`, no Go changes, no default change, app.css (incl. #144 10-inch sizing) untouched. Each verified at 1280×800 via a real driven screenshot.

Relates to universaltill/ut-docs#145, universaltill/ut-docs#146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PC7bUiXcj47ztWSZnNNG8V