### PR TITLE
fix: self-update works on Pi kiosk installs; no website dead-end (#147)

### DIFF
--- a/deploy/raspberry-pi/install.sh
+++ b/deploy/raspberry-pi/install.sh
@@ -25,6 +25,13 @@ fi
 echo "==> Installing web assets + env"
 cp -R "$REPO_ROOT/web" "$DEST/web"
 [[ -f "$DEST/pos.env" ]] || cp "$REPO_ROOT/pos.env.dev" "$DEST/pos.env"
+# Own the whole install tree as the `pos` service user. This is REQUIRED for
+# in-app self-update, not just tidiness: the updater swaps the binary with an
+# os.Rename inside $DEST/bin and swaps $DEST/web, both of which need the running
+# service (User=pos) to have write on those directories. If this tree is left
+# root-owned (e.g. after a later `sudo go build -o $DEST/bin/...`), self-update
+# silently downgrades to "not supported" and Settings→Update dead-ends — see
+# ut-docs#147. Keep $DEST pos-owned whenever you rebuild in place.
 chown -R pos:pos "$DEST"
 
 echo "==> Installing systemd units"

--- a/docs/code-reviews/2026-07-31-selfupdate-kiosk-writability.md
+++ b/docs/code-reviews/2026-07-31-selfupdate-kiosk-writability.md
@@ -1,0 +1,96 @@
+# Code review — self-update on Pi kiosk installs (board #147, #148)
+
+- **Date**: 2026-07-31
+- **Branch**: `fix/selfupdate-kiosk-writability` → PR #111
+- **Cards**: ut-docs #147 (p1 field report — Settings→Update dead-ends at the
+  website on the Pi kiosk) and #148 (asset-staleness follow-on, found during
+  the review and folded into this PR).
+
+## The bug (#147)
+
+On the Raspberry Pi kiosk the in-app updater refused to run, so Settings →
+Update rendered a link to the website download page — a dead end on a
+fullscreen kiosk with no way out. Two coupled causes:
+
+1. `supportedFor()` blanket-blocklisted any `/opt/unitill/*` path as
+   "packaged → apt". But the Pi installs a *portable* binary there
+   (`deploy/raspberry-pi/install.sh`), owned by the `pos` service user — it
+   self-updates fine. The path prefix was a wrong proxy for the real question.
+2. Nothing checked the *real* precondition for the in-place swap (an
+   `os.Rename` within a directory): that the directory is **writable by the
+   running service user**.
+
+## The fix
+
+- `supportedFor(exe, goos)` is now a pure OS/location policy gate: windows and
+  android/ios never; darwin always (the `.dmg` bundle path); `/usr` stays
+  apt's domain; everything else — including `/opt/unitill` — is
+  location-eligible.
+- `Supported()` applies the true precondition via `dirWritable()` (a
+  create+remove temp-file probe) on **both** the binary's directory and the
+  server's working directory (see #148 below).
+- The update-check fallback (`internal/pages/update_api.go`) no longer renders
+  a website link on non-Windows installs: Windows keeps the actionable
+  download link; unix shows a plain "in-app update isn't available for this
+  install" message (new i18n key `settings.update.unavailable_here`, all 4
+  locales). A correctly provisioned kiosk never reaches this branch —
+  `Supported()` is true, so the inline Apply button shows instead.
+- `install.sh`: documented that the `chown -R pos:pos` is REQUIRED for
+  self-update (not cosmetic), so a later in-place rebuild doesn't silently
+  re-break it.
+
+## Independent (opus) review — found a BLOCKER, fixed in the same PR
+
+The reviewer confirmed the OS/location-policy split and writability concept
+are sound, and **verified the `.deb` non-regression**: the `.deb` runs as
+`pos` and `postinstall.sh` leaves `/opt/unitill/bin` root-owned, so
+`dirWritable` is false there → still defers to apt. Correct.
+
+**BLOCKER (fixed): web/ was swapped at the wrong directory on the exact kiosk
+layout this change enables (#148).** `Apply` computed the web-swap target from
+the binary's directory (`filepath.Dir(exe)/web`). On the Pi the binary is at
+`/opt/unitill/bin/unitill-pos` but the server reads its on-disk `web/` override
+**cwd-relative** (`WorkingDirectory=/opt/unitill` → `/opt/unitill/web`), and
+`fallbackFS.Open` serves the disk side *ahead of* the embedded side. So a
+self-update would swap the binary (templates + locales update from the embedded
+FS, fine) but dump the new `web/` into `/opt/unitill/bin/web` where nothing
+reads it — leaving **stale `/public` CSS/JS/themes** shadowing the new binary's
+embedded assets, while reporting success. No existing test caught it because
+every `Apply` fixture used a flat layout.
+
+Fix: `Apply` now resolves the web base from the working directory (`os.Getwd`),
+matching how the server reads it — unchanged for a flat install (cwd ==
+installDir), correct for the bin-subdir kiosk layout. `Supported()` was
+extended to also require the working directory writable (the SHOULD-FIX the
+reviewer flagged — otherwise a partially-owned tree would pass the gate then
+fail mid-swap). New `TestApplySwapsWebAtWorkingDirNotBinaryDir` builds the
+split layout and asserts web is swapped at `cwd/web` and never at `bin/web`;
+**mutation-probed** (reverting the web base to the binary dir fails it on both
+assertions — stale web and a wrongly-created `bin/web`).
+
+**Accepted nits (not changed):** `ErrUnsupported`'s message ("use the
+installer / apt") is slightly off for a merely root-owned-but-portable install,
+but the UI gates on `Supported()` and shows the clean fallback, so it only
+surfaces in logs — low value. `dirWritable`'s probe file could linger if the
+remove fails after a successful create (rare; `O_EXCL` + random name, same-user
+local dir — no security concern). The `.deb`-stays-unsupported path and the
+"exists but not writable" branch are only covered indirectly in root-run CI
+containers (the read-only-dir test skips under root); the split-layout test now
+covers the layout that actually mattered.
+
+## Verification
+
+- `go build ./...`, `go vet`, full `go test ./...`, `guard-data-access.sh`,
+  `guard-i18n.sh` — all green.
+- selfupdate unit tests (policy split, writability gate, split-layout web
+  swap, macOS bundle paths — no regression); `update_api` fallback link/no-link.
+- **Real Pi4 end-to-end**: see the close-out comment on #147 — deployed the
+  fixed arm64 build to a service-writable `/opt/unitill`, confirmed the Update
+  button now appears (not the website link), and drove a live self-update +
+  re-exec with the kiosk reconnecting.
+
+## Note
+
+The first fixed build must be placed on the Pi manually — the running v0.2.50
+binary can't self-update to the fix (that's the bug). Every subsequent update
+is in-app. `install.sh`'s pos-ownership is what keeps it self-updatable.

--- a/internal/pages/update_api.go
+++ b/internal/pages/update_api.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html"
 	"net/http"
+	"runtime"
 
 	"github.com/universaltill/universal-till/internal/buildinfo"
 	"github.com/universaltill/universal-till/internal/httpx"
@@ -12,6 +13,26 @@ import (
 	"github.com/universaltill/universal-till/internal/selfupdate"
 	"github.com/universaltill/universal-till/internal/updates"
 )
+
+// updateUnavailableHTML renders the status line for "a newer version exists but
+// in-app apply can't run on this install". On Windows a download link is
+// actionable (the user runs the installer); on a unix kiosk a website link is a
+// dead end — fullscreen with no way out and no installer to run — so it states
+// the situation plainly with no link (board ut-docs#147). A correctly
+// provisioned kiosk never reaches here: selfupdate.Supported() is true for a
+// service-writable install, so the inline Apply button is shown instead.
+func updateUnavailableHTML(locale, latest, goos string) string {
+	if goos == "windows" {
+		return fmt.Sprintf(`<span>⬆ %s v%s — <a href="https://www.universaltill.com/download" rel="noopener">%s</a></span>`,
+			html.EscapeString(httpx.T(locale, "status.update_available")),
+			html.EscapeString(latest),
+			html.EscapeString(httpx.T(locale, "settings.update.download")))
+	}
+	return fmt.Sprintf(`<span>⬆ %s v%s — %s</span>`,
+		html.EscapeString(httpx.T(locale, "status.update_available")),
+		html.EscapeString(latest),
+		html.EscapeString(httpx.T(locale, "settings.update.unavailable_here")))
+}
 
 // registerUpdateAPI exposes the manager-gated in-app updater. It downloads the
 // latest release, verifies its checksum, swaps the binary + web assets, and
@@ -91,10 +112,7 @@ func registerUpdateAPI(mux *http.ServeMux, d *common.Deps) {
 				html.EscapeString(httpx.T(locale, "settings.update.apply_confirm")),
 				html.EscapeString(httpx.T(locale, "status.update_now")))
 		default:
-			fmt.Fprintf(w, `<span>⬆ %s v%s — <a href="https://www.universaltill.com/download" rel="noopener">%s</a></span>`,
-				html.EscapeString(httpx.T(locale, "status.update_available")),
-				html.EscapeString(st.Latest),
-				html.EscapeString(httpx.T(locale, "settings.update.download")))
+			fmt.Fprint(w, updateUnavailableHTML(locale, st.Latest, runtime.GOOS))
 		}
 	})
 }

--- a/internal/pages/update_api_test.go
+++ b/internal/pages/update_api_test.go
@@ -3,10 +3,47 @@ package pages
 import (
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/universaltill/universal-till/internal/config"
+	"github.com/universaltill/universal-till/internal/httpx"
 	"github.com/universaltill/universal-till/internal/pages/common"
 )
+
+// When an update exists but in-app apply is unsupported, a Windows desktop
+// keeps an actionable download link (the user runs the installer), but a unix
+// kiosk must NOT get a website link it can't act on (no way out of fullscreen)
+// — it gets a plain "unavailable" message instead. Regression guard for the
+// Pi kiosk dead-end (ut-docs#147).
+func TestUpdateFallbackHTML(t *testing.T) {
+	chdirRoot(t) // so web/locales resolves regardless of test ordering
+	i18n, err := config.NewI18n(filepath.Join("web", "locales"), "en")
+	if err != nil {
+		t.Fatalf("i18n: %v", err)
+	}
+	httpx.InitI18n(i18n, "en")
+
+	win := updateUnavailableHTML("en", "0.2.51", "windows")
+	if !strings.Contains(win, `href="https://www.universaltill.com/download"`) {
+		t.Errorf("windows fallback should keep the download link, got %q", win)
+	}
+
+	kiosk := updateUnavailableHTML("en", "0.2.51", "linux")
+	if strings.Contains(kiosk, "universaltill.com/download") || strings.Contains(kiosk, "<a ") {
+		t.Errorf("kiosk fallback must not contain a website link, got %q", kiosk)
+	}
+	if !strings.Contains(kiosk, "available for this install") { // apostrophe is HTML-escaped
+		t.Errorf("kiosk fallback should state in-app update is unavailable, got %q", kiosk)
+	}
+	// Both still surface the available version so the operator knows one exists.
+	for _, h := range []string{win, kiosk} {
+		if !strings.Contains(h, "0.2.51") {
+			t.Errorf("fallback should show the available version, got %q", h)
+		}
+	}
+}
 
 // The updater endpoints are manager-gated. Without auth-off and without a
 // manager in context, both must refuse before doing any work (crucially, apply

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -53,44 +53,73 @@ func Supported() bool {
 	if err != nil {
 		return false
 	}
-	return supportedFor(exe, runtime.GOOS)
-}
-
-// supportedFor is the testable core of Supported: in-app self-update only works
-// for the portable archive (.tar.gz) installs, where swapping the binary in
-// place is safe.
-func supportedFor(exe, goos string) bool {
-	if goos == "windows" {
-		return false // updates via the installer
-	}
-	if goos == "android" || goos == "ios" {
-		// Neither had a real self-update mechanism to begin with — this was
-		// falling through to the desktop default (true) with nothing to
-		// back it up. Apply() only ever fetches a
-		// unitill-pos_<version>_<goos>_<arch>.tar.gz release archive (or,
-		// on darwin, a .dmg via applyMacApp); no such archive is ever
-		// published for android/ios (mobile/mobile.go's release job
-		// attaches an .apk, nothing a self-swap could use), so tapping
-		// "Update now" here was guaranteed to fail with a confusing "no
-		// release archive" error — same user-visible symptom as the
-		// stale-cache Mac bug fixed alongside this, different root cause
-		// (a feature that was never actually built for this platform, not
-		// a timing bug). False here makes the status bar correctly fall
-		// back to the plain "Update available" download-page link instead
-		// (same fallback Windows already uses). A real mobile in-app
-		// updater (download the .apk, launch Android's package-install
-		// intent) is a genuine feature to build later, not implemented by
-		// this change.
+	if !supportedFor(exe, runtime.GOOS) {
 		return false
 	}
-	// Packaged installs update via their package manager, not a self-swap.
-	for _, p := range []string{"/usr/", "/opt/unitill/"} {
-		if strings.HasPrefix(exe, p) {
-			return false // .deb → apt
-		}
+	// A macOS .app updates the whole bundle via the .dmg (applyMacApp handles
+	// its own privilege/relaunch path), so it isn't gated on plain
+	// dir-writability. A *portable* darwin binary outside a bundle still does
+	// the tar.gz swap below, so it needs a writable dir just like linux.
+	if runtime.GOOS == "darwin" && appBundlePath(exe) != "" {
+		return true
 	}
-	// A macOS .app updates via the .dmg (whole-bundle replace + relaunch), not by
-	// swapping the inner binary — handled by applyMacApp. Still supported.
+	// The real precondition for a portable unix install: the in-place swap is a
+	// rename WITHIN the binary's directory (see Apply), so it succeeds only when
+	// that directory is writable by the running service user. Checking this
+	// directly — instead of guessing from the path — is what lets a
+	// service-writable /opt/unitill kiosk install self-update, while a
+	// root-owned one honestly reports "no in-app update" rather than the old
+	// kiosk dead-end (board ut-docs#147).
+	return dirWritable(filepath.Dir(exe))
+}
+
+// supportedFor is the OS/location POLICY gate (pure, no filesystem access):
+// which install shapes can *ever* self-update. The final writability
+// precondition is applied by Supported(), not here.
+func supportedFor(exe, goos string) bool {
+	switch goos {
+	case "windows":
+		return false // updates via the installer
+	case "android", "ios":
+		// Neither has a real self-update mechanism. Apply() only ever fetches
+		// a unitill-pos_<version>_<goos>_<arch>.tar.gz archive (or, on darwin,
+		// a .dmg via applyMacApp); no such archive is published for
+		// android/ios (their release job attaches an .apk, nothing a self-swap
+		// can use), so "Update now" here would fail with a confusing "no
+		// release archive" error. False makes the status bar fall back to the
+		// plain download link instead (same as Windows). A real mobile
+		// updater (fetch the .apk, launch the package-install intent) is a
+		// feature to build later.
+		return false
+	case "darwin":
+		// A macOS .app updates via the .dmg (whole-bundle replace + relaunch),
+		// handled by applyMacApp — always location-eligible.
+		return true
+	}
+	// apt/dpkg owns the /usr system prefix — never self-swap there (its
+	// domain). /opt/unitill is NOT blocklisted: the Pi kiosk installs there as
+	// the service user and self-updates fine; the old blanket /opt block was
+	// the bug behind the kiosk dead-end (ut-docs#147). Whether this particular
+	// install can actually be swapped is decided by dirWritable in Supported().
+	if strings.HasPrefix(exe, "/usr/") {
+		return false
+	}
+	return true
+}
+
+// dirWritable reports whether dir can be written by the current process — the
+// precondition for the rename-based binary swap in Apply. It probes by
+// creating and removing a temp file, which honours ownership, ACLs and
+// read-only mounts more reliably than inspecting the mode bits. A non-existent
+// or non-writable directory returns false.
+func dirWritable(dir string) bool {
+	f, err := os.CreateTemp(dir, ".unitill-uptest-*")
+	if err != nil {
+		return false
+	}
+	name := f.Name()
+	_ = f.Close()
+	_ = os.Remove(name)
 	return true
 }
 

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -63,14 +63,24 @@ func Supported() bool {
 	if runtime.GOOS == "darwin" && appBundlePath(exe) != "" {
 		return true
 	}
-	// The real precondition for a portable unix install: the in-place swap is a
-	// rename WITHIN the binary's directory (see Apply), so it succeeds only when
-	// that directory is writable by the running service user. Checking this
-	// directly — instead of guessing from the path — is what lets a
-	// service-writable /opt/unitill kiosk install self-update, while a
-	// root-owned one honestly reports "no in-app update" rather than the old
-	// kiosk dead-end (board ut-docs#147).
-	return dirWritable(filepath.Dir(exe))
+	// The real precondition for a portable unix install: Apply's swaps are
+	// renames within (a) the binary's directory — for the binary + its .bak —
+	// and (b) the server's working directory — for the on-disk web/ override,
+	// which the server resolves cwd-relative, NOT next to the binary (the Pi
+	// kiosk runs /opt/unitill/bin/unitill-pos with cwd=/opt/unitill and web at
+	// /opt/unitill/web). Both must be writable by the service user, or Apply
+	// would fail — or worse, half-complete — mid-swap. Checking this directly,
+	// instead of guessing from the path, is what lets a service-writable
+	// /opt/unitill kiosk install self-update while a root-owned one honestly
+	// reports "no in-app update" rather than the old kiosk dead-end
+	// (board ut-docs#147).
+	if !dirWritable(filepath.Dir(exe)) {
+		return false
+	}
+	if cwd, err := os.Getwd(); err == nil && cwd != filepath.Dir(exe) && !dirWritable(cwd) {
+		return false
+	}
+	return true
 }
 
 // supportedFor is the OS/location POLICY gate (pure, no filesystem access):
@@ -164,6 +174,18 @@ func Apply(ctx context.Context) error {
 		}
 	}
 	installDir := filepath.Dir(exe)
+	// The server resolves its on-disk web/ override relative to its working
+	// directory (registerStatic → filepath.Join("web","public")), which is NOT
+	// necessarily the binary's directory: the Pi kiosk runs
+	// /opt/unitill/bin/unitill-pos with WorkingDirectory=/opt/unitill and web
+	// at /opt/unitill/web. Swap web/ where the server actually reads it, or a
+	// self-update silently serves stale /public assets over the freshly-swapped
+	// binary's newer embedded ones (ut-docs#148). For a flat portable install
+	// cwd == installDir, so this is unchanged there.
+	webBase := installDir
+	if cwd, err := os.Getwd(); err == nil {
+		webBase = cwd
+	}
 
 	rel, err := fetchLatest(ctx)
 	if err != nil {
@@ -235,7 +257,7 @@ func Apply(ctx context.Context) error {
 
 	// Swap web/ if the archive shipped it (keep a backup, best-effort).
 	if _, err := os.Stat(newWeb); err == nil {
-		curWeb := filepath.Join(installDir, "web")
+		curWeb := filepath.Join(webBase, "web")
 		webBak := curWeb + ".bak"
 		_ = os.RemoveAll(webBak)
 		if _, err := os.Stat(curWeb); err == nil {

--- a/internal/selfupdate/selfupdate_apply_test.go
+++ b/internal/selfupdate/selfupdate_apply_test.go
@@ -309,9 +309,15 @@ func TestApplyArchiveMissingBinary(t *testing.T) {
 	}
 }
 
-func TestApplyBackupFailureLeavesBinary(t *testing.T) {
+// A read-only install directory can't be swapped into. The writability
+// precondition (Supported → dirWritable) now catches this up front and returns
+// ErrUnsupported, so the binary is never touched and the UI shows the clean
+// "no in-app update" fallback rather than half-attempting a swap that fails at
+// the rename. (Before ut-docs#147 this only surfaced as a "back up current
+// binary" rename error mid-Apply.)
+func TestApplyReadOnlyDirIsUnsupportedAndLeavesBinary(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Skip("running as root; read-only dir does not block rename")
+		t.Skip("running as root; read-only dir does not block writes")
 	}
 	fix := newInstallFixture(t)
 	name := archiveNameFor("0.2.0")
@@ -325,11 +331,11 @@ func TestApplyBackupFailureLeavesBinary(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(fix.dir, 0o755) })
 	err := Apply(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "back up current binary") {
-		t.Fatalf("err = %v, want backup failure", err)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("err = %v, want ErrUnsupported for a read-only install dir", err)
 	}
 	if got, _ := os.ReadFile(fix.exe); string(got) != fix.oldBin {
-		t.Errorf("binary changed despite backup failure: %q", got)
+		t.Errorf("binary changed despite unwritable dir: %q", got)
 	}
 }
 

--- a/internal/selfupdate/selfupdate_apply_test.go
+++ b/internal/selfupdate/selfupdate_apply_test.go
@@ -126,9 +126,27 @@ type installFixture struct {
 	reexecd chan string
 }
 
+// chdirTo switches the process working directory for the duration of the test
+// (restored on cleanup). Safe here because these tests are non-parallel.
+func chdirTo(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+}
+
 func newInstallFixture(t *testing.T) *installFixture {
 	t.Helper()
 	dir := t.TempDir()
+	// Run "from" the install dir, like a real portable install (cwd ==
+	// installDir). Apply resolves the on-disk web/ override relative to cwd, so
+	// this both mirrors production and keeps the test off the real repo's web/.
+	chdirTo(t, dir)
 	exe := filepath.Join(dir, "unitill-pos")
 	f := &installFixture{dir: dir, exe: exe, oldBin: "OLD-BINARY-v1", reexecd: make(chan string, 1)}
 	if err := os.WriteFile(exe, []byte(f.oldBin), 0o755); err != nil {
@@ -194,6 +212,71 @@ func TestApplySuccessSwapsBinaryAndWeb(t *testing.T) {
 		if exe != fix.exe {
 			t.Errorf("re-exec'd %q, want %q", exe, fix.exe)
 		}
+	case <-time.After(2 * time.Second):
+		t.Error("re-exec never scheduled")
+	}
+}
+
+// Regression for ut-docs#148 (found reviewing the #147 fix): on the Pi kiosk
+// layout the binary lives in a bin/ subdir while web/ sits in the working
+// directory (the server reads it cwd-relative). Apply must swap web/ where the
+// server reads it (cwd/web), NOT next to the binary (cwd/bin/web) — otherwise a
+// self-update leaves stale /public assets shadowing the new embedded ones.
+func TestApplySwapsWebAtWorkingDirNotBinaryDir(t *testing.T) {
+	dir := t.TempDir()
+	chdirTo(t, dir) // cwd = install root, like unitill-pos.service WorkingDirectory
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	exe := filepath.Join(binDir, "unitill-pos")
+	if err := os.WriteFile(exe, []byte("OLD-BINARY-v1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "web"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "web", "index.html"), []byte("OLD-WEB"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reexecd := make(chan string, 1)
+	oldExec, oldReexec, oldDelay, oldVer := osExecutable, reexecFn, reexecDelay, buildinfo.Version
+	osExecutable = func() (string, error) { return exe, nil }
+	reexecFn = func(path string) error { reexecd <- path; return nil }
+	reexecDelay = 5 * time.Millisecond
+	buildinfo.Version = "0.1.0"
+	t.Cleanup(func() {
+		osExecutable, reexecFn, reexecDelay, buildinfo.Version = oldExec, oldReexec, oldDelay, oldVer
+	})
+
+	name := archiveNameFor("0.2.0")
+	archive := makeTarGz(t, []tarEntry{
+		{name: "unitill-pos", body: "NEW-BINARY-v2"},
+		{name: "web", dir: true},
+		{name: "web/index.html", body: "NEW-WEB"},
+	})
+	newReleaseServer(t, "v0.2.0", map[string][]byte{
+		name:            archive,
+		"checksums.txt": []byte(sha256hex(archive) + "  " + name + "\n"),
+	})
+
+	if err := Apply(context.Background()); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got, _ := os.ReadFile(exe); string(got) != "NEW-BINARY-v2" {
+		t.Errorf("binary not swapped, content = %q", got)
+	}
+	// web/ swapped at the working dir (where the server reads it)...
+	if got, _ := os.ReadFile(filepath.Join(dir, "web", "index.html")); string(got) != "NEW-WEB" {
+		t.Errorf("web not swapped at cwd/web, content = %q", got)
+	}
+	// ...NOT dumped next to the binary where nothing reads it.
+	if _, err := os.Stat(filepath.Join(binDir, "web")); !os.IsNotExist(err) {
+		t.Errorf("web wrongly written under the binary dir (bin/web): err=%v", err)
+	}
+	select {
+	case <-reexecd:
 	case <-time.After(2 * time.Second):
 		t.Error("re-exec never scheduled")
 	}

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -1,10 +1,21 @@
 package selfupdate
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
-// In-app update is supported for portable archives (.tar.gz swap) AND macOS
-// .app bundles (whole-.dmg replace via applyMacApp). It must refuse a .deb
-// (/usr, /opt → apt) and Windows (installer).
+// supportedFor is the OS/location POLICY gate (pure, no filesystem access):
+// which install shapes can ever self-update. Windows uses its installer;
+// android/ios have no self-swap; apt owns /usr. macOS is always eligible (the
+// .dmg whole-bundle replace via applyMacApp). Everything else on unix is
+// location-eligible — the final precondition (is the binary's dir actually
+// writable by the running service user?) is applied by Supported() via
+// dirWritable, NOT here. /opt/unitill is deliberately NOT blocklisted: the Pi
+// kiosk installs there as the service user, and that install self-updates
+// fine — the old blanket /opt block was the bug behind the kiosk dead-end
+// (board ut-docs#147).
 func TestSupportedFor(t *testing.T) {
 	cases := []struct {
 		name string
@@ -15,8 +26,8 @@ func TestSupportedFor(t *testing.T) {
 		{"mac .app bundle", "/Applications/Universal Till.app/Contents/MacOS/unitill-pos", "darwin", true},
 		{"mac portable archive", "/Users/ali/unitill/unitill-pos", "darwin", true},
 		{"linux portable archive", "/home/ali/unitill/unitill-pos", "linux", true},
-		{"deb /usr", "/usr/bin/unitill-pos", "linux", false},
-		{"deb /opt", "/opt/unitill/unitill-pos", "linux", false},
+		{"linux /opt kiosk install (writability decides in Supported)", "/opt/unitill/bin/unitill-pos", "linux", true},
+		{"deb /usr (apt's domain)", "/usr/bin/unitill-pos", "linux", false},
 		{"windows", `C:\\Program Files\\UniversalTill\\unitill-pos.exe`, "windows", false},
 		{"android", "/data/app/com.universaltill.pos/lib/arm64/libmobile.so", "android", false},
 		{"ios", "/var/containers/Bundle/Application/x/Universal Till.app/unitill-pos", "ios", false},
@@ -25,6 +36,35 @@ func TestSupportedFor(t *testing.T) {
 		if got := supportedFor(c.exe, c.goos); got != c.want {
 			t.Errorf("%s: supportedFor(%q,%q) = %v, want %v", c.name, c.exe, c.goos, got, c.want)
 		}
+	}
+}
+
+// dirWritable is the real self-update precondition: the rename-based binary
+// swap (os.Rename within the binary's directory) only succeeds where that
+// directory is writable by the current process. A service-writable /opt/unitill
+// kiosk install passes; a root-owned one (or a missing dir) fails — which is
+// exactly why the kiosk should report "no in-app update" instead of dead-ending
+// at a website link it can't act on.
+func TestDirWritable(t *testing.T) {
+	// A freshly-created temp dir is writable by us.
+	if !dirWritable(t.TempDir()) {
+		t.Errorf("expected a temp dir to be writable")
+	}
+	// A path that does not exist can never be swapped into. (Deterministic
+	// regardless of uid — unlike a chmod 0555 dir, which root would still
+	// write, flaking in root-run CI containers.)
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if dirWritable(missing) {
+		t.Errorf("expected a non-existent dir to be reported not writable")
+	}
+	// Sanity: a real file's parent (the temp dir) is writable, a bare file is
+	// not a directory we can create siblings in only if its parent isn't.
+	f := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(f, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !dirWritable(f) {
+		t.Errorf("expected an owned 0755 dir to be writable")
 	}
 }
 

--- a/web/locales/ar.json
+++ b/web/locales/ar.json
@@ -666,6 +666,7 @@
   "settings.update.download": "تنزيل",
   "settings.update.title": "تحديث البرنامج",
   "settings.update.up_to_date": "أنت على أحدث إصدار",
+  "settings.update.unavailable_here": "التحديث داخل التطبيق غير متاح لهذا التثبيت",
   "settings.value": "القيمة",
   "setup.back": "رجوع",
   "setup.country.ae": "الإمارات العربية المتحدة",

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -666,6 +666,7 @@
   "settings.update.download": "Download",
   "settings.update.title": "Software update",
   "settings.update.up_to_date": "You are up to date",
+  "settings.update.unavailable_here": "In-app update isn't available for this install",
   "settings.value": "Value",
   "setup.back": "Back",
   "setup.country.ae": "United Arab Emirates",

--- a/web/locales/fa.json
+++ b/web/locales/fa.json
@@ -666,6 +666,7 @@
   "settings.update.download": "دانلود",
   "settings.update.title": "به‌روزرسانی نرم‌افزار",
   "settings.update.up_to_date": "شما به‌روز هستید",
+  "settings.update.unavailable_here": "به‌روزرسانی درون‌برنامه‌ای برای این نصب در دسترس نیست",
   "settings.value": "مقدار",
   "setup.back": "قبلی",
   "setup.country.ae": "امارات متحده عربی",

--- a/web/locales/tr.json
+++ b/web/locales/tr.json
@@ -666,6 +666,7 @@
   "settings.update.download": "İndir",
   "settings.update.title": "Yazılım güncellemesi",
   "settings.update.up_to_date": "Güncelsiniz",
+  "settings.update.unavailable_here": "Bu kurulum için uygulama içi güncelleme kullanılamıyor",
   "settings.value": "Değer",
   "setup.back": "Geri",
   "setup.country.ae": "Birleşik Arap Emirlikleri",


### PR DESCRIPTION
Fixes the Pi kiosk self-update dead-end (board ut-docs#147, p1 field report).

**Root cause (two coupled):**
1. `supportedFor()` blanket-blocklisted `/opt/unitill/*` as "packaged → apt", but the Pi installs a portable binary there owned by the `pos` service user — self-updatable. The path prefix was a wrong proxy.
2. The real precondition for the in-place swap (`os.Rename` within the binary's dir) is that the dir is **writable by the service user** — nothing checked it.

**Fix:** `supportedFor()` is now a pure OS/location policy gate (windows/mobile never; `/usr` stays apt's; else — incl. `/opt/unitill` — location-eligible); `Supported()` applies the real precondition via a `dirWritable()` probe. A service-writable kiosk install self-updates end-to-end; a root-owned one honestly reports "no in-app update" and never touches the binary.

**Also:** the update-check fallback no longer renders a website link on non-Windows (a dead end on a fullscreen kiosk) — Windows keeps the actionable link, unix shows a plain message (new i18n key, 4 locales). A correctly provisioned kiosk shows the inline Apply button instead.

**Verification:** unit tests (writability + policy split, fallback link/no-link); independent review; real-Pi4 end-to-end (in progress — device authorized).

Closes universaltill/ut-docs#147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PC7bUiXcj47ztWSZnNNG8V