### PR TITLE
test: coverage batch 12 — marketplace/httpx/db + typed-nil i18n panic fix

### DIFF
--- a/docs/code-reviews/2026-07-31-coverage-batch-12-marketplace-httpx-db.md
+++ b/docs/code-reviews/2026-07-31-coverage-batch-12-marketplace-httpx-db.md
@@ -1,0 +1,46 @@
+# Code review — coverage batch 12: marketplace, httpx, db (2026-07-31)
+
+**Branch:** `test/coverage-batch-12-marketplace-httpx-db` (ut-docs#9, batch 12)
+**Scope:** test-only additions in three packages + one small production fix in `internal/httpx`.
+
+## What shipped
+
+- `internal/httpx/template_helpers_test.go` — render pipeline (NewRenderer/Render/RenderWith), JSON handler wrapper, template-helper family (minorUnits, toJSON, imgVersion, IsRTL, Currencies), init/clamp functions (UI scale, OSK mode, idle lock, kiosk), T/DefaultLocale/ResolveLocale fallbacks, mux dispatch.
+- `internal/plugins/marketplace/client_more_test.go` — ResolveURL, DeviceIDFromConfig, AckDownload, ReportPluginStatus (opt-in posts, opt-out sends nothing, server error), GetRevocations, IssueDownloadToken error envelopes (each branch's distinct message pinned), GetOrFetch cache/fetch/offline, corrupt-snapshot handling, cache-dir failure.
+- `internal/db/tx_test.go` + `backup_more_test.go` — WithTx commit/rollback/begin-error, StageRestoreFromReader staging + failed-copy cleanup, Open with uncreatable data dir, backup-dir error propagation, Snapshot on closed DB, StageRestore missing backup, ApplyReplicaIdentity no-file/corrupt-file.
+- **Production fix:** `internal/httpx/httpx.go` — `T()` and the `FuncsFor` `"T"`/`"locales"` closures guarded with an interface nil-check that a typed-nil `*config.I18n` (stored by `InitI18n(nil, …)`) passes, then panicked on `mu.RLock` of a nil receiver. New `translator()` helper does a typed assertion. TDD: test written first, confirmed panicking pre-fix (nil pointer dereference at `config/i18n.go:69`), passing post-fix. No behavior change for real callers — the only production caller (`internal/pages/init.go`) always passes a non-nil translator; typed-nil now degrades to key-fallback instead of panicking.
+
+## Coverage
+
+| package | before | after |
+|---|---|---|
+| internal/httpx | 65.1% | 94.5% |
+| internal/plugins/marketplace | 62.3% | 85.7% |
+| internal/db | 66.7% | 79.8% |
+
+Accepted remainder (documented, not theater): `db` migrate/applyMigration/loadMigrations error branches need fault injection into embedded migrations; Snapshot same-second reuse branch is timing-dependent; ApplyPendingRestore rename-failure branches need forced-IO mocking. `marketplace` doRequest/doWithFallback internals partially covered by existing dev-override tests. `httpx` remainder is assetVersion boot-time fallback and template-func plumbing exercised only via full renders.
+
+## Verification beyond automated tests
+
+- Full `go test ./...` green; `go vet` clean; `guard-data-access.sh` and `guard-i18n.sh` pass.
+- Mutation spot-checks by Tester (all correctly failed their new test): WithTx ignoring fn error → `TestWithTxRollsBackOnError` FAIL; telemetry opt-out check removed → `TestReportPluginStatusOptOutSendsNothing` FAIL; staged-restore cleanup removed → `TestStageRestoreFromReaderCleansUpOnCopyError` FAIL.
+- TDD claim re-verified by Reviewer personally: fix stashed → panic reproduced; restored → green.
+
+## Independent review (different model: Opus subagent)
+
+Ran build/vet/tests itself, including `-race` and 6× `-shuffle=on` runs on httpx. Independently re-verified the typed-nil fix by restoring the pre-fix code and watching the test panic. Verdict: nothing blocking; 2 should-fix + 5 nits, **all fixed**:
+
+1. **Should-fix (proven false-pass):** the `"error envelope"` subcase of `TestIssueDownloadTokenErrorPaths` still passed with the error-envelope branch deleted (fell through to the missing-data error). Fixed by pinning each subcase's distinct error message; mutation re-run now FAILs correctly. Same message-pinning applied to the AckDownload/GetRevocations/ReportPluginStatus server-error tests.
+2. **Should-fix (tautology):** `TestNewMux` only nil-checked a `http.NewServeMux()` wrapper — unfailable. Replaced with a real dispatch assertion.
+3. Nits, all applied: length guard in the stripWebPrefixes comparison; `defer` restores for the uiScale/oskMode/idleLock package atomics; `realI18n` helper deduplicated into `httpx_test.go`; comment documenting that `StageRestoreFromReader`'s no-MkdirAll behavior is deliberate (staging happens next to an existing DB); removed redundant `io.Reader` interface assertion.
+
+Review also confirmed: no real client/shop names, no credential-shaped literals, no leaked httptest servers, money/data-access/i18n rules respected, and neither recurring bug class (missing MkdirAll / cwd-relative path) applies to the production diff.
+
+## Verdict
+
+**Safe to merge.** Test-only change plus a strictly-defensive production fix, all gates green after review fixes.
+
+## Deferred
+
+- `internal/plugins/storage` (39.3%) stays excluded — dead-code decision is ut-docs#28.
+- Next-lowest packages for batch 13 (from this batch's sweep): `internal/ai` 68.3%, `internal/paths` 69.7%, `internal/logging` 73.5%, `internal/pos` 74.4%.

--- a/internal/db/backup_more_test.go
+++ b/internal/db/backup_more_test.go
@@ -1,0 +1,87 @@
+package db
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// blockedDBPath returns a db path whose parent "directory" is a regular file,
+// so any MkdirAll under it fails — the cheap, real way to reach the
+// filesystem error branches without fault injection.
+func blockedDBPath(t *testing.T) string {
+	t.Helper()
+	blocker := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+	return filepath.Join(blocker, "unitill-pos.db")
+}
+
+func TestBackupDirFailsWhenParentIsFile(t *testing.T) {
+	if _, err := BackupDir(blockedDBPath(t)); err == nil {
+		t.Fatal("BackupDir under a file: want error")
+	}
+}
+
+func TestListBackupsPropagatesBackupDirError(t *testing.T) {
+	if _, err := ListBackups(blockedDBPath(t)); err == nil {
+		t.Fatal("ListBackups under a file: want error")
+	}
+}
+
+func TestPruneBackupsPropagatesListError(t *testing.T) {
+	if err := PruneBackups(blockedDBPath(t), 3); err == nil {
+		t.Fatal("PruneBackups under a file: want error")
+	}
+}
+
+func TestSnapshotFailsOnClosedDB(t *testing.T) {
+	dir := t.TempDir()
+	sqlDB, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	sqlDB.Close()
+	if _, err := Snapshot(sqlDB, filepath.Join(dir, "unitill-pos.db")); err == nil {
+		t.Fatal("Snapshot on closed DB: want error")
+	}
+}
+
+func TestStageRestoreRejectsMissingBackup(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "unitill-pos.db")
+	err := StageRestore(dbPath, "unitill-pos-20990101-000000.db")
+	if err == nil || !strings.Contains(err.Error(), "backup not found") {
+		t.Fatalf("StageRestore missing backup = %v; want backup not found", err)
+	}
+}
+
+func TestApplyReplicaIdentityNoFileIsNoop(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "unitill-pos.db")
+	d, err := Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+	applied, err := ApplyReplicaIdentity(d.DB, path)
+	if err != nil || applied {
+		t.Fatalf("ApplyReplicaIdentity without identity file: applied=%v err=%v; want false,nil", applied, err)
+	}
+}
+
+func TestApplyReplicaIdentityRejectsCorruptFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "unitill-pos.db")
+	d, err := Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+	if err := os.WriteFile(ReplicaIdentityPath(path), []byte("{corrupt"), 0o600); err != nil {
+		t.Fatalf("write corrupt identity: %v", err)
+	}
+	if _, err := ApplyReplicaIdentity(d.DB, path); err == nil {
+		t.Fatal("ApplyReplicaIdentity with corrupt identity: want error")
+	}
+}

--- a/internal/db/tx_test.go
+++ b/internal/db/tx_test.go
@@ -1,0 +1,135 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func memDB(t *testing.T) *sql.DB {
+	t.Helper()
+	sqlDB, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { sqlDB.Close() })
+	if _, err := sqlDB.Exec(`CREATE TABLE t (n INTEGER)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	return sqlDB
+}
+
+func countRows(t *testing.T, sqlDB *sql.DB) int {
+	t.Helper()
+	var n int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM t`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	return n
+}
+
+func TestWithTxCommits(t *testing.T) {
+	sqlDB := memDB(t)
+	err := WithTx(context.Background(), sqlDB, func(tx *sql.Tx) error {
+		_, err := tx.Exec(`INSERT INTO t (n) VALUES (1)`)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("WithTx: %v", err)
+	}
+	if got := countRows(t, sqlDB); got != 1 {
+		t.Fatalf("rows after commit = %d; want 1", got)
+	}
+}
+
+func TestWithTxRollsBackOnError(t *testing.T) {
+	sqlDB := memDB(t)
+	boom := errors.New("boom")
+	err := WithTx(context.Background(), sqlDB, func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`INSERT INTO t (n) VALUES (1)`); err != nil {
+			return err
+		}
+		return boom
+	})
+	if !errors.Is(err, boom) {
+		t.Fatalf("WithTx error = %v; want the fn's own error", err)
+	}
+	if got := countRows(t, sqlDB); got != 0 {
+		t.Fatalf("rows after rollback = %d; want 0", got)
+	}
+}
+
+func TestWithTxBeginError(t *testing.T) {
+	sqlDB := memDB(t)
+	sqlDB.Close()
+	err := WithTx(context.Background(), sqlDB, func(tx *sql.Tx) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "begin tx") {
+		t.Fatalf("WithTx on closed DB = %v; want begin tx error", err)
+	}
+}
+
+func TestStageRestoreFromReaderStagesPendingFile(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "unitill-pos.db")
+	if err := StageRestoreFromReader(dbPath, strings.NewReader("snapshot-bytes")); err != nil {
+		t.Fatalf("StageRestoreFromReader: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, restorePendingName))
+	if err != nil {
+		t.Fatalf("read pending file: %v", err)
+	}
+	if string(got) != "snapshot-bytes" {
+		t.Fatalf("pending file content = %q", got)
+	}
+}
+
+// failingReader errors mid-copy, like a dropped download connection.
+type failingReader struct{ served bool }
+
+func (f *failingReader) Read(p []byte) (int, error) {
+	if f.served {
+		return 0, errors.New("connection reset")
+	}
+	f.served = true
+	n := copy(p, "partial")
+	return n, nil
+}
+
+func TestStageRestoreFromReaderCleansUpOnCopyError(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "unitill-pos.db")
+	err := StageRestoreFromReader(dbPath, &failingReader{})
+	if err == nil {
+		t.Fatal("StageRestoreFromReader with failing reader: want error")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, restorePendingName)); !os.IsNotExist(statErr) {
+		t.Fatalf("partial pending file left behind (stat err = %v)", statErr)
+	}
+}
+
+func TestStageRestoreFromReaderFailsWhenDirMissing(t *testing.T) {
+	// Deliberate: StageRestoreFromReader stages NEXT TO an existing DB (whose
+	// dir Open() already created) — staging beside a nonexistent DB is a
+	// genuine error, not a missing-MkdirAll bug.
+	dbPath := filepath.Join(t.TempDir(), "no-such-dir", "unitill-pos.db")
+	if err := StageRestoreFromReader(dbPath, strings.NewReader("x")); err == nil {
+		t.Fatal("StageRestoreFromReader into missing dir: want error")
+	}
+}
+
+func TestOpenFailsWhenDataDirUncreatable(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "file")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+	// Parent "directory" is a regular file — MkdirAll must fail.
+	_, err := Open(filepath.Join(blocker, "sub", "unitill-pos.db"))
+	if err == nil || !strings.Contains(err.Error(), "create data dir") {
+		t.Fatalf("Open under a file = %v; want create data dir error", err)
+	}
+}

--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -192,11 +192,19 @@ func IsRTL(locale string) bool {
 	return false
 }
 
+// translator returns the wired i18n, or nil. The typed assertion matters:
+// InitI18n(nil, ...) stores a typed nil *config.I18n, which an interface
+// nil-check alone would treat as present and then panic on method call.
+func translator() *config.I18n {
+	t, _ := i18nRef.Load().(*config.I18n)
+	return t
+}
+
 // T translates a key for a locale outside templates (handlers building toasts
 // or fragments). Falls back to the key itself, mirroring the template func.
 func T(locale, key string) string {
-	if tAny := i18nRef.Load(); tAny != nil {
-		return tAny.(*config.I18n).T(locale, key)
+	if t := translator(); t != nil {
+		return t.T(locale, key)
 	}
 	return key
 }
@@ -313,14 +321,14 @@ func FuncsFor(locale string) template.FuncMap {
 		return "ltr"
 	}
 	funcs["locales"] = func() []string {
-		if tAny := i18nRef.Load(); tAny != nil {
-			return tAny.(*config.I18n).Available()
+		if t := translator(); t != nil {
+			return t.Available()
 		}
 		return []string{"en"}
 	}
 	funcs["T"] = func(key string) string {
-		if tAny := i18nRef.Load(); tAny != nil {
-			return tAny.(*config.I18n).T(locale, key)
+		if t := translator(); t != nil {
+			return t.T(locale, key)
 		}
 		return key
 	}

--- a/internal/httpx/httpx_test.go
+++ b/internal/httpx/httpx_test.go
@@ -4,10 +4,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"testing"
 
-	config "github.com/universaltill/universal-till/internal/config"
 	moneypkg "github.com/universaltill/universal-till/internal/money"
 )
 
@@ -116,12 +114,7 @@ func TestResolveLocaleCookieFallback(t *testing.T) {
 
 func TestFuncsForExposesMoneyAndI18n(t *testing.T) {
 	InitCurrency("EUR")
-	locales := filepath.Join("..", "..", "web", "locales")
-	i18n, err := config.NewI18n(locales, "en")
-	if err != nil {
-		t.Fatalf("NewI18n: %v", err)
-	}
-	InitI18n(i18n, "en")
+	InitI18n(realI18n(t), "en")
 
 	// money is locale-bound now: an en locale keeps Latin digits…
 	funcs := FuncsFor("en")

--- a/internal/httpx/template_helpers_test.go
+++ b/internal/httpx/template_helpers_test.go
@@ -1,0 +1,331 @@
+package httpx
+
+import (
+	"encoding/json"
+	"errors"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	config "github.com/universaltill/universal-till/internal/config"
+	moneypkg "github.com/universaltill/universal-till/internal/money"
+)
+
+func realI18n(t *testing.T) *config.I18n {
+	t.Helper()
+	i18n, err := config.NewI18n(filepath.Join("..", "..", "web", "locales"), "en")
+	if err != nil {
+		t.Fatalf("NewI18n: %v", err)
+	}
+	return i18n
+}
+
+// TestTFallsBackToKeyWithoutTranslator guards the typed-nil trap: InitI18n(nil,
+// ...) stores a typed nil *config.I18n in the atomic, which still compares
+// non-nil as an interface — T must fall back to the key, not call a method on
+// a nil receiver and panic.
+func TestTFallsBackToKeyWithoutTranslator(t *testing.T) {
+	InitI18n(nil, "en")
+	if got := T("en", "some.key"); got != "some.key" {
+		t.Fatalf("T without translator = %q; want the key itself", got)
+	}
+}
+
+func TestTTranslatesWithRealTranslator(t *testing.T) {
+	InitI18n(realI18n(t), "en")
+	got := T("en", "nav.settings")
+	if got == "" || got == "nav.settings" {
+		t.Fatalf("T with real translator returned %q; want a translation", got)
+	}
+	// Unknown keys fall back to the key.
+	if got := T("en", "definitely.not.a.key"); got != "definitely.not.a.key" {
+		t.Fatalf("T unknown key = %q; want key fallback", got)
+	}
+}
+
+// TestFuncsForTAndLocalesWithoutTranslator covers the same typed-nil trap for
+// the closures FuncsFor hands to templates.
+func TestFuncsForTAndLocalesWithoutTranslator(t *testing.T) {
+	InitI18n(nil, "en")
+	funcs := FuncsFor("en")
+	tFn := funcs["T"].(func(string) string)
+	if got := tFn("some.key"); got != "some.key" {
+		t.Fatalf("template T without translator = %q; want the key", got)
+	}
+	localesFn := funcs["locales"].(func() []string)
+	if got := localesFn(); len(got) != 1 || got[0] != "en" {
+		t.Fatalf("locales without translator = %v; want [en]", got)
+	}
+}
+
+func TestDefaultLocale(t *testing.T) {
+	InitI18n(nil, "de")
+	if got := DefaultLocale(); got != "de" {
+		t.Fatalf("DefaultLocale = %q; want de", got)
+	}
+	InitI18n(nil, "")
+	if got := DefaultLocale(); got != "en" {
+		t.Fatalf("DefaultLocale with empty fallback = %q; want en", got)
+	}
+	InitI18n(nil, "en") // restore the value other tests assume
+}
+
+func TestResolveLocaleFallsBackToEnWithEmptyDefault(t *testing.T) {
+	InitI18n(nil, "")
+	defer InitI18n(nil, "en")
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	if got := ResolveLocale(w, r); got != "en" {
+		t.Fatalf("ResolveLocale with empty default = %q; want en", got)
+	}
+}
+
+func TestStripWebPrefixes(t *testing.T) {
+	got := stripWebPrefixes([]string{
+		filepath.Join("web", "ui", "pages", "x.html"),
+		"ui/partials/nav.html", // already stripped stays as-is
+	})
+	want := []string{"ui/pages/x.html", "ui/partials/nav.html"}
+	if len(got) != len(want) {
+		t.Fatalf("stripWebPrefixes returned %d entries; want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("stripWebPrefixes[%d] = %q; want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestNewRendererRendersEmbeddedPage(t *testing.T) {
+	InitI18n(realI18n(t), "en")
+	r, err := NewRenderer(
+		filepath.Join("web", "ui", "layouts", "base.html"),
+		filepath.Join("web", "ui", "pages", "pin.html"),
+		FuncsFor("en"),
+	)
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	w := httptest.NewRecorder()
+	data := map[string]any{"title": "Change PIN", "theme": "", "menuItems": nil, "errKey": ""}
+	if err := r.Render(w, "base", data); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !strings.Contains(w.Body.String(), "<html") {
+		t.Fatalf("rendered page missing <html>: %.200s", w.Body.String())
+	}
+}
+
+func TestNewRendererFailsOnMissingPage(t *testing.T) {
+	_, err := NewRenderer(
+		filepath.Join("web", "ui", "layouts", "base.html"),
+		filepath.Join("web", "ui", "pages", "no-such-page.html"),
+		template.FuncMap{},
+	)
+	if err == nil {
+		t.Fatal("NewRenderer with a missing page: want error, got nil")
+	}
+}
+
+func TestRenderWithRendersAndReports500OnBadFile(t *testing.T) {
+	InitI18n(realI18n(t), "en")
+	files := []string{
+		filepath.Join("web", "ui", "layouts", "base.html"),
+		filepath.Join("web", "ui", "pages", "pin.html"),
+		filepath.Join("web", "ui", "partials", "nav.html"),
+	}
+	h := RenderWith(files, FuncsFor("en"))("base", map[string]any{
+		"title": "Change PIN", "theme": "", "menuItems": nil, "errKey": "",
+	})
+	w := httptest.NewRecorder()
+	h(w, httptest.NewRequest("GET", "/pin", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("RenderWith = %d: %s", w.Code, w.Body.String())
+	}
+
+	bad := RenderWith([]string{"web/ui/pages/no-such.html"}, template.FuncMap{})("base", nil)
+	w = httptest.NewRecorder()
+	bad(w, httptest.NewRequest("GET", "/", nil))
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("RenderWith missing file = %d; want 500", w.Code)
+	}
+}
+
+func TestNewMuxDispatchesRegisteredRoutes(t *testing.T) {
+	mux := NewMux()
+	mux.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, httptest.NewRequest("GET", "/ping", nil))
+	if w.Code != http.StatusTeapot {
+		t.Fatalf("mux dispatch = %d; want 418", w.Code)
+	}
+}
+
+func TestJSONHandlerSuccessAndError(t *testing.T) {
+	type in struct {
+		Name string `json:"name"`
+	}
+	ok := JSON(func(i in) (map[string]string, error) {
+		return map[string]string{"hello": i.Name}, nil
+	})
+	w := httptest.NewRecorder()
+	ok(w, httptest.NewRequest("POST", "/", strings.NewReader(`{"name":"till"}`)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("JSON success status = %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("Content-Type = %q", ct)
+	}
+	var out map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out["hello"] != "till" {
+		t.Fatalf("body = %v; want hello=till", out)
+	}
+
+	fail := JSON(func(i in) (map[string]string, error) {
+		return nil, errors.New("boom")
+	})
+	w = httptest.NewRecorder()
+	fail(w, httptest.NewRequest("POST", "/", strings.NewReader(`{}`)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("JSON error status = %d; want 400", w.Code)
+	}
+	var errOut map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &errOut); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if errOut["error"] != "boom" {
+		t.Fatalf("error body = %v; want error=boom", errOut)
+	}
+}
+
+func TestToJSON(t *testing.T) {
+	got := toJSON(map[string]int{"a": 1})
+	if string(got) != `{"a":1}` {
+		t.Fatalf("toJSON = %s", got)
+	}
+}
+
+func TestMinorUnits(t *testing.T) {
+	cases := []struct {
+		in   any
+		want int64
+		ok   bool
+	}{
+		{moneypkg.FromMinor(1234), 1234, true},
+		{int64(99), 99, true},
+		{int(7), 7, true},
+		{int32(8), 8, true},
+		{"nope", 0, false},
+		{1.5, 0, false},
+	}
+	for _, c := range cases {
+		got, ok := minorUnits(c.in)
+		if got != c.want || ok != c.ok {
+			t.Fatalf("minorUnits(%v) = %d,%v; want %d,%v", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestInitUIScaleClampsAndScalesRootPx(t *testing.T) {
+	defer InitUIScale(1.0)
+	InitUIScale(1.3)
+	if got := uiScalePx(); got != "20.8" {
+		t.Fatalf("uiScalePx(1.3) = %q; want 20.8", got)
+	}
+	InitUIScale(3.0) // out of range resets to 1.0
+	if got := uiScalePx(); got != "16" {
+		t.Fatalf("uiScalePx(out-of-range) = %q; want 16", got)
+	}
+	InitUIScale(0.4) // below range resets to 1.0
+	if got := uiScalePx(); got != "16" {
+		t.Fatalf("uiScalePx(below-range) = %q; want 16", got)
+	}
+}
+
+func TestInitOSKModeValidatesInput(t *testing.T) {
+	defer InitOSKMode("auto")
+	InitOSKMode("on")
+	if got := oskModeVal(); got != "on" {
+		t.Fatalf("oskModeVal = %q; want on", got)
+	}
+	InitOSKMode("bogus")
+	if got := oskModeVal(); got != "auto" {
+		t.Fatalf("oskModeVal after invalid mode = %q; want auto", got)
+	}
+}
+
+func TestInitIdleLockConvertsMinutesAndClampsNegative(t *testing.T) {
+	defer InitIdleLock(0)
+	InitIdleLock(5)
+	if got := idleLockSecs.Load(); got != 300 {
+		t.Fatalf("idleLockSecs = %d; want 300", got)
+	}
+	InitIdleLock(-3)
+	if got := idleLockSecs.Load(); got != 0 {
+		t.Fatalf("idleLockSecs negative = %d; want 0", got)
+	}
+}
+
+func TestInitKioskExposedToTemplates(t *testing.T) {
+	InitKiosk(true)
+	defer InitKiosk(false)
+	kioskFn := FuncsFor("en")["kiosk"].(func() bool)
+	if !kioskFn() {
+		t.Fatal("kiosk template func = false after InitKiosk(true)")
+	}
+	InitKiosk(false)
+	if kioskFn() {
+		t.Fatal("kiosk template func = true after InitKiosk(false)")
+	}
+}
+
+func TestCurrenciesRegistryIsUsable(t *testing.T) {
+	all := Currencies()
+	if len(all) == 0 {
+		t.Fatal("Currencies() is empty")
+	}
+	seenGBP := false
+	for _, c := range all {
+		if c.Code == "" || c.Display == "" || c.Name == "" {
+			t.Fatalf("currency with empty field: %+v", c)
+		}
+		if c.Code == "GBP" {
+			seenGBP = true
+		}
+	}
+	if !seenGBP {
+		t.Fatal("GBP missing from the currency registry")
+	}
+}
+
+func TestImgVersionOnlyStampsPublicURLs(t *testing.T) {
+	if got := imgVersion("/public/items/a.png"); !strings.HasPrefix(got, "/public/items/a.png?v=") {
+		t.Fatalf("imgVersion(public) = %q; want ?v= suffix", got)
+	}
+	if got := imgVersion("/ui/logo.png"); got != "/ui/logo.png" {
+		t.Fatalf("imgVersion(non-public) = %q; want unchanged", got)
+	}
+	if got := imgVersion("public/items/a.png"); got != "public/items/a.png" {
+		t.Fatalf("imgVersion(no leading slash) = %q; want unchanged", got)
+	}
+}
+
+func TestIsRTL(t *testing.T) {
+	cases := map[string]bool{
+		"fa": true, "fa-IR": true, "ar_SA": true, "he": true, "ur": true,
+		"en": false, "en-GB": false, "tr": false, "": false,
+	}
+	for locale, want := range cases {
+		if got := IsRTL(locale); got != want {
+			t.Fatalf("IsRTL(%q) = %v; want %v", locale, got, want)
+		}
+	}
+}

--- a/internal/plugins/marketplace/client_more_test.go
+++ b/internal/plugins/marketplace/client_more_test.go
@@ -1,0 +1,355 @@
+package marketplace
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/universaltill/universal-till/internal/config"
+)
+
+func testClient(t *testing.T, endpoint string) *Client {
+	t.Helper()
+	cfg := &config.MarketplaceConfig{
+		EndpointURL:       endpoint,
+		APIVersion:        "1.0.0",
+		RequestTimeoutSec: 5,
+	}
+	return NewClient(cfg, &mockTokenClient{token: "test-token"})
+}
+
+func TestResolveURL(t *testing.T) {
+	c := testClient(t, "https://market.example.com")
+
+	got, err := c.ResolveURL("/api/v1/downloads/artifact/abc")
+	if err != nil {
+		t.Fatalf("ResolveURL relative: %v", err)
+	}
+	if got != "https://market.example.com/api/v1/downloads/artifact/abc" {
+		t.Fatalf("ResolveURL relative = %q", got)
+	}
+
+	abs := "https://cdn.example.com/bundle.tar.gz"
+	got, err = c.ResolveURL(abs)
+	if err != nil {
+		t.Fatalf("ResolveURL absolute: %v", err)
+	}
+	if got != abs {
+		t.Fatalf("ResolveURL absolute = %q; want unchanged", got)
+	}
+
+	bad := testClient(t, "://not-a-url")
+	if _, err := bad.ResolveURL("/x"); err == nil {
+		t.Fatal("ResolveURL with invalid endpoint: want error")
+	}
+}
+
+func TestDeviceIDFromConfig(t *testing.T) {
+	if got := DeviceIDFromConfig(nil); got != "pos-device-1" {
+		t.Fatalf("DeviceIDFromConfig(nil) = %q", got)
+	}
+	if got := DeviceIDFromConfig(&config.MarketplaceConfig{DeviceID: "till-7"}); got != "till-7" {
+		t.Fatalf("DeviceIDFromConfig(explicit) = %q", got)
+	}
+	// No explicit id: falls back to the hostname when one exists.
+	hostname, _ := os.Hostname()
+	if hostname == "" {
+		t.Skip("no hostname on this machine")
+	}
+	if got := DeviceIDFromConfig(&config.MarketplaceConfig{}); got != hostname {
+		t.Fatalf("DeviceIDFromConfig(fallback) = %q; want hostname %q", got, hostname)
+	}
+}
+
+func TestAckDownload(t *testing.T) {
+	var gotReq AckDownloadRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/download/ack" || r.Method != http.MethodPost {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
+			t.Errorf("decode ack: %v", err)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := testClient(t, server.URL)
+	err := c.AckDownload(context.Background(), &AckDownloadRequest{
+		PluginID: "p1", Version: "1.0.0", Token: "tok", Success: true,
+	})
+	if err != nil {
+		t.Fatalf("AckDownload: %v", err)
+	}
+	if gotReq.PluginID != "p1" || !gotReq.Success {
+		t.Fatalf("server saw %+v", gotReq)
+	}
+}
+
+func TestAckDownloadServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	err := testClient(t, server.URL).AckDownload(context.Background(), &AckDownloadRequest{PluginID: "p1"})
+	if err == nil || !strings.Contains(err.Error(), "status 500") {
+		t.Fatalf("AckDownload on 500 = %v; want status 500 error", err)
+	}
+}
+
+func TestReportPluginStatusOptInPosts(t *testing.T) {
+	var got ReportPluginStatusRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/telemetry/status" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decode telemetry: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := &config.MarketplaceConfig{
+		EndpointURL:       server.URL,
+		APIVersion:        "1.0.0",
+		RequestTimeoutSec: 5,
+		TelemetryOptIn:    true,
+	}
+	c := NewClient(cfg, &mockTokenClient{token: "t"})
+	err := c.ReportPluginStatus(context.Background(), &ReportPluginStatusRequest{
+		Statuses: []PluginStatus{{PluginID: "p1", InstalledVersion: "1.0.0", Status: "enabled"}},
+	})
+	if err != nil {
+		t.Fatalf("ReportPluginStatus: %v", err)
+	}
+	if len(got.Statuses) != 1 || got.Statuses[0].PluginID != "p1" {
+		t.Fatalf("server saw %+v", got)
+	}
+}
+
+func TestReportPluginStatusOptOutSendsNothing(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+	}))
+	defer server.Close()
+
+	cfg := &config.MarketplaceConfig{
+		EndpointURL:       server.URL,
+		RequestTimeoutSec: 5,
+		TelemetryOptIn:    false,
+	}
+	c := NewClient(cfg, &mockTokenClient{token: "t"})
+	if err := c.ReportPluginStatus(context.Background(), &ReportPluginStatusRequest{
+		Statuses: []PluginStatus{{PluginID: "p1"}},
+	}); err != nil {
+		t.Fatalf("ReportPluginStatus opt-out: %v", err)
+	}
+	if requests != 0 {
+		t.Fatalf("opted-out telemetry still sent %d request(s)", requests)
+	}
+}
+
+func TestReportPluginStatusServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	cfg := &config.MarketplaceConfig{
+		EndpointURL:       server.URL,
+		RequestTimeoutSec: 5,
+		TelemetryOptIn:    true,
+	}
+	c := NewClient(cfg, &mockTokenClient{token: "t"})
+	err := c.ReportPluginStatus(context.Background(), &ReportPluginStatusRequest{})
+	if err == nil || !strings.Contains(err.Error(), "status 502") {
+		t.Fatalf("ReportPluginStatus on 502 = %v; want status 502 error", err)
+	}
+}
+
+func TestGetRevocations(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/revocations" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("since_version"); got != "42" {
+			t.Errorf("since_version = %q; want 42", got)
+		}
+		json.NewEncoder(w).Encode(GetRevocationsResponse{
+			Revocations: []Revocation{
+				{PluginID: "bad-plugin", Version: "1.0.0", Action: "disable", Reason: "vuln"},
+			},
+			LatestVersion: 43,
+		})
+	}))
+	defer server.Close()
+
+	resp, err := testClient(t, server.URL).GetRevocations(context.Background(), &GetRevocationsRequest{SinceVersion: 42})
+	if err != nil {
+		t.Fatalf("GetRevocations: %v", err)
+	}
+	if resp.LatestVersion != 43 || len(resp.Revocations) != 1 || resp.Revocations[0].Action != "disable" {
+		t.Fatalf("GetRevocations = %+v", resp)
+	}
+}
+
+func TestGetRevocationsServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, err := testClient(t, server.URL).GetRevocations(context.Background(), &GetRevocationsRequest{})
+	if err == nil || !strings.Contains(err.Error(), "status 404") {
+		t.Fatalf("GetRevocations on 404 = %v; want status 404 error", err)
+	}
+}
+
+func TestIssueDownloadTokenErrorPaths(t *testing.T) {
+	// Each subcase pins the distinct error message its branch produces, so a
+	// regression that collapses one branch into another fails the test.
+	cases := []struct {
+		name    string
+		wantErr string
+		handler http.HandlerFunc
+	}{
+		{"non-200", "status 403", func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "denied", http.StatusForbidden)
+		}},
+		{"error envelope", "listing revoked", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"error":{"message":"listing revoked"}}`))
+		}},
+		{"missing data", "missing response data", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}},
+		{"bad json", "failed to decode", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`not json`))
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+			_, err := testClient(t, server.URL).IssueDownloadToken(context.Background(), &IssueDownloadTokenRequest{})
+			if err == nil {
+				t.Fatalf("%s: want error, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("%s: error = %q; want it to contain %q", tc.name, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func catalogServer(t *testing.T, hits *int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hits != nil {
+			*hits++
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"plugins": []map[string]any{
+				{"listing_id": "p1", "name": "P1", "version": "1.0.0", "canonical_type": "payment"},
+			},
+		})
+	}))
+}
+
+func TestGetOrFetchPrefersCache(t *testing.T) {
+	hits := 0
+	server := catalogServer(t, &hits)
+	defer server.Close()
+
+	repo, err := NewCatalogRepository(testClient(t, server.URL), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewCatalogRepository: %v", err)
+	}
+	ctx := context.Background()
+	if _, err := repo.Fetch(ctx, "en", "linux/amd64"); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	fetchesAfterWarm := hits
+
+	snap, stale, err := repo.GetOrFetch(ctx, "en", "linux/amd64")
+	if err != nil {
+		t.Fatalf("GetOrFetch: %v", err)
+	}
+	if stale {
+		t.Fatal("fresh cache reported stale")
+	}
+	if len(snap.Plugins) != 1 {
+		t.Fatalf("snapshot plugins = %d; want 1", len(snap.Plugins))
+	}
+	if hits != fetchesAfterWarm {
+		t.Fatalf("GetOrFetch hit the network despite a warm cache (%d -> %d requests)", fetchesAfterWarm, hits)
+	}
+}
+
+func TestGetOrFetchFetchesWhenNoCache(t *testing.T) {
+	hits := 0
+	server := catalogServer(t, &hits)
+	defer server.Close()
+
+	repo, err := NewCatalogRepository(testClient(t, server.URL), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewCatalogRepository: %v", err)
+	}
+	snap, stale, err := repo.GetOrFetch(context.Background(), "en", "linux/amd64")
+	if err != nil {
+		t.Fatalf("GetOrFetch cold: %v", err)
+	}
+	if stale || len(snap.Plugins) != 1 || hits == 0 {
+		t.Fatalf("cold GetOrFetch: stale=%v plugins=%d hits=%d", stale, len(snap.Plugins), hits)
+	}
+}
+
+func TestGetOrFetchErrorsWhenOfflineAndNoCache(t *testing.T) {
+	// A closed server: connection refused, and nothing cached on disk.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := server.URL
+	server.Close()
+
+	repo, err := NewCatalogRepository(testClient(t, url), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewCatalogRepository: %v", err)
+	}
+	if _, _, err := repo.GetOrFetch(context.Background(), "en", "linux/amd64"); err == nil {
+		t.Fatal("GetOrFetch offline with no cache: want error")
+	}
+}
+
+func TestGetReportsCorruptSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	repo, err := NewCatalogRepository(testClient(t, "http://unused.example.com"), dir)
+	if err != nil {
+		t.Fatalf("NewCatalogRepository: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "catalog-snapshot.json"), []byte("{corrupt"), 0o644); err != nil {
+		t.Fatalf("write corrupt snapshot: %v", err)
+	}
+	if _, _, err := repo.Get(); err == nil {
+		t.Fatal("Get with corrupt snapshot: want error")
+	}
+}
+
+func TestNewCatalogRepositoryFailsWhenCacheDirIsAFile(t *testing.T) {
+	dir := t.TempDir()
+	blocked := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(blocked, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write blocker file: %v", err)
+	}
+	if _, err := NewCatalogRepository(testClient(t, "http://unused.example.com"), blocked); err == nil {
+		t.Fatal("NewCatalogRepository with a file as cache dir: want error")
+	}
+}


### PR DESCRIPTION
Batch 12 of the coverage push (universaltill/ut-docs#9).

| package | before | after |
|---|---|---|
| internal/httpx | 65.1% | 94.5% |
| internal/plugins/marketplace | 62.3% | 85.7% |
| internal/db | 66.7% | 79.8% |

Also fixes a real bug the new tests exposed: `httpx.T` / `FuncsFor`'s `T`/`locales` closures panicked on a typed-nil `*config.I18n` (interface nil-check passed, then `mu.RLock` on nil receiver). Now degrades to key-fallback.

Verified: full suite green, vet clean, both CI guards pass, three mutation spot-checks + independent Opus review (2 should-fix, 5 nits — all fixed, false-pass mutation re-verified). Review record: `docs/code-reviews/2026-07-31-coverage-batch-12-marketplace-httpx-db.md`.

Remainder honestly deferred (migration fault-injection, forced-IO rename failures) — documented in the review record. Next-lowest packages for batch 13: `internal/ai` 68.3%, `internal/paths` 69.7%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013T6tFkEe7DDfE4cMUKBhSj